### PR TITLE
[codex] Clarify bootstrap validation profile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Config templates for AI coding tools and shell environment.
 | `fish/` | `~/.config/fish/` | `fish_plugins`, `functions/direnv.fish`, `env.fish` |
 | `git/` | `~/.config/git/` | `config` |
 
+The filenames listed above are installed target filenames. Source files in this
+repo may carry a `.template` suffix before they are copied or rendered to those
+targets.
+
 ## Conventions
 
 **`.template` suffix** — copy to the target path and fill in any `{{PLACEHOLDERS}}`.

--- a/specs/001-dotfiles-bootstrap-validation/contracts/cli.md
+++ b/specs/001-dotfiles-bootstrap-validation/contracts/cli.md
@@ -16,6 +16,14 @@ a stable JSON validation report with the common report shape below.
 | `--repo PATH` | Yes | Repository root containing `dotfiles-manifest.json` |
 | `--json` | No | Emit stable JSON report instead of human-readable text |
 
+## Profiles
+
+- `machine`: default home bootstrap profile for installing and validating
+  dotfiles under the selected `--home` directory.
+- `repo`: repository-local protected checks for `.gitignore` and agent template
+  symlinks. This profile is for repository validation and maintenance, not
+  normal machine installation.
+
 ## Common JSON Report
 
 ```json

--- a/specs/001-dotfiles-bootstrap-validation/data-model.md
+++ b/specs/001-dotfiles-bootstrap-validation/data-model.md
@@ -12,11 +12,13 @@ Fields:
 
 Validation rules:
 - `version` is required.
-- `profiles.machine.entries` must reference existing entry IDs.
+- Each profile's `entries` list must reference existing entry IDs.
+- The committed manifest defines `machine` for home bootstrap and `repo` for
+  repository-local protected checks.
 - Every entry ID must be unique.
 - Source paths must be relative to the repository root and must not escape it.
 - Target paths must be relative to the selected home directory or project
-  directory unless explicitly marked as repository-local validation only.
+  directory, or repository-relative when `scope=repo`.
 
 ## Manifest Entry
 
@@ -26,8 +28,10 @@ Fields:
 - `id`: stable unique ID, used for protected opt-in.
 - `source`: repository-relative source path.
 - `target`: target path relative to home or project root.
+- `scope`: target root classification, allowed values `home`, `repo`, and
+  `project`; omitted scope defaults to current home-target behavior.
 - `profiles`: profile membership array, initially containing `machine`,
-  `project`, or both where applicable.
+  `repo`, `project`, or combinations where applicable.
 - `kind`: `template`, `file`, or `symlink`.
 - `protected`: boolean.
 - `manual_reason`: required when `protected` is true.

--- a/specs/001-dotfiles-bootstrap-validation/plan.md
+++ b/specs/001-dotfiles-bootstrap-validation/plan.md
@@ -136,6 +136,9 @@ Design artifacts:
 - **Validation Before Coverage**: PASS. Quickstart and plan require tests before coverage upload; CI uploads only when token exists.
 - **uv Python Workflow**: PASS. All Python commands in quickstart use `uv`.
 
+Post-design verification on 2026-05-01 confirmed the implementation and Codacy
+coverage upload path after PR #69 and PR #70.
+
 ## Complexity Tracking
 
 No constitution violations are accepted for this feature.

--- a/specs/001-dotfiles-bootstrap-validation/quickstart.md
+++ b/specs/001-dotfiles-bootstrap-validation/quickstart.md
@@ -82,9 +82,9 @@ Expected result: `coverage.xml` exists after tests pass.
 
 ## 8. CI Behavior
 
-The GitHub Actions workflow should:
+The GitHub Actions workflow `.github/workflows/dotfiles-validation.yml` should:
 
 1. Run the unit tests.
 2. Generate `coverage.xml`.
-3. Upload coverage to Codacy only when `CODACY_API_TOKEN` is configured.
+3. Upload coverage to Codacy only when `CODACY_COVERAGE_API_TOKEN` is configured.
 4. Skip coverage upload without failing validation when the token is absent.

--- a/specs/001-dotfiles-bootstrap-validation/spec.md
+++ b/specs/001-dotfiles-bootstrap-validation/spec.md
@@ -141,6 +141,13 @@ A maintainer wants CI to run validation tests and produce a supported coverage r
 - **FR-023**: If an approved apply operation fails after earlier writes have completed, the system MUST stop on the first failed write, preserve completed changes and backups, and report partial-apply status.
 - **FR-024**: The user-facing CLI command names MUST be `doctor`, `plan`, `apply`, and `init-project`; documentation MUST use those names as canonical.
 
+### Protected Entry Classification
+
+Manifest entries SHOULD be classified as protected when automatic writes could
+change local identity, expose secrets or generated artifacts, require external
+or manual tool actions after installation, or break symlink/source-of-truth
+invariants.
+
 ### Key Entities
 
 - **Manifest**: The repository-owned source of truth describing setup profiles, source files, target paths, template handling, and protected/manual entries.

--- a/specs/001-dotfiles-bootstrap-validation/tasks.md
+++ b/specs/001-dotfiles-bootstrap-validation/tasks.md
@@ -168,7 +168,7 @@
 - [X] T055 [US5] Update validation and coverage documentation with uv-based test and coverage commands in `README.md`
 - [X] T056 [US5] Update runtime agent guidance with uv-based validation commands and no-lock-file constraints in `AGENTS.md`
 
-**Checkpoint**: Local coverage produces `coverage.xml`, and workflow upload is skipped safely without `CODACY_API_TOKEN`.
+**Checkpoint**: Local coverage produces `coverage.xml`, and workflow upload is skipped safely without `CODACY_COVERAGE_API_TOKEN`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarify that README target names can come from `.template` sources before install/render.
- Document `machine` and `repo` bootstrap validation profiles and repo-scoped manifest entries.
- Refresh Spec Kit validation notes for the Codacy coverage token name and post-design verification.

## Validation
- `git diff --cached --check`
- `uv run python -m unittest discover -s tests`
- `uv run --with coverage coverage run -m unittest discover -s tests`
- `uv run --with coverage coverage xml`