### PR TITLE
Use dedicated Codacy coverage token

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     env:
-      CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
+      CODACY_COVERAGE_API_TOKEN: ${{ secrets.CODACY_COVERAGE_API_TOKEN }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -23,8 +23,8 @@ jobs:
         run: uv run --with coverage coverage xml
 
       - name: Upload coverage to Codacy
-        if: ${{ env.CODACY_API_TOKEN != '' }}
+        if: ${{ env.CODACY_COVERAGE_API_TOKEN != '' }}
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
-          project-token: ${{ secrets.CODACY_API_TOKEN }}
+          api-token: ${{ secrets.CODACY_COVERAGE_API_TOKEN }}
           coverage-reports: coverage.xml

--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ test -f coverage.xml
 ```
 
 CI runs the same validation suite and generates `coverage.xml`. Codacy upload is
-attempted only when `CODACY_API_TOKEN` is configured.
+attempted only when the `CODACY_COVERAGE_API_TOKEN` GitHub Actions secret is
+configured.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,5 +7,6 @@ class WorkflowTests(DotfilesTestCase):
         self.assertIn("coverage run -m unittest discover -s tests", workflow)
         self.assertIn("coverage xml", workflow)
         self.assertIn("coverage.xml", workflow)
-        self.assertIn("CODACY_API_TOKEN", workflow)
+        self.assertIn("CODACY_COVERAGE_API_TOKEN", workflow)
+        self.assertIn("api-token:", workflow)
         self.assertIn("codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699", workflow)


### PR DESCRIPTION
## Summary

Wires coverage upload to the new `CODACY_COVERAGE_API_TOKEN` secret so it stays separate from existing Codacy setup.

## Changes

- Uses `api-token` for Codacy coverage reporter account-token uploads.
- Gates coverage upload on `CODACY_COVERAGE_API_TOKEN`.
- Updates README and workflow test expectations.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache PYTHONDONTWRITEBYTECODE=1 uv run python -m unittest discover -s tests`
- `git diff --check`
- changed-file secret scan via `dotfiles_tools.secrets`: no findings