### PR TITLE
[codex] Add compact setup dashboard

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -8,7 +8,3 @@ engines:
   metric:
     exclude_paths:
       - "dotfiles_tools/**"
-  metrics:
-    exclude_paths:
-      - "dotfiles_tools/**"
-      - "tests/**"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -8,3 +8,7 @@ engines:
   metric:
     exclude_paths:
       - "dotfiles_tools/**"
+  metrics:
+    exclude_paths:
+      - "dotfiles_tools/**"
+      - "tests/**"

--- a/README.md
+++ b/README.md
@@ -33,15 +33,65 @@ ln -sf AGENTS.md GEMINI.md
 
 ## Bootstrap a new machine
 
+The root `./setup` script is the fresh-machine entrypoint:
+
+```bash
+./setup
+```
+
+With no arguments, it first ensures `uv` is available. If `uv` is missing, it
+runs the official standalone installer with `curl` or `wget`, refreshes the
+current process `PATH`, verifies `uv --version`, then continues. If `uv` is
+already installed, it runs `uv self update` first; package-manager installations
+that cannot self-update are warned about and reused when `uv --version` still
+works.
+
+After the uv-first bootstrap, `./setup` uses the machine doctor and bootstrap
+plan internally, but the default screen is a short decision summary. It groups
+the pending work into files that will be updated with backups, files that will
+be created, protected/manual files that will not be touched, a dedicated Fonts
+section, and baseline tool/auth guidance for `uv`, `git`, `gh`, `fish`,
+`direnv`, `codex`, `claude`, and `gemini`. It then offers:
+
+1. apply safe non-protected dotfiles plus approved install/update recipes,
+2. show the full diagnostic output, including font detection,
+3. show tool and sign-in guidance,
+4. exit without writing.
+
+The Fonts stage is catalog driven. On standard Ubuntu-style Linux it manages
+the Nerd Fonts release assets `JetBrainsMono.zip`, `FiraCode.zip`, `Hack.zip`,
+and `Meslo.zip`, caching archives under `~/.cache/000-dotfiles/fonts/` and
+installing each family under `~/.local/share/fonts/`. Terminal checks and
+settings always use `* Nerd Font Mono` faces, never Propo faces. The same stage
+also installs or updates apt fallback packages for emoji and symbols:
+`fonts-noto-color-emoji`, `fonts-symbola`, `fonts-freefont-ttf`, and
+`fonts-dejavu-core`.
+
+Platform-specific handling stays explicit. WSL installs all Nerd Font families
+Linux-side, installs JetBrainsMono Nerd Font Mono on the Windows host when
+PowerShell is available, and updates Windows Terminal defaults when its settings
+JSON is discoverable. Raspberry Pi installs all Nerd Font families plus Noto
+Color Emoji, Symbola, and FreeFont, and verifies `MesloLGS Nerd Font Mono`.
+Pixel Terminal embeds a `JBMono NF` subset of JetBrainsMono Nerd Font Mono into
+ttyd and installs `fonts-noto-color-emoji`. Pixel AVF skips Nerd Font UI setup
+because `weston-terminal` ignores it, and writes a plain prompt fallback
+instead.
+
+The underlying commands remain available directly:
+
 ```bash
 uv run python -m dotfiles_tools doctor --repo . --home "$HOME"
 uv run python -m dotfiles_tools plan --repo . --home "$HOME" --profile machine
 uv run python -m dotfiles_tools apply --repo . --home "$HOME" --profile machine --backup-dir "$HOME/.dotfiles-backups" --yes
+uv run python -m dotfiles_tools bootstrap-plan --repo . --home "$HOME" --json
+uv run python -m dotfiles_tools bootstrap-apply --repo . --home "$HOME" --yes
 ```
 
 `dotfiles-manifest.json` is the source of truth for machine targets. `doctor`
 audits without writing, `plan` prints exact operations, and `apply` writes only
 after `--yes`. Existing differing files are backed up before replacement.
+`bootstrap-plan` and `bootstrap-apply` wrap the same manifest operations and add
+install recipes such as fonts.
 
 Protected entries are reported but skipped by default:
 
@@ -62,18 +112,26 @@ The `./setup` entrypoint at the repo root is the recommended way to scaffold or
 verify agent docs in a project that lives in any folder. It self-locates this
 dotfiles repo so it works directly or via a `PATH` symlink.
 
+Passing a project path keeps project setup separate from machine setup:
+
+```bash
+./setup ~/Apps/my-project
+```
+
+Empty folders get agent-doc bootstrap options. Existing projects get verify,
+repair/bootstrap, and Copilot options. When no variables file exists, inferred
+metadata is saved to `.dotfiles/project-vars.json` in the target project.
+
 What `./setup` can complete:
 
 | Command | What it completes | Notes |
 |---|---|---|
+| `./setup` | Prepares/checks this computer, including uv bootstrap, machine doctor, bootstrap plan, font recipes, and safe apply options. | This is the fresh-machine flow. `uv` and approved setup recipes such as fonts may be installed automatically. |
+| `./setup /path/to/project` | Inspects a project folder and offers project agent-doc actions. | Stores inferred metadata in `.dotfiles/project-vars.json` when needed. |
 | `./setup init --yes` | Renders project `AGENTS.md`, creates `CLAUDE.md` and `GEMINI.md` symlinks to `AGENTS.md`, then automatically runs `verify`. | Uses `project-vars.json` from the project root or `.dotfiles/` unless `--vars` is provided. Requires `uv` because it wraps `dotfiles_tools init-project`. |
 | `./setup init --copilot --yes` | Completes the same agent-doc bootstrap plus `.github/copilot-instructions.md`, then verifies all generated agent docs. | Use when the project should also receive Copilot instructions from this repo's template. |
 | `./setup verify` | Performs a read-only project check for `AGENTS.md`, `CLAUDE.md`/`GEMINI.md` symlink targets, and unresolved `{{PLACEHOLDER}}` values. | Does not require `uv` or Python, so it is suitable for quick local checks, CI, or pre-commit hooks. Add `--copilot` to require and check `.github/copilot-instructions.md`. |
 | `./setup doctor` | Runs the repo's machine-home audit with sensible defaults. | Wraps `dotfiles_tools doctor --repo <this repo> --home "$HOME" --profile machine`; this is read-only and requires `uv`. |
-
-`./setup` does not apply machine dotfiles. Use the direct `dotfiles_tools plan`
-and `dotfiles_tools apply` commands in the machine bootstrap section when you
-want to preview or write files into a home directory.
 
 ```bash
 cd path/to/your-project

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -103,28 +103,41 @@ def collect_tool_baseline(path: str | None = None) -> dict[str, list[dict[str, A
 def render_setup_guidance(path: str | None = None) -> str:
     baseline = collect_tool_baseline(path)
     missing_tools = [item for item in baseline["tool_checks"] if item["state"] == "missing"]
-
-    lines = ["Tool status:"]
-    if missing_tools:
-        lines.append("  Missing tools:")
-        for item in missing_tools:
-            lines.append(f"    - {item['command']}: {item['install_hint']}")
-    else:
-        lines.append("  - No missing baseline tools. All expected commands are visible on PATH.")
-
     available_auth = [item for item in baseline["auth_guidance"] if item["state"] == "available"]
     missing_auth_tools = [item for item in baseline["auth_guidance"] if item["state"] != "available"]
-    if available_auth:
-        lines.append("")
-        lines.append("Optional sign-in checks:")
-        for item in available_auth:
-            lines.append(f"  - {item['command']}: {item['guidance']}")
-    if missing_auth_tools:
-        lines.append("")
-        lines.append("Sign-in checks unavailable until the tool is installed:")
-        for item in missing_auth_tools:
-            lines.append(f"  - {item['tool']}")
+
+    lines = ["Tool status:"]
+    _extend_missing_tools(lines, missing_tools)
+    _extend_available_auth(lines, available_auth)
+    _extend_missing_auth_tools(lines, missing_auth_tools)
     return "\n".join(lines) + "\n"
+
+
+def _extend_missing_tools(lines: list[str], missing_tools: list[dict[str, Any]]) -> None:
+    if not missing_tools:
+        lines.append("  - No missing baseline tools. All expected commands are visible on PATH.")
+        return
+    lines.append("  Missing tools:")
+    for item in missing_tools:
+        lines.append(f"    - {item['command']}: {item['install_hint']}")
+
+
+def _extend_available_auth(lines: list[str], available_auth: list[dict[str, Any]]) -> None:
+    if not available_auth:
+        return
+    lines.append("")
+    lines.append("Optional sign-in checks:")
+    for item in available_auth:
+        lines.append(f"  - {item['command']}: {item['guidance']}")
+
+
+def _extend_missing_auth_tools(lines: list[str], missing_auth_tools: list[dict[str, Any]]) -> None:
+    if not missing_auth_tools:
+        return
+    lines.append("")
+    lines.append("Sign-in checks unavailable until the tool is installed:")
+    for item in missing_auth_tools:
+        lines.append(f"  - {item['tool']}")
 
 
 def _tool_check(item: dict[str, Any], search_path: str) -> dict[str, Any]:

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any
+
+
+TOOL_BASELINE = (
+    {
+        "id": "uv",
+        "label": "uv",
+        "command": "uv",
+        "bootstrap": True,
+        "install_hint": "Installed automatically by ./setup when missing.",
+    },
+    {
+        "id": "git",
+        "label": "Git",
+        "command": "git",
+        "bootstrap": False,
+        "install_hint": "Install git with the operating-system package manager.",
+    },
+    {
+        "id": "gh",
+        "label": "GitHub CLI",
+        "command": "gh",
+        "bootstrap": False,
+        "install_hint": "Install the GitHub CLI, then run gh auth status.",
+    },
+    {
+        "id": "fish",
+        "label": "fish",
+        "command": "fish",
+        "bootstrap": False,
+        "install_hint": "Install fish with the operating-system package manager.",
+    },
+    {
+        "id": "direnv",
+        "label": "direnv",
+        "command": "direnv",
+        "bootstrap": False,
+        "install_hint": "Install direnv and enable the shell hook.",
+    },
+    {
+        "id": "codex",
+        "label": "Codex CLI",
+        "command": "codex",
+        "bootstrap": False,
+        "install_hint": "Install Codex CLI, then run codex auth.",
+    },
+    {
+        "id": "claude",
+        "label": "Claude Code",
+        "command": "claude",
+        "bootstrap": False,
+        "install_hint": "Install Claude Code CLI, then run claude login.",
+    },
+    {
+        "id": "gemini",
+        "label": "Gemini CLI",
+        "command": "gemini",
+        "bootstrap": False,
+        "install_hint": "Install Gemini CLI, then complete its login/setup flow.",
+    },
+)
+
+
+AUTH_GUIDANCE = (
+    {
+        "id": "gh",
+        "tool": "gh",
+        "command": "gh auth status",
+        "guidance": "If it reports no authenticated host, run gh auth login.",
+    },
+    {
+        "id": "codex",
+        "tool": "codex",
+        "command": "codex auth",
+        "guidance": "Run when Codex CLI is installed and needs user authentication.",
+    },
+    {
+        "id": "claude",
+        "tool": "claude",
+        "command": "claude login",
+        "guidance": "Run when Claude Code CLI is installed and needs user authentication.",
+    },
+    {
+        "id": "gemini",
+        "tool": "gemini",
+        "command": "gemini",
+        "guidance": "Start Gemini CLI and complete its login/setup prompt if needed.",
+    },
+)
+
+
+def collect_tool_baseline(path: str | None = None) -> dict[str, list[dict[str, Any]]]:
+    search_path = path if path is not None else os.environ.get("PATH", "")
+    tool_checks = [_tool_check(item, search_path) for item in TOOL_BASELINE]
+    auth_guidance = [_auth_check(item, search_path) for item in AUTH_GUIDANCE]
+    return {"tool_checks": tool_checks, "auth_guidance": auth_guidance}
+
+
+def render_setup_guidance(path: str | None = None) -> str:
+    baseline = collect_tool_baseline(path)
+    missing_tools = [item for item in baseline["tool_checks"] if item["state"] == "missing"]
+
+    lines = ["Tool status:"]
+    if missing_tools:
+        lines.append("  Missing tools:")
+        for item in missing_tools:
+            lines.append(f"    - {item['command']}: {item['install_hint']}")
+    else:
+        lines.append("  - No missing baseline tools. All expected commands are visible on PATH.")
+
+    available_auth = [item for item in baseline["auth_guidance"] if item["state"] == "available"]
+    missing_auth_tools = [item for item in baseline["auth_guidance"] if item["state"] != "available"]
+    if available_auth:
+        lines.append("")
+        lines.append("Optional sign-in checks:")
+        for item in available_auth:
+            lines.append(f"  - {item['command']}: {item['guidance']}")
+    if missing_auth_tools:
+        lines.append("")
+        lines.append("Sign-in checks unavailable until the tool is installed:")
+        for item in missing_auth_tools:
+            lines.append(f"  - {item['tool']}")
+    return "\n".join(lines) + "\n"
+
+
+def _tool_check(item: dict[str, Any], search_path: str) -> dict[str, Any]:
+    found = shutil.which(item["command"], path=search_path)
+    return {
+        "id": item["id"],
+        "label": item["label"],
+        "command": item["command"],
+        "state": "installed" if found else "missing",
+        "path": found,
+        "bootstrap": item["bootstrap"],
+        "install_hint": item["install_hint"],
+    }
+
+
+def _auth_check(item: dict[str, str], search_path: str) -> dict[str, str]:
+    found = shutil.which(item["tool"], path=search_path)
+    return {
+        "id": item["id"],
+        "tool": item["tool"],
+        "command": item["command"],
+        "state": "available" if found else "tool_missing",
+        "guidance": item["guidance"],
+    }
+
+
+if __name__ == "__main__":
+    print(render_setup_guidance(), end="")

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -62,7 +62,6 @@ def apply_bootstrap(
     yes: bool = False,
     include_protected: list[str] | None = None,
     env: Mapping[str, str] | None = None,
-    path: str | None = None,
     runner: CommandRunner | None = None,
 ) -> Report:
     repo_path = Path(repo).resolve()
@@ -84,7 +83,6 @@ def apply_bootstrap(
         profile=profile,
         include_protected=include_protected,
         env=env,
-        path=path,
         runner=runner,
     )
     report.command = "bootstrap-apply"

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from .backups import BackupError
+from .fonts import CommandRunner, execute_font_operation, build_font_plan
+from .installer import build_plan, execute_manifest_operation
+from .reports import Report
+
+
+WARNING_STATES = {"missing", "drifted", "protected", "manual", "unsupported", "needs_update"}
+FAILED_STATES = {"invalid", "blocked"}
+
+
+def build_bootstrap_plan(
+    repo: Path | str,
+    home: Path | str,
+    *,
+    profile: str = "machine",
+    include_protected: list[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    path: str | None = None,
+    runner: CommandRunner | None = None,
+) -> Report:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    manifest_report = build_plan(repo_path, home_path, profile=profile, include_protected=include_protected)
+    entries = list(manifest_report.entries)
+    operations = list(manifest_report.operations)
+    errors = list(manifest_report.errors)
+    extra: dict[str, Any] = dict(manifest_report.extra)
+
+    if profile == "machine":
+        font_plan = build_font_plan(home_path, env=env, path=path, runner=runner)
+        entries.extend(font_plan["entries"])
+        operations.extend(font_plan["operations"])
+        extra["fonts"] = font_plan["fonts"]
+        extra["font_context"] = font_plan["context"]
+
+    _renumber_operations(operations)
+    status = _status(entries, operations, errors)
+    return Report(
+        "bootstrap-plan",
+        status,
+        str(repo_path),
+        home=str(home_path),
+        profile=profile,
+        entries=entries,
+        operations=operations,
+        errors=errors,
+        extra=extra,
+    )
+
+
+def apply_bootstrap(
+    repo: Path | str,
+    home: Path | str,
+    *,
+    profile: str = "machine",
+    backup_dir: Path | str | None = None,
+    yes: bool = False,
+    include_protected: list[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    path: str | None = None,
+    runner: CommandRunner | None = None,
+) -> Report:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    if not yes:
+        return Report(
+            "bootstrap-apply",
+            "failed",
+            str(repo_path),
+            home=str(home_path),
+            profile=profile,
+            errors=[{"message": "bootstrap-apply requires --yes before writing"}],
+        )
+
+    report = build_bootstrap_plan(
+        repo_path,
+        home_path,
+        profile=profile,
+        include_protected=include_protected,
+        env=env,
+        path=path,
+        runner=runner,
+    )
+    report.command = "bootstrap-apply"
+    if report.errors or any(entry.get("state") in FAILED_STATES for entry in report.entries):
+        report.status = "failed"
+        return report
+
+    return _execute_bootstrap_operations(report, repo_path, backup_path, runner)
+
+
+def _execute_bootstrap_operations(
+    report: Report,
+    repo_path: Path,
+    backup_path: Path,
+    runner: CommandRunner | None,
+) -> Report:
+    backups: list[dict[str, Any]] = []
+    completed_writes = 0
+    executed: list[dict[str, Any]] = []
+    for op in report.operations:
+        try:
+            completed_writes += _execute_operation(op, repo_path, backup_path, backups, runner)
+            executed.append(op)
+        except (OSError, BackupError, RuntimeError) as exc:
+            return _failed_report(report, executed, op, backups, completed_writes, exc)
+    report.backups = backups
+    report.status = "warning" if _has_manual_or_refused_work(report) else "ok"
+    return report
+
+
+def _execute_operation(
+    op: dict[str, Any],
+    repo_path: Path,
+    backup_path: Path,
+    backups: list[dict[str, Any]],
+    runner: CommandRunner | None,
+) -> int:
+    if op.get("recipe") == "fonts" or str(op.get("type", "")).startswith("font_"):
+        return execute_font_operation(op, runner=runner, backup_dir=backup_path, backups=backups)
+    return execute_manifest_operation(op, repo_path, backup_path, backups)
+
+
+def _failed_report(
+    report: Report,
+    executed: list[dict[str, Any]],
+    op: dict[str, Any],
+    backups: list[dict[str, Any]],
+    completed_writes: int,
+    exc: Exception,
+) -> Report:
+    report.errors.append({
+        "operation_id": op.get("operation_id", ""),
+        "entry_id": op.get("entry_id", ""),
+        "message": str(exc),
+    })
+    report.operations = executed + [op]
+    report.backups = backups
+    report.status = "partial" if completed_writes else "failed"
+    if completed_writes:
+        report.operations.append({
+            "operation_id": f"op-{len(report.operations) + 1:03d}",
+            "entry_id": op.get("entry_id", ""),
+            "type": "partial_apply",
+            "target": op.get("target"),
+            "reason": "stopped on first failed write",
+            "requires_approval": False,
+        })
+    return report
+
+
+def _has_manual_or_refused_work(report: Report) -> bool:
+    if any(op.get("type") in {"refuse", "font_manual"} for op in report.operations):
+        return True
+    return any(entry.get("state") in {"protected", "manual", "unsupported"} for entry in report.entries)
+
+
+def _status(entries: list[dict[str, Any]], operations: list[dict[str, Any]], errors: list[Any]) -> str:
+    if errors or any(entry.get("state") in FAILED_STATES for entry in entries):
+        return "failed"
+    if operations or any(entry.get("state") in WARNING_STATES for entry in entries):
+        return "warning"
+    return "ok"
+
+
+def _renumber_operations(operations: list[dict[str, Any]]) -> None:
+    for index, operation in enumerate(operations, 1):
+        operation["operation_id"] = f"op-{index:03d}"

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Sequence
 
+from .bootstrap import apply_bootstrap, build_bootstrap_plan
 from .doctor import run_doctor
 from .installer import apply_plan, build_plan
 from .project_init import init_project
@@ -33,6 +34,26 @@ def build_parser() -> argparse.ArgumentParser:
     apply.add_argument("--yes", action="store_true")
     apply.add_argument("--include-protected", action="append", default=[])
 
+    bootstrap_plan = subparsers.add_parser(
+        "bootstrap-plan",
+        help="Print machine setup operations including install recipes",
+    )
+    _common(bootstrap_plan)
+    bootstrap_plan.add_argument("--home", required=True)
+    bootstrap_plan.add_argument("--profile", default="machine")
+    bootstrap_plan.add_argument("--include-protected", action="append", default=[])
+
+    bootstrap_apply = subparsers.add_parser(
+        "bootstrap-apply",
+        help="Apply machine setup operations and install recipes",
+    )
+    _common(bootstrap_apply)
+    bootstrap_apply.add_argument("--home", required=True)
+    bootstrap_apply.add_argument("--profile", default="machine")
+    bootstrap_apply.add_argument("--backup-dir")
+    bootstrap_apply.add_argument("--yes", action="store_true")
+    bootstrap_apply.add_argument("--include-protected", action="append", default=[])
+
     project = subparsers.add_parser("init-project", help="Initialize project-level agent docs")
     _common(project)
     project.add_argument("--project", required=True)
@@ -57,7 +78,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif args.command == "plan":
         report = build_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
     elif args.command == "apply":
-        report = apply_plan(repo, args.home, profile=args.profile, backup_dir=args.backup_dir, yes=args.yes, include_protected=args.include_protected)
+        report = apply_plan(
+            repo,
+            args.home,
+            profile=args.profile,
+            backup_dir=args.backup_dir,
+            yes=args.yes,
+            include_protected=args.include_protected,
+        )
+    elif args.command == "bootstrap-plan":
+        report = build_bootstrap_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
+    elif args.command == "bootstrap-apply":
+        report = apply_bootstrap(
+            repo,
+            args.home,
+            profile=args.profile,
+            backup_dir=args.backup_dir,
+            yes=args.yes,
+            include_protected=args.include_protected,
+        )
     elif args.command == "init-project":
         report = init_project(repo, args.project, args.vars, backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot)
     else:

--- a/dotfiles_tools/doctor.py
+++ b/dotfiles_tools/doctor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .baseline import collect_tool_baseline
 from .manifest import ManifestEntry, ManifestError, load_manifest, resolve_source, resolve_target, validate_included_protected
 from .reports import Report, status_from_entries
 from .secrets import scan_file
@@ -168,11 +169,14 @@ def run_doctor(repo: Path | str, home: Path | str, *, profile: str = "machine", 
     home_path = Path(home).resolve()
     entries: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
+    extra: dict[str, Any] = {}
     try:
         manifest = load_manifest(repo_path)
         include_set = validate_included_protected(manifest, include_protected)
         entries.extend(check_symlinks(repo_path))
         entries.extend(evaluate_entry(repo_path, home_path, entry, include_set) for entry in manifest.entries_for_profile(profile))
+        if profile == "machine":
+            extra.update(collect_tool_baseline())
     except ManifestError as exc:
         errors.append({"message": str(exc)})
     status = status_from_entries(entries, errors)
@@ -184,4 +188,5 @@ def run_doctor(repo: Path | str, home: Path | str, *, profile: str = "machine", 
         profile=profile,
         entries=entries,
         errors=errors,
+        extra=extra,
     )

--- a/dotfiles_tools/font_assets.py
+++ b/dotfiles_tools/font_assets.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from .font_catalog import PIXEL_TTYD_FONT_ALIAS
+
+
+def windows_font_install_script(source_dir: str) -> str:
+    escaped = source_dir.replace("'", "''")
+    return (
+        "$FontDir = Join-Path $env:LOCALAPPDATA 'Microsoft\\Windows\\Fonts'; "
+        "New-Item -ItemType Directory -Force -Path $FontDir | Out-Null; "
+        f"Get-ChildItem -Path '{escaped}' -File | Where-Object {{ $_.Extension -in '.ttf','.otf' }} | ForEach-Object {{ "
+        "$Dest = Join-Path $FontDir $_.Name; "
+        "Copy-Item $_.FullName $Dest -Force; "
+        "New-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' "
+        "-Name \"$($_.BaseName) (TrueType)\" -Value $_.Name -PropertyType String -Force | Out-Null "
+        "}"
+    )
+
+
+def ttyd_html(font_path: Path) -> str:
+    encoded = base64.b64encode(font_path.read_bytes()).decode("ascii")
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@font-face {{
+  font-family: '{PIXEL_TTYD_FONT_ALIAS}';
+  src: url(data:font/truetype;charset=utf-8;base64,{encoded}) format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}}
+body, #terminal, .terminal, .xterm, .xterm-rows {{
+  font-family: '{PIXEL_TTYD_FONT_ALIAS}', 'Noto Color Emoji', monospace !important;
+}}
+</style>
+</head>
+<body>
+<div id="terminal"></div>
+</body>
+</html>
+"""
+
+
+def ttyd_service() -> str:
+    return """[Unit]
+Description=ttyd terminal with dotfiles-managed font embedding
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/ttyd --index /etc/ttyd/index.html -W /bin/bash
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def pixel_avf_prompt_text() -> str:
+    return """# Managed by 000-dotfiles for Pixel AVF weston-terminal.
+# Uses a plain prompt without Nerd Font private-use glyphs.
+function fish_prompt
+    set -l code $status
+    set -l marker '>'
+    if test $code -ne 0
+        set marker '!'
+    end
+    printf '%s %s ' (prompt_pwd) $marker
+end
+"""

--- a/dotfiles_tools/font_catalog.py
+++ b/dotfiles_tools/font_catalog.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+NERD_FONTS_RELEASE_URL = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
+NERD_FONTS_REPO = "ryanoasis/nerd-fonts"
+FONT_CACHE_REL = Path(".cache/000-dotfiles/fonts")
+FONT_INSTALL_BASE_REL = Path(".local/share/fonts")
+FONT_MARKER_NAME = ".000-dotfiles-font-source.json"
+WINDOWS_TERMINAL_PACKAGES = (
+    "Microsoft.WindowsTerminal_8wekyb3d8bbwe",
+    "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe",
+)
+
+FONT_ASSET_NAME = "JetBrainsMono.zip"
+FONT_FACE = "JetBrainsMono Nerd Font Mono"
+FONT_LABEL = "JetBrainsMono Nerd Font"
+FONT_ENTRY_ID = "fonts.jetbrains-mono-nerd"
+FONT_INSTALL_REL = FONT_INSTALL_BASE_REL / "JetBrainsMonoNerdFont"
+FONT_EXTRACTED_DIR = "JetBrainsMono"
+FONT_ARCHIVE_NAME = FONT_ASSET_NAME
+FONT_VERSION_NAME = "JetBrainsMono.version.json"
+EXPECTED_TTF = "JetBrainsMonoNerdFontMono-Regular.ttf"
+WINDOWS_ENTRY_ID = "fonts.windows-host"
+PIXEL_TTYD_ENTRY_ID = "fonts.pixel-ttyd"
+PIXEL_AVF_ENTRY_ID = "fonts.pixel-avf-prompt"
+PIXEL_TTYD_FONT_ALIAS = "JBMono NF"
+PIXEL_AVF_PROMPT_REL = Path(".config/fish/conf.d/000-dotfiles-pixel-avf-prompt.fish")
+
+
+class FontError(RuntimeError):
+    """Raised when a font recipe cannot complete."""
+
+
+@dataclass(frozen=True)
+class NerdFontItem:
+    entry_id: str
+    label: str
+    family: str
+    asset_name: str
+    install_dir_name: str
+    terminal_face: str
+    expected_regular: str
+
+    @property
+    def cache_stem(self) -> str:
+        return Path(self.asset_name).stem
+
+
+NERD_FONT_CATALOG: tuple[NerdFontItem, ...] = (
+    NerdFontItem(
+        FONT_ENTRY_ID,
+        FONT_LABEL,
+        "JetBrainsMono",
+        FONT_ASSET_NAME,
+        "JetBrainsMonoNerdFont",
+        FONT_FACE,
+        EXPECTED_TTF,
+    ),
+    NerdFontItem(
+        "fonts.fira-code-nerd",
+        "FiraCode Nerd Font",
+        "FiraCode",
+        "FiraCode.zip",
+        "FiraCodeNerdFont",
+        "FiraCode Nerd Font Mono",
+        "FiraCodeNerdFontMono-Regular.ttf",
+    ),
+    NerdFontItem(
+        "fonts.hack-nerd",
+        "Hack Nerd Font",
+        "Hack",
+        "Hack.zip",
+        "HackNerdFont",
+        "Hack Nerd Font Mono",
+        "HackNerdFontMono-Regular.ttf",
+    ),
+    NerdFontItem(
+        "fonts.meslo-nerd",
+        "MesloLGS Nerd Font",
+        "MesloLGS",
+        "Meslo.zip",
+        "MesloNerdFont",
+        "MesloLGS Nerd Font Mono",
+        "MesloLGSNerdFontMono-Regular.ttf",
+    ),
+)
+
+APT_FONT_CATALOG: tuple[dict[str, str], ...] = (
+    {
+        "entry_id": "fonts.apt.noto-color-emoji",
+        "family": "Noto Color Emoji",
+        "package": "fonts-noto-color-emoji",
+        "terminal_face": "Noto Color Emoji",
+    },
+    {
+        "entry_id": "fonts.apt.symbola",
+        "family": "Symbola",
+        "package": "fonts-symbola",
+        "terminal_face": "Symbola",
+    },
+    {
+        "entry_id": "fonts.apt.freefont",
+        "family": "GNU FreeFont",
+        "package": "fonts-freefont-ttf",
+        "terminal_face": "FreeMono",
+    },
+    {
+        "entry_id": "fonts.apt.dejavu-core",
+        "family": "DejaVu Core",
+        "package": "fonts-dejavu-core",
+        "terminal_face": "DejaVu Sans Mono",
+    },
+)

--- a/dotfiles_tools/font_context.py
+++ b/dotfiles_tools/font_context.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+import platform
+from typing import Any, Mapping
+
+from .font_catalog import APT_FONT_CATALOG, NERD_FONT_CATALOG, WINDOWS_TERMINAL_PACKAGES
+from .font_runner import CommandRunner
+
+
+def detect_context(home: Path, env: Mapping[str, str], path: str, runner: CommandRunner) -> dict[str, Any]:
+    return {
+        "platform": platform_id(env),
+        "architecture": platform.machine().lower(),
+        "path": path,
+        "powershell": runner.which("powershell.exe"),
+        "wslpath": runner.which("wslpath"),
+        "windows_terminal_settings": discover_windows_terminal_settings(home, env),
+    }
+
+
+def platform_id(env: Mapping[str, str]) -> str:
+    override = (env.get("DOTFILES_PLATFORM") or "").strip().lower()
+    override_id = platform_override(override)
+    if override_id:
+        return override_id
+    return detected_platform(env)
+
+
+def platform_override(override: str) -> str | None:
+    overrides = {
+        "linux": "linux",
+        "native-linux": "linux",
+        "ubuntu": "linux",
+        "pi": "pi",
+        "raspberry-pi": "pi",
+        "raspberrypi": "pi",
+        "wsl": "wsl",
+        "wsl-linux": "wsl",
+        "wsl2": "wsl",
+        "pixel-terminal": "pixel-terminal",
+        "pixel_ttyd": "pixel-terminal",
+        "ttyd": "pixel-terminal",
+        "pixel-avf": "pixel-avf",
+        "avf": "pixel-avf",
+    }
+    return overrides.get(override)
+
+
+def detected_platform(env: Mapping[str, str]) -> str:
+    if is_wsl(env):
+        return "wsl"
+    if is_raspberry_pi():
+        return "pi"
+    if Path("/etc/ttyd").exists() or Path("/etc/systemd/system/ttyd.service").exists():
+        return "pixel-terminal"
+    return "linux" if platform.system().lower() == "linux" else "unsupported"
+
+
+def is_wsl(env: Mapping[str, str]) -> bool:
+    if env.get("WSL_DISTRO_NAME") or env.get("WSL_INTEROP"):
+        return True
+    try:
+        return "microsoft" in Path("/proc/version").read_text(errors="ignore").lower()
+    except OSError:
+        return False
+
+
+def is_raspberry_pi() -> bool:
+    try:
+        return "raspberry pi" in Path("/proc/device-tree/model").read_text(errors="ignore").lower()
+    except OSError:
+        return False
+
+
+def discover_windows_terminal_settings(home: Path, env: Mapping[str, str]) -> str | None:
+    explicit = env.get("DOTFILES_WINDOWS_TERMINAL_SETTINGS")
+    if explicit:
+        path = Path(explicit)
+        return str(path) if path.exists() else None
+    users_root = Path("/mnt/c/Users")
+    if not users_root.exists():
+        return None
+    candidates: list[Path] = []
+    for user_dir in users_root.glob("*"):
+        for package in WINDOWS_TERMINAL_PACKAGES:
+            candidates.append(user_dir / "AppData/Local/Packages" / package / "LocalState/settings.json")
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def nerd_items_for_platform(platform_name: str) -> tuple:
+    if platform_name == "pixel-terminal":
+        return (NERD_FONT_CATALOG[0],)
+    if platform_name in {"linux", "wsl", "pi"}:
+        return NERD_FONT_CATALOG
+    return ()
+
+
+def apt_items_for_platform(platform_name: str) -> tuple[dict[str, str], ...]:
+    if platform_name in {"linux", "wsl"}:
+        return APT_FONT_CATALOG
+    if platform_name == "pi":
+        return tuple(item for item in APT_FONT_CATALOG if item["package"] != "fonts-dejavu-core")
+    if platform_name == "pixel-terminal":
+        return tuple(item for item in APT_FONT_CATALOG if item["package"] == "fonts-noto-color-emoji")
+    return ()
+
+
+def terminal_impact(platform_name: str) -> str:
+    if platform_name == "wsl":
+        return "Linux terminals get Nerd Font Mono faces; Windows Terminal is updated when its settings file is discoverable."
+    if platform_name == "pixel-terminal":
+        return "Pixel Terminal ttyd pages use an embedded JetBrainsMono Nerd Font Mono subset."
+    if platform_name == "pi":
+        return "Local Linux terminal apps can select Nerd Font Mono faces; emoji/symbol fallbacks are installed with apt."
+    if platform_name == "pixel-avf":
+        return "Pixel AVF weston-terminal ignores Nerd Font configuration; a plain prompt fallback is used."
+    return "Local Linux terminal apps can select Nerd Font Mono faces after install."
+
+
+def host_action(context: dict[str, Any]) -> str:
+    platform_name = context["platform"]
+    if platform_name == "wsl":
+        return wsl_host_action(context)
+    if platform_name == "pixel-terminal":
+        return "sudo writes /etc/ttyd/index.html and ttyd.service, then restarts ttyd.service."
+    if platform_name == "pixel-avf":
+        return "No host font action; weston-terminal ignores Nerd Font UI configuration."
+    return "No host-side action."
+
+
+def wsl_host_action(context: dict[str, Any]) -> str:
+    if context.get("powershell") and context.get("windows_terminal_settings"):
+        return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows and Windows Terminal defaults are updated."
+    if context.get("powershell"):
+        return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows; set Windows Terminal manually if no settings file is found."
+    return "Manual Windows host font install required because powershell.exe was not found."

--- a/dotfiles_tools/font_pixel.py
+++ b/dotfiles_tools/font_pixel.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .font_catalog import FONT_CACHE_REL, FONT_INSTALL_BASE_REL, NERD_FONT_CATALOG, PIXEL_TTYD_ENTRY_ID
+from .font_context import host_action, terminal_impact
+
+
+def pixel_ttyd_plan(
+    home: Path,
+    context: dict[str, Any],
+    font_summary: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    paths = jetbrains_paths(home)
+    entry = {
+        "entry_id": PIXEL_TTYD_ENTRY_ID,
+        "source": str(paths["install_dir"]),
+        "source_type": "pixel_ttyd",
+        "family": "JetBrainsMono",
+        "target": "/etc/ttyd/index.html",
+        "state": "missing",
+        "protected": False,
+        "reason": "Pixel Terminal ttyd font embedding is managed as a system recipe",
+        "recipe": "fonts",
+        "requires_sudo": True,
+        "terminal_face": font_summary["terminal_face"],
+        "terminal_impact": terminal_impact("pixel-terminal"),
+        "host_action": host_action(context),
+    }
+    operations = pixel_ttyd_operations(paths)
+    return entry, operations, {"host_action": host_action(context), "terminal_impact": terminal_impact("pixel-terminal")}
+
+
+def pixel_ttyd_operations(paths: dict[str, Path]) -> list[dict[str, Any]]:
+    base = {"entry_id": PIXEL_TTYD_ENTRY_ID, "requires_approval": True, "requires_sudo": True, "recipe": "fonts"}
+    return [
+        {
+            **base,
+            "type": "font_ttyd_write_html",
+            "source": str(paths["install_dir"]),
+            "target": "/etc/ttyd/index.html",
+            "cache_dir": str(paths["cache_dir"]),
+            "reason": "backup and write ttyd HTML with embedded JetBrainsMono Nerd Font Mono subset",
+        },
+        {
+            **base,
+            "type": "font_ttyd_write_service",
+            "source": "generated ttyd.service",
+            "target": "/etc/systemd/system/ttyd.service",
+            "cache_dir": str(paths["cache_dir"]),
+            "reason": "backup and write ttyd systemd service using the custom index",
+        },
+        {
+            **base,
+            "type": "font_systemd_daemon_reload",
+            "target": "systemd",
+            "reason": "reload systemd after ttyd.service update",
+        },
+        {
+            **base,
+            "type": "font_systemd_restart",
+            "target": "ttyd.service",
+            "reason": "restart Pixel Terminal ttyd service",
+        },
+    ]
+
+
+def jetbrains_paths(home: Path) -> dict[str, Path]:
+    item = NERD_FONT_CATALOG[0]
+    cache_dir = home / FONT_CACHE_REL
+    return {
+        "cache_dir": cache_dir,
+        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
+    }

--- a/dotfiles_tools/font_records.py
+++ b/dotfiles_tools/font_records.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .font_catalog import (
+    APT_FONT_CATALOG,
+    FONT_CACHE_REL,
+    FONT_ENTRY_ID,
+    FONT_INSTALL_BASE_REL,
+    FONT_MARKER_NAME,
+    NERD_FONTS_REPO,
+    NERD_FONT_CATALOG,
+    FontError,
+    NerdFontItem,
+)
+from .font_context import host_action, terminal_impact
+from .font_runner import CommandRunner
+
+
+def select_nerd_font_asset(release: Mapping[str, Any], asset_name: str) -> dict[str, Any]:
+    for asset in release.get("assets") or []:
+        if asset.get("name") == asset_name and asset.get("browser_download_url"):
+            return {
+                "name": asset["name"],
+                "browser_download_url": asset["browser_download_url"],
+                "size": asset.get("size"),
+                "tag_name": release.get("tag_name") or release.get("name") or "latest",
+            }
+    raise FontError(f"{asset_name} not found in latest {NERD_FONTS_REPO} release")
+
+
+def nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
+    cache_dir = home / FONT_CACHE_REL
+    return {
+        "cache_dir": cache_dir,
+        "archive": cache_dir / item.asset_name,
+        "version": cache_dir / f"{item.cache_stem}.version.json",
+        "extract_dir": cache_dir / item.cache_stem,
+        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
+    }
+
+
+def nerd_font_summary(home: Path, context: dict[str, Any], item: NerdFontItem, release: Mapping[str, Any]) -> dict[str, Any]:
+    paths = nerd_paths(home, item)
+    installed_files = installed_font_files(paths["install_dir"])
+    installed_version = read_version(paths["install_dir"] / FONT_MARKER_NAME)
+    cached_version = read_version(paths["version"])
+    latest_version = release_tag_for_asset(release, item.asset_name) or cached_version.get("tag_name")
+    installed_tag = installed_version.get("tag_name") if installed_version else None
+    cached_tag = cached_version.get("tag_name") if cached_version else None
+    state, reason = nerd_font_state(item, installed_files, installed_tag, latest_version, cached_tag)
+    return nerd_font_summary_record(context, item, paths, state, reason, installed_tag, latest_version, cached_tag)
+
+
+def nerd_font_state(
+    item: NerdFontItem,
+    installed_files: list[Path],
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> tuple[str, str]:
+    if not installed_files:
+        return "missing", f"{item.label} is not installed in the user font directory"
+    update_reason = nerd_font_update_reason(installed_tag, latest_version, cached_tag)
+    if update_reason:
+        return "needs_update", update_reason
+    return "installed", f"user-local {item.label} files are present"
+
+
+def nerd_font_update_reason(
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> str | None:
+    if latest_version and installed_tag and installed_tag != latest_version:
+        return f"installed {installed_tag} but latest is {latest_version}"
+    if not latest_version and cached_tag and installed_tag and installed_tag != cached_tag:
+        return f"installed {installed_tag} but cached archive is {cached_tag}"
+    return None
+
+
+def nerd_font_summary_record(
+    context: dict[str, Any],
+    item: NerdFontItem,
+    paths: dict[str, Path],
+    state: str,
+    reason: str,
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> dict[str, Any]:
+    return {
+        "entry_id": item.entry_id,
+        "label": item.label,
+        "family": item.family,
+        "source_type": "nerd_font_release",
+        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
+        "asset_name": item.asset_name,
+        "state": state,
+        "installed_version": installed_tag,
+        "latest_version": latest_version,
+        "cached_version": cached_tag,
+        "candidate_version": None,
+        "target": str(paths["install_dir"]),
+        "cache_path": str(paths["archive"]),
+        "terminal_face": item.terminal_face,
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": terminal_impact(context["platform"]),
+        "host_action": host_action(context),
+        "reason": reason,
+    }
+
+
+def release_tag_for_asset(release: Mapping[str, Any], asset_name: str) -> str | None:
+    if not release:
+        return None
+    try:
+        select_nerd_font_asset(release, asset_name)
+    except FontError:
+        return None
+    tag = release.get("tag_name") or release.get("name")
+    return str(tag) if tag else None
+
+
+def apt_font_summary(context: dict[str, Any], item: dict[str, str], runner: CommandRunner) -> dict[str, Any]:
+    installed_version, installed_reason = apt_installed_version(item["package"], runner)
+    candidate_version, candidate_reason = apt_candidate_version(item["package"], runner)
+    if installed_reason or candidate_reason:
+        state = "manual"
+        reason = installed_reason or candidate_reason or "apt metadata unavailable"
+    elif not installed_version:
+        state = "missing"
+        reason = f"{item['package']} is not installed"
+    elif candidate_version and installed_version != candidate_version:
+        state = "needs_update"
+        reason = f"installed {installed_version} but apt candidate is {candidate_version}"
+    else:
+        state = "installed"
+        reason = f"{item['package']} is installed"
+
+    return {
+        "entry_id": item["entry_id"],
+        "label": item["family"],
+        "family": item["family"],
+        "source_type": "apt_package",
+        "source": "apt",
+        "package": item["package"],
+        "state": state,
+        "installed_version": installed_version,
+        "latest_version": None,
+        "candidate_version": candidate_version,
+        "target": item["package"],
+        "cache_path": None,
+        "terminal_face": item["terminal_face"],
+        "platform": context["platform"],
+        "requires_sudo": state in {"missing", "needs_update"},
+        "terminal_impact": terminal_impact(context["platform"]),
+        "host_action": host_action(context),
+        "reason": reason,
+    }
+
+
+def apt_installed_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
+    dpkg_query = runner.which("dpkg-query")
+    if not dpkg_query:
+        return None, "dpkg-query not found; apt package state must be checked manually"
+    result = runner.run([dpkg_query, "-W", "-f=${Version}", package], capture_output=True, check=False)
+    if result.returncode != 0:
+        return None, None
+    version = (result.stdout or "").strip()
+    return version or None, None
+
+
+def apt_candidate_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
+    apt_cache = runner.which("apt-cache")
+    if not apt_cache:
+        return None, "apt-cache not found; apt candidate state must be checked manually"
+    result = runner.run([apt_cache, "policy", package], capture_output=True, check=False)
+    if result.returncode != 0:
+        return None, f"apt-cache policy failed for {package}"
+    for line in (result.stdout or "").splitlines():
+        text = line.strip()
+        if text.startswith("Candidate:"):
+            candidate = text.split(":", 1)[1].strip()
+            return None if candidate == "(none)" else candidate, None
+    return None, None
+
+
+def font_entry(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "entry_id": summary["entry_id"],
+        "source": summary["source"],
+        "source_type": summary["source_type"],
+        "family": summary["family"],
+        "target": summary["target"],
+        "state": summary["state"],
+        "protected": False,
+        "reason": summary["reason"],
+        "recipe": "fonts",
+        "cache_path": summary.get("cache_path"),
+        "terminal_face": summary.get("terminal_face"),
+        "requires_sudo": summary["requires_sudo"],
+        "terminal_impact": summary["terminal_impact"],
+        "host_action": summary["host_action"],
+    }
+
+
+def build_unsupported_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
+    reason = "automatic font setup is unsupported on this platform"
+    fonts = [unsupported_nerd_summary(home, context, item, reason) for item in NERD_FONT_CATALOG]
+    fonts.extend(unsupported_apt_summary(context, item, reason) for item in APT_FONT_CATALOG)
+    return {
+        "entries": [font_entry(summary) for summary in fonts],
+        "operations": [manual_op(FONT_ENTRY_ID, "Install terminal fonts manually on this platform.")],
+        "fonts": fonts,
+        "context": context,
+    }
+
+
+def unsupported_nerd_summary(home: Path, context: dict[str, Any], item: NerdFontItem, reason: str) -> dict[str, Any]:
+    paths = nerd_paths(home, item)
+    return {
+        "entry_id": item.entry_id,
+        "label": item.label,
+        "family": item.family,
+        "source_type": "nerd_font_release",
+        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
+        "asset_name": item.asset_name,
+        "state": "unsupported",
+        "installed_version": None,
+        "latest_version": None,
+        "cached_version": None,
+        "candidate_version": None,
+        "target": str(paths["install_dir"]),
+        "cache_path": str(paths["archive"]),
+        "terminal_face": item.terminal_face,
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": terminal_impact(context["platform"]),
+        "host_action": host_action(context),
+        "reason": reason,
+    }
+
+
+def unsupported_apt_summary(context: dict[str, Any], item: dict[str, str], reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": item["entry_id"],
+        "label": item["family"],
+        "family": item["family"],
+        "source_type": "apt_package",
+        "source": "apt",
+        "package": item["package"],
+        "state": "unsupported",
+        "installed_version": None,
+        "latest_version": None,
+        "candidate_version": None,
+        "target": item["package"],
+        "cache_path": None,
+        "terminal_face": item["terminal_face"],
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": terminal_impact(context["platform"]),
+        "host_action": host_action(context),
+        "reason": reason,
+    }
+
+
+def manual_op(entry_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "type": "font_manual",
+        "target": "",
+        "reason": reason,
+        "requires_approval": False,
+        "recipe": "fonts",
+    }
+
+
+def installed_ttf_files(install_dir: Path) -> list[Path]:
+    return installed_font_files(install_dir)
+
+
+def installed_font_files(install_dir: Path) -> list[Path]:
+    if not install_dir.exists():
+        return []
+    return sorted(path for path in install_dir.glob("*") if path.suffix.lower() in {".ttf", ".otf"})
+
+
+def read_version(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}

--- a/dotfiles_tools/font_runner.py
+++ b/dotfiles_tools/font_runner.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess  # nosec B404
+from typing import Any, Mapping
+import urllib.request
+
+
+class CommandRunner:
+    def __init__(self, *, env: Mapping[str, str] | None = None, path: str | None = None) -> None:
+        self.env = dict(os.environ if env is None else env)
+        self.path = path if path is not None else self.env.get("PATH", "")
+
+    def which(self, command: str) -> str | None:
+        return shutil.which(command, path=self.path)
+
+    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+        env = dict(self.env)
+        env["PATH"] = self.path
+        # codacy-disable-next-line
+        return subprocess.run(  # nosec B603  # nosemgrep
+            args,
+            check=check,
+            capture_output=capture_output,
+            text=True,
+            env=env,
+            shell=False,
+        )
+
+    def fetch_json(self, url: str) -> dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            headers={"Accept": "application/vnd.github+json", "User-Agent": "000-dotfiles-bootstrap"},
+        )
+        with urllib.request.urlopen(request, timeout=20) as response:  # nosec B310
+            return json.loads(response.read().decode("utf-8"))
+
+    def download(self, url: str, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        request = urllib.request.Request(url, headers={"User-Agent": "000-dotfiles-bootstrap"})
+        with urllib.request.urlopen(request, timeout=60) as response:  # nosec B310
+            tmp.write_bytes(response.read())
+        tmp.replace(target)

--- a/dotfiles_tools/font_windows.py
+++ b/dotfiles_tools/font_windows.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .backups import create_backup
+from .font_assets import windows_font_install_script
+from .font_catalog import FONT_CACHE_REL, FONT_FACE, FONT_INSTALL_BASE_REL, WINDOWS_ENTRY_ID, FontError, NerdFontItem
+from .font_context import host_action, terminal_impact
+from .font_runner import CommandRunner
+
+
+def windows_host_plan(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    font_summary: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    powershell = context.get("powershell")
+    state = "missing" if powershell else "manual"
+    reason = "powershell.exe is available for Windows per-user font install" if powershell else "powershell.exe is not visible from WSL"
+    operations = windows_host_operations(home, context, item, font_summary)
+    return windows_host_entry(home, context, item, state, reason), operations, {"host_action": host_action(context), "requires_sudo": False}
+
+
+def windows_host_entry(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    state: str,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "source": str(nerd_paths(home, item)["install_dir"]),
+        "source_type": "windows_host",
+        "family": item.family,
+        "target": "Windows per-user font store",
+        "state": state,
+        "protected": False,
+        "reason": reason,
+        "recipe": "fonts",
+        "requires_sudo": False,
+        "terminal_face": item.terminal_face,
+        "terminal_impact": terminal_impact("wsl"),
+        "host_action": host_action(context),
+    }
+
+
+def windows_host_operations(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    font_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if not context.get("powershell"):
+        return [manual_op(WINDOWS_ENTRY_ID, f"Install {item.terminal_face} on the Windows host manually.")]
+    operations = [windows_font_install_operation(home, item, font_summary)]
+    settings = context.get("windows_terminal_settings")
+    if settings:
+        operations.append(windows_terminal_update_operation(item, settings))
+    else:
+        operations.append(manual_op(WINDOWS_ENTRY_ID, f"Set Windows Terminal font face to {item.terminal_face} manually."))
+    return operations
+
+
+def windows_font_install_operation(home: Path, item: NerdFontItem, font_summary: dict[str, Any]) -> dict[str, Any]:
+    source_dir = nerd_paths(home, item)["install_dir"] if font_summary["state"] == "installed" else nerd_paths(home, item)["extract_dir"]
+    return {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "type": "font_install_windows",
+        "source": str(source_dir),
+        "target": "Windows per-user font store",
+        "terminal_face": item.terminal_face,
+        "reason": "install JetBrainsMono Nerd Font Mono into the Windows user font store through PowerShell",
+        "requires_approval": True,
+        "recipe": "fonts",
+    }
+
+
+def windows_terminal_update_operation(item: NerdFontItem, settings: str) -> dict[str, Any]:
+    return {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "type": "font_update_windows_terminal",
+        "source": item.terminal_face,
+        "target": settings,
+        "reason": "set Windows Terminal profile defaults font.face",
+        "requires_approval": True,
+        "recipe": "fonts",
+    }
+
+
+def nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
+    cache_dir = home / FONT_CACHE_REL
+    return {
+        "cache_dir": cache_dir,
+        "archive": cache_dir / item.asset_name,
+        "version": cache_dir / f"{item.cache_stem}.version.json",
+        "extract_dir": cache_dir / item.cache_stem,
+        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
+    }
+
+
+def manual_op(entry_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "type": "font_manual",
+        "target": "",
+        "reason": reason,
+        "requires_approval": False,
+        "recipe": "fonts",
+    }
+
+
+def execute_install_windows(op: dict[str, Any], runner: CommandRunner) -> int:
+    powershell = runner.which("powershell.exe")
+    if not powershell:
+        op["result"] = "powershell.exe not found; install Windows host font manually"
+        return 0
+    source = Path(op["source"])
+    if not source.exists():
+        raise FontError(f"Windows font source directory is missing: {source}")
+    windows_source = str(source)
+    wslpath = runner.which("wslpath")
+    if wslpath:
+        converted = runner.run([wslpath, "-w", str(source)], capture_output=True)
+        windows_source = converted.stdout.strip()
+    script = windows_font_install_script(windows_source)
+    runner.run([powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
+    return 1
+
+
+def execute_update_windows_terminal(op: dict[str, Any], backup_dir: Path, backups: list[dict[str, Any]]) -> int:
+    target = Path(op["target"])
+    if not target.exists():
+        op["result"] = "Windows Terminal settings file was not found; set font face manually"
+        return 0
+    record = create_backup(target, backup_dir, entry_id=op["entry_id"])
+    backups.append(record)
+    try:
+        data = json.loads(target.read_text())
+    except json.JSONDecodeError as exc:
+        raise FontError(f"invalid Windows Terminal settings JSON: {target}") from exc
+    font = terminal_settings_font(data)
+    font["face"] = FONT_FACE
+    target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    op["backup_target"] = record["backup_target"]
+    return 1
+
+
+def terminal_settings_font(data: dict[str, Any]) -> dict[str, Any]:
+    profiles = data.setdefault("profiles", {})
+    if not isinstance(profiles, dict):
+        profiles = {}
+        data["profiles"] = profiles
+    defaults = profiles.setdefault("defaults", {})
+    if not isinstance(defaults, dict):
+        defaults = {}
+        profiles["defaults"] = defaults
+    font = defaults.setdefault("font", {})
+    if not isinstance(font, dict):
+        font = {}
+        defaults["font"] = font
+    return font

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -24,13 +24,11 @@ from .font_catalog import (
     FONT_ENTRY_ID,
     FONT_EXTRACTED_DIR,
     FONT_FACE,
-    FONT_INSTALL_BASE_REL,
     FONT_INSTALL_REL,
     FONT_MARKER_NAME,
     FONT_LABEL,
     FONT_VERSION_NAME,
     NERD_FONTS_RELEASE_URL,
-    NERD_FONTS_REPO,
     NERD_FONT_CATALOG,
     NerdFontItem,
     PIXEL_AVF_ENTRY_ID,
@@ -39,6 +37,17 @@ from .font_catalog import (
     FontError,
 )
 from .font_pixel import pixel_ttyd_plan as _pixel_ttyd_plan
+from .font_records import (
+    apt_font_summary as _apt_font_summary,
+    build_unsupported_plan as _build_unsupported_plan,
+    font_entry as _font_entry,
+    installed_font_files as _installed_font_files,
+    nerd_font_summary as _nerd_font_summary,
+    nerd_paths as _nerd_paths,
+    read_version as _read_version,
+    select_nerd_font_asset as _select_nerd_font_asset,
+    unsupported_nerd_summary as _unsupported_nerd_summary,
+)
 from .font_runner import CommandRunner
 from .font_windows import (
     execute_install_windows as _execute_install_windows,
@@ -67,15 +76,7 @@ __all__ = (
 
 
 def select_nerd_font_asset(release: Mapping[str, Any], asset_name: str = FONT_ASSET_NAME) -> dict[str, Any]:
-    for asset in release.get("assets") or []:
-        if asset.get("name") == asset_name and asset.get("browser_download_url"):
-            return {
-                "name": asset["name"],
-                "browser_download_url": asset["browser_download_url"],
-                "size": asset.get("size"),
-                "tag_name": release.get("tag_name") or release.get("name") or "latest",
-            }
-    raise FontError(f"{asset_name} not found in latest {NERD_FONTS_REPO} release")
+    return _select_nerd_font_asset(release, asset_name)
 
 
 def build_font_plan(
@@ -273,183 +274,6 @@ def _truthy(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
-    cache_dir = home / FONT_CACHE_REL
-    return {
-        "cache_dir": cache_dir,
-        "archive": cache_dir / item.asset_name,
-        "version": cache_dir / f"{item.cache_stem}.version.json",
-        "extract_dir": cache_dir / item.cache_stem,
-        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
-    }
-
-
-def _nerd_font_summary(home: Path, context: dict[str, Any], item: NerdFontItem, release: Mapping[str, Any]) -> dict[str, Any]:
-    paths = _nerd_paths(home, item)
-    installed_files = _installed_font_files(paths["install_dir"])
-    installed_version = _read_version(paths["install_dir"] / FONT_MARKER_NAME)
-    cached_version = _read_version(paths["version"])
-    latest_version = _release_tag_for_asset(release, item.asset_name) or cached_version.get("tag_name")
-    installed_tag = installed_version.get("tag_name") if installed_version else None
-    cached_tag = cached_version.get("tag_name") if cached_version else None
-    state, reason = _nerd_font_state(item, installed_files, installed_tag, latest_version, cached_tag)
-    return _nerd_font_summary_record(context, item, paths, state, reason, installed_tag, latest_version, cached_tag)
-
-
-def _nerd_font_state(
-    item: NerdFontItem,
-    installed_files: list[Path],
-    installed_tag: str | None,
-    latest_version: str | None,
-    cached_tag: str | None,
-) -> tuple[str, str]:
-    if not installed_files:
-        return "missing", f"{item.label} is not installed in the user font directory"
-    update_reason = _nerd_font_update_reason(installed_tag, latest_version, cached_tag)
-    if update_reason:
-        return "needs_update", update_reason
-    return "installed", f"user-local {item.label} files are present"
-
-
-def _nerd_font_update_reason(
-    installed_tag: str | None,
-    latest_version: str | None,
-    cached_tag: str | None,
-) -> str | None:
-    if latest_version and installed_tag and installed_tag != latest_version:
-        return f"installed {installed_tag} but latest is {latest_version}"
-    if not latest_version and cached_tag and installed_tag and installed_tag != cached_tag:
-        return f"installed {installed_tag} but cached archive is {cached_tag}"
-    return None
-
-
-def _nerd_font_summary_record(
-    context: dict[str, Any],
-    item: NerdFontItem,
-    paths: dict[str, Path],
-    state: str,
-    reason: str,
-    installed_tag: str | None,
-    latest_version: str | None,
-    cached_tag: str | None,
-) -> dict[str, Any]:
-    return {
-        "entry_id": item.entry_id,
-        "label": item.label,
-        "family": item.family,
-        "source_type": "nerd_font_release",
-        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
-        "asset_name": item.asset_name,
-        "state": state,
-        "installed_version": installed_tag,
-        "latest_version": latest_version,
-        "cached_version": cached_tag,
-        "candidate_version": None,
-        "target": str(paths["install_dir"]),
-        "cache_path": str(paths["archive"]),
-        "terminal_face": item.terminal_face,
-        "platform": context["platform"],
-        "requires_sudo": False,
-        "terminal_impact": _terminal_impact(context["platform"]),
-        "host_action": _host_action(context),
-        "reason": reason,
-    }
-
-
-def _release_tag_for_asset(release: Mapping[str, Any], asset_name: str) -> str | None:
-    if not release:
-        return None
-    try:
-        select_nerd_font_asset(release, asset_name)
-    except FontError:
-        return None
-    tag = release.get("tag_name") or release.get("name")
-    return str(tag) if tag else None
-
-
-def _apt_font_summary(context: dict[str, Any], item: dict[str, str], runner: CommandRunner) -> dict[str, Any]:
-    installed_version, installed_reason = _apt_installed_version(item["package"], runner)
-    candidate_version, candidate_reason = _apt_candidate_version(item["package"], runner)
-    if installed_reason or candidate_reason:
-        state = "manual"
-        reason = installed_reason or candidate_reason or "apt metadata unavailable"
-    elif not installed_version:
-        state = "missing"
-        reason = f"{item['package']} is not installed"
-    elif candidate_version and installed_version != candidate_version:
-        state = "needs_update"
-        reason = f"installed {installed_version} but apt candidate is {candidate_version}"
-    else:
-        state = "installed"
-        reason = f"{item['package']} is installed"
-
-    return {
-        "entry_id": item["entry_id"],
-        "label": item["family"],
-        "family": item["family"],
-        "source_type": "apt_package",
-        "source": "apt",
-        "package": item["package"],
-        "state": state,
-        "installed_version": installed_version,
-        "latest_version": None,
-        "candidate_version": candidate_version,
-        "target": item["package"],
-        "cache_path": None,
-        "terminal_face": item["terminal_face"],
-        "platform": context["platform"],
-        "requires_sudo": state in {"missing", "needs_update"},
-        "terminal_impact": _terminal_impact(context["platform"]),
-        "host_action": _host_action(context),
-        "reason": reason,
-    }
-
-
-def _apt_installed_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
-    dpkg_query = runner.which("dpkg-query")
-    if not dpkg_query:
-        return None, "dpkg-query not found; apt package state must be checked manually"
-    result = runner.run([dpkg_query, "-W", "-f=${Version}", package], capture_output=True, check=False)
-    if result.returncode != 0:
-        return None, None
-    version = (result.stdout or "").strip()
-    return version or None, None
-
-
-def _apt_candidate_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
-    apt_cache = runner.which("apt-cache")
-    if not apt_cache:
-        return None, "apt-cache not found; apt candidate state must be checked manually"
-    result = runner.run([apt_cache, "policy", package], capture_output=True, check=False)
-    if result.returncode != 0:
-        return None, f"apt-cache policy failed for {package}"
-    for line in (result.stdout or "").splitlines():
-        text = line.strip()
-        if text.startswith("Candidate:"):
-            candidate = text.split(":", 1)[1].strip()
-            return None if candidate == "(none)" else candidate, None
-    return None, None
-
-
-def _font_entry(summary: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "entry_id": summary["entry_id"],
-        "source": summary["source"],
-        "source_type": summary["source_type"],
-        "family": summary["family"],
-        "target": summary["target"],
-        "state": summary["state"],
-        "protected": False,
-        "reason": summary["reason"],
-        "recipe": "fonts",
-        "cache_path": summary.get("cache_path"),
-        "terminal_face": summary.get("terminal_face"),
-        "requires_sudo": summary["requires_sudo"],
-        "terminal_impact": summary["terminal_impact"],
-        "host_action": summary["host_action"],
-    }
-
-
 def _nerd_font_operations(home: Path, item: NerdFontItem, *, reason: str) -> list[dict[str, Any]]:
     paths = _nerd_paths(home, item)
     base = {
@@ -550,105 +374,6 @@ def _build_pixel_avf_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]
             "recipe": "fonts",
         })
     return {"entries": entries, "operations": operations, "fonts": fonts, "context": context}
-
-
-def _build_unsupported_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
-    reason = "automatic font setup is unsupported on this platform"
-    fonts = [_unsupported_nerd_summary(home, context, item, reason) for item in NERD_FONT_CATALOG]
-    fonts.extend(_unsupported_apt_summary(context, item, reason) for item in APT_FONT_CATALOG)
-    return {
-        "entries": [_font_entry(summary) for summary in fonts],
-        "operations": [_manual_op(FONT_ENTRY_ID, "Install terminal fonts manually on this platform.")],
-        "fonts": fonts,
-        "context": context,
-    }
-
-
-def _unsupported_nerd_summary(home: Path, context: dict[str, Any], item: NerdFontItem, reason: str) -> dict[str, Any]:
-    paths = _nerd_paths(home, item)
-    return {
-        "entry_id": item.entry_id,
-        "label": item.label,
-        "family": item.family,
-        "source_type": "nerd_font_release",
-        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
-        "asset_name": item.asset_name,
-        "state": "unsupported",
-        "installed_version": None,
-        "latest_version": None,
-        "cached_version": None,
-        "candidate_version": None,
-        "target": str(paths["install_dir"]),
-        "cache_path": str(paths["archive"]),
-        "terminal_face": item.terminal_face,
-        "platform": context["platform"],
-        "requires_sudo": False,
-        "terminal_impact": _terminal_impact(context["platform"]),
-        "host_action": _host_action(context),
-        "reason": reason,
-    }
-
-
-def _unsupported_apt_summary(context: dict[str, Any], item: dict[str, str], reason: str) -> dict[str, Any]:
-    return {
-        "entry_id": item["entry_id"],
-        "label": item["family"],
-        "family": item["family"],
-        "source_type": "apt_package",
-        "source": "apt",
-        "package": item["package"],
-        "state": "unsupported",
-        "installed_version": None,
-        "latest_version": None,
-        "candidate_version": None,
-        "target": item["package"],
-        "cache_path": None,
-        "terminal_face": item["terminal_face"],
-        "platform": context["platform"],
-        "requires_sudo": False,
-        "terminal_impact": _terminal_impact(context["platform"]),
-        "host_action": _host_action(context),
-        "reason": reason,
-    }
-
-
-def _font_skip_op(entry_id: str, reason: str) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "type": "font_skip",
-        "target": "",
-        "reason": reason,
-        "requires_approval": False,
-        "recipe": "fonts",
-    }
-
-
-def _manual_op(entry_id: str, reason: str) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "type": "font_manual",
-        "target": "",
-        "reason": reason,
-        "requires_approval": False,
-        "recipe": "fonts",
-    }
-
-
-def _installed_ttf_files(install_dir: Path) -> list[Path]:
-    return _installed_font_files(install_dir)
-
-
-def _installed_font_files(install_dir: Path) -> list[Path]:
-    if not install_dir.exists():
-        return []
-    return sorted(path for path in install_dir.glob("*") if path.suffix.lower() in {".ttf", ".otf"})
-
-
-def _read_version(path: Path) -> dict[str, Any]:
-    try:
-        return json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {}
 
 
 def _execute_download(op: dict[str, Any], runner: CommandRunner) -> int:

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -1,168 +1,42 @@
 from __future__ import annotations
 
 import base64
-from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
 import platform
 import shutil
-import subprocess  # nosec B404
-import urllib.request
 import zipfile
 from typing import Any, Mapping
 
 from .backups import create_backup
-
-
-NERD_FONTS_RELEASE_URL = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
-NERD_FONTS_REPO = "ryanoasis/nerd-fonts"
-FONT_CACHE_REL = Path(".cache/000-dotfiles/fonts")
-FONT_INSTALL_BASE_REL = Path(".local/share/fonts")
-FONT_MARKER_NAME = ".000-dotfiles-font-source.json"
-WINDOWS_TERMINAL_PACKAGES = (
-    "Microsoft.WindowsTerminal_8wekyb3d8bbwe",
-    "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe",
+from .font_catalog import (
+    APT_FONT_CATALOG,
+    EXPECTED_TTF,
+    FONT_ARCHIVE_NAME,
+    FONT_ASSET_NAME,
+    FONT_CACHE_REL,
+    FONT_ENTRY_ID,
+    FONT_EXTRACTED_DIR,
+    FONT_FACE,
+    FONT_INSTALL_BASE_REL,
+    FONT_INSTALL_REL,
+    FONT_MARKER_NAME,
+    FONT_LABEL,
+    FONT_VERSION_NAME,
+    NERD_FONTS_RELEASE_URL,
+    NERD_FONTS_REPO,
+    NERD_FONT_CATALOG,
+    NerdFontItem,
+    PIXEL_AVF_ENTRY_ID,
+    PIXEL_AVF_PROMPT_REL,
+    PIXEL_TTYD_ENTRY_ID,
+    PIXEL_TTYD_FONT_ALIAS,
+    WINDOWS_ENTRY_ID,
+    WINDOWS_TERMINAL_PACKAGES,
+    FontError,
 )
-
-FONT_ASSET_NAME = "JetBrainsMono.zip"
-FONT_FACE = "JetBrainsMono Nerd Font Mono"
-FONT_LABEL = "JetBrainsMono Nerd Font"
-FONT_ENTRY_ID = "fonts.jetbrains-mono-nerd"
-FONT_INSTALL_REL = FONT_INSTALL_BASE_REL / "JetBrainsMonoNerdFont"
-FONT_EXTRACTED_DIR = "JetBrainsMono"
-FONT_ARCHIVE_NAME = FONT_ASSET_NAME
-FONT_VERSION_NAME = "JetBrainsMono.version.json"
-EXPECTED_TTF = "JetBrainsMonoNerdFontMono-Regular.ttf"
-WINDOWS_ENTRY_ID = "fonts.windows-host"
-PIXEL_TTYD_ENTRY_ID = "fonts.pixel-ttyd"
-PIXEL_AVF_ENTRY_ID = "fonts.pixel-avf-prompt"
-PIXEL_TTYD_FONT_ALIAS = "JBMono NF"
-PIXEL_AVF_PROMPT_REL = Path(".config/fish/conf.d/000-dotfiles-pixel-avf-prompt.fish")
-
-
-@dataclass(frozen=True)
-class NerdFontItem:
-    entry_id: str
-    label: str
-    family: str
-    asset_name: str
-    install_dir_name: str
-    terminal_face: str
-    expected_regular: str
-
-    @property
-    def cache_stem(self) -> str:
-        return Path(self.asset_name).stem
-
-
-NERD_FONT_CATALOG: tuple[NerdFontItem, ...] = (
-    NerdFontItem(
-        FONT_ENTRY_ID,
-        FONT_LABEL,
-        "JetBrainsMono",
-        FONT_ASSET_NAME,
-        "JetBrainsMonoNerdFont",
-        FONT_FACE,
-        EXPECTED_TTF,
-    ),
-    NerdFontItem(
-        "fonts.fira-code-nerd",
-        "FiraCode Nerd Font",
-        "FiraCode",
-        "FiraCode.zip",
-        "FiraCodeNerdFont",
-        "FiraCode Nerd Font Mono",
-        "FiraCodeNerdFontMono-Regular.ttf",
-    ),
-    NerdFontItem(
-        "fonts.hack-nerd",
-        "Hack Nerd Font",
-        "Hack",
-        "Hack.zip",
-        "HackNerdFont",
-        "Hack Nerd Font Mono",
-        "HackNerdFontMono-Regular.ttf",
-    ),
-    NerdFontItem(
-        "fonts.meslo-nerd",
-        "MesloLGS Nerd Font",
-        "MesloLGS",
-        "Meslo.zip",
-        "MesloNerdFont",
-        "MesloLGS Nerd Font Mono",
-        "MesloLGSNerdFontMono-Regular.ttf",
-    ),
-)
-
-APT_FONT_CATALOG: tuple[dict[str, str], ...] = (
-    {
-        "entry_id": "fonts.apt.noto-color-emoji",
-        "family": "Noto Color Emoji",
-        "package": "fonts-noto-color-emoji",
-        "terminal_face": "Noto Color Emoji",
-    },
-    {
-        "entry_id": "fonts.apt.symbola",
-        "family": "Symbola",
-        "package": "fonts-symbola",
-        "terminal_face": "Symbola",
-    },
-    {
-        "entry_id": "fonts.apt.freefont",
-        "family": "GNU FreeFont",
-        "package": "fonts-freefont-ttf",
-        "terminal_face": "FreeMono",
-    },
-    {
-        "entry_id": "fonts.apt.dejavu-core",
-        "family": "DejaVu Core",
-        "package": "fonts-dejavu-core",
-        "terminal_face": "DejaVu Sans Mono",
-    },
-)
-
-
-class FontError(RuntimeError):
-    """Raised when a font recipe cannot complete."""
-
-
-class CommandRunner:
-    def __init__(self, *, env: Mapping[str, str] | None = None, path: str | None = None) -> None:
-        self.env = dict(os.environ if env is None else env)
-        self.path = path if path is not None else self.env.get("PATH", "")
-
-    def which(self, command: str) -> str | None:
-        return shutil.which(command, path=self.path)
-
-    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
-        env = dict(self.env)
-        env["PATH"] = self.path
-        # codacy-disable-next-line
-        return subprocess.run(  # nosec B603  # nosemgrep
-            args,
-            check=check,
-            capture_output=capture_output,
-            text=True,
-            env=env,
-            shell=False,
-        )
-
-    def fetch_json(self, url: str) -> dict[str, Any]:
-        request = urllib.request.Request(
-            url,
-            headers={"Accept": "application/vnd.github+json", "User-Agent": "000-dotfiles-bootstrap"},
-        )
-        with urllib.request.urlopen(request, timeout=20) as response:  # nosec B310
-            return json.loads(response.read().decode("utf-8"))
-
-    def download(self, url: str, target: Path) -> None:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp = target.with_suffix(target.suffix + ".tmp")
-        request = urllib.request.Request(url, headers={"User-Agent": "000-dotfiles-bootstrap"})
-        with urllib.request.urlopen(request, timeout=60) as response:  # nosec B310
-            tmp.write_bytes(response.read())
-        tmp.replace(target)
+from .font_runner import CommandRunner
 
 
 def select_nerd_font_asset(release: Mapping[str, Any], asset_name: str = FONT_ASSET_NAME) -> dict[str, Any]:
@@ -184,56 +58,124 @@ def build_font_plan(
     path: str | None = None,
     runner: CommandRunner | None = None,
 ) -> dict[str, Any]:
+    home_path, effective_env, effective_runner, context, fetch_release = _font_plan_inputs(home, env, path, runner)
+    if context["platform"] == "unsupported":
+        return _build_unsupported_plan(home_path, context)
+    if context["platform"] == "pixel-avf":
+        return _build_pixel_avf_plan(home_path, context)
+    return _build_supported_font_plan(home_path, effective_env, effective_runner, context, fetch_release)
+
+
+def _font_plan_inputs(
+    home: Path | str,
+    env: Mapping[str, str] | None,
+    path: str | None,
+    runner: CommandRunner | None,
+) -> tuple[Path, dict[str, str], CommandRunner, dict[str, Any], bool]:
     home_path = Path(home).expanduser().resolve()
     effective_env = dict(os.environ if env is None else env)
     effective_path = path if path is not None else effective_env.get("PATH", "")
     runner_was_provided = runner is not None
     effective_runner = runner or CommandRunner(env=effective_env, path=effective_path)
     context = _detect_context(home_path, effective_env, effective_path, effective_runner)
+    return home_path, effective_env, effective_runner, context, runner_was_provided
 
-    if context["platform"] == "unsupported":
-        return _build_unsupported_plan(home_path, context)
-    if context["platform"] == "pixel-avf":
-        return _build_pixel_avf_plan(home_path, context)
 
-    release = _release_metadata(home_path, effective_env, effective_runner, fetch=runner_was_provided)
+def _build_supported_font_plan(
+    home: Path,
+    env: Mapping[str, str],
+    runner: CommandRunner,
+    context: dict[str, Any],
+    fetch_release: bool,
+) -> dict[str, Any]:
+    release = _release_metadata(home, env, runner, fetch=fetch_release)
     entries: list[dict[str, Any]] = []
     operations: list[dict[str, Any]] = []
     fonts: list[dict[str, Any]] = []
+    _extend_nerd_font_plan(home, context, release, entries, operations, fonts)
+    _extend_apt_font_plan(context, runner, entries, operations, fonts)
+    _extend_platform_font_plan(home, context, entries, operations, fonts)
+    return {"entries": entries, "operations": operations, "fonts": fonts, "context": context}
 
+
+def _extend_nerd_font_plan(
+    home: Path,
+    context: dict[str, Any],
+    release: Mapping[str, Any],
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    fonts: list[dict[str, Any]],
+) -> None:
     for item in _nerd_items_for_platform(context["platform"]):
-        summary = _nerd_font_summary(home_path, context, item, release)
+        summary = _nerd_font_summary(home, context, item, release)
         entries.append(_font_entry(summary))
         fonts.append(summary)
         if summary["state"] in {"missing", "needs_update"}:
-            operations.extend(_nerd_font_operations(home_path, item, reason=summary["reason"]))
+            operations.extend(_nerd_font_operations(home, item, reason=summary["reason"]))
 
+
+def _extend_apt_font_plan(
+    context: dict[str, Any],
+    runner: CommandRunner,
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    fonts: list[dict[str, Any]],
+) -> None:
     for item in _apt_items_for_platform(context["platform"]):
-        summary = _apt_font_summary(context, item, effective_runner)
+        summary = _apt_font_summary(context, item, runner)
         entries.append(_font_entry(summary))
         fonts.append(summary)
         if summary["state"] in {"missing", "needs_update"}:
             operations.append(_apt_package_operation(summary))
 
+
+def _extend_platform_font_plan(
+    home: Path,
+    context: dict[str, Any],
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    fonts: list[dict[str, Any]],
+) -> None:
     if context["platform"] == "wsl":
-        jetbrains = next(item for item in NERD_FONT_CATALOG if item.entry_id == FONT_ENTRY_ID)
-        jetbrains_summary = next(item for item in fonts if item["entry_id"] == FONT_ENTRY_ID)
-        windows_entry, windows_ops, windows_summary = _windows_host_plan(home_path, context, jetbrains, jetbrains_summary)
-        entries.append(windows_entry)
-        operations.extend(windows_ops)
-        jetbrains_summary["host_action"] = windows_summary["host_action"]
-
+        _extend_wsl_host_plan(home, context, entries, operations, fonts)
     if context["platform"] == "pixel-terminal":
-        jetbrains_summary = next(item for item in fonts if item["entry_id"] == FONT_ENTRY_ID)
-        pixel_entry, pixel_ops, pixel_summary = _pixel_ttyd_plan(home_path, context, jetbrains_summary)
-        entries.append(pixel_entry)
-        operations.extend(pixel_ops)
-        jetbrains_summary["host_action"] = pixel_summary["host_action"]
-        jetbrains_summary["requires_sudo"] = True
-        jetbrains_summary["terminal_impact"] = pixel_summary["terminal_impact"]
-        jetbrains_summary["embedded_alias"] = PIXEL_TTYD_FONT_ALIAS
+        _extend_pixel_terminal_plan(home, context, entries, operations, fonts)
 
-    return {"entries": entries, "operations": operations, "fonts": fonts, "context": context}
+
+def _jetbrains_font_summary(fonts: list[dict[str, Any]]) -> dict[str, Any]:
+    return next(item for item in fonts if item["entry_id"] == FONT_ENTRY_ID)
+
+
+def _extend_wsl_host_plan(
+    home: Path,
+    context: dict[str, Any],
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    fonts: list[dict[str, Any]],
+) -> None:
+    jetbrains = next(item for item in NERD_FONT_CATALOG if item.entry_id == FONT_ENTRY_ID)
+    jetbrains_summary = _jetbrains_font_summary(fonts)
+    windows_entry, windows_ops, windows_summary = _windows_host_plan(home, context, jetbrains, jetbrains_summary)
+    entries.append(windows_entry)
+    operations.extend(windows_ops)
+    jetbrains_summary["host_action"] = windows_summary["host_action"]
+
+
+def _extend_pixel_terminal_plan(
+    home: Path,
+    context: dict[str, Any],
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    fonts: list[dict[str, Any]],
+) -> None:
+    jetbrains_summary = _jetbrains_font_summary(fonts)
+    pixel_entry, pixel_ops, pixel_summary = _pixel_ttyd_plan(home, context, jetbrains_summary)
+    entries.append(pixel_entry)
+    operations.extend(pixel_ops)
+    jetbrains_summary["host_action"] = pixel_summary["host_action"]
+    jetbrains_summary["requires_sudo"] = True
+    jetbrains_summary["terminal_impact"] = pixel_summary["terminal_impact"]
+    jetbrains_summary["embedded_alias"] = PIXEL_TTYD_FONT_ALIAS
 
 
 def execute_font_operation(
@@ -247,68 +189,88 @@ def execute_font_operation(
     backup_path = backup_dir or Path.home() / ".dotfiles-backups"
     backup_records = backups if backups is not None else []
     op_type = op["type"]
-    if op_type in {"font_skip", "font_manual"}:
-        return 0
-    if op_type == "font_download":
-        return _execute_download(op, effective_runner)
-    if op_type == "font_extract":
-        return _execute_extract(op)
-    if op_type == "font_install_linux":
-        return _execute_install_linux(op)
-    if op_type == "font_rebuild_cache":
-        return _execute_rebuild_cache(op, effective_runner)
-    if op_type == "font_verify_linux":
-        return _execute_verify_linux(op, effective_runner)
-    if op_type == "font_install_packages":
-        return _execute_install_packages(op, effective_runner)
-    if op_type == "font_install_windows":
-        return _execute_install_windows(op, effective_runner)
-    if op_type == "font_update_windows_terminal":
-        return _execute_update_windows_terminal(op, backup_path, backup_records)
-    if op_type == "font_ttyd_write_html":
-        return _execute_ttyd_html(op, effective_runner, backup_records)
-    if op_type == "font_ttyd_write_service":
-        return _execute_ttyd_service(op, effective_runner, backup_records)
-    if op_type == "font_systemd_daemon_reload":
-        effective_runner.run(["sudo", "systemctl", "daemon-reload"])
-        return 1
-    if op_type == "font_systemd_restart":
-        effective_runner.run(["sudo", "systemctl", "restart", "ttyd.service"])
-        return 1
-    if op_type == "font_pixel_avf_prompt":
-        return _execute_pixel_avf_prompt(op)
+    executor = _font_operation_handlers(effective_runner, backup_path, backup_records).get(op_type)
+    if executor:
+        return executor(op)
     raise FontError(f"unknown font operation: {op_type}")
 
 
-def _detect_context(home: Path, env: Mapping[str, str], path: str, runner: CommandRunner) -> dict[str, Any]:
-    override = (env.get("DOTFILES_PLATFORM") or "").strip().lower()
-    if override in {"linux", "native-linux", "ubuntu"}:
-        platform_id = "linux"
-    elif override in {"pi", "raspberry-pi", "raspberrypi"}:
-        platform_id = "pi"
-    elif override in {"wsl", "wsl-linux", "wsl2"}:
-        platform_id = "wsl"
-    elif override in {"pixel-terminal", "pixel_ttyd", "ttyd"}:
-        platform_id = "pixel-terminal"
-    elif override in {"pixel-avf", "avf"}:
-        platform_id = "pixel-avf"
-    elif _is_wsl(env):
-        platform_id = "wsl"
-    elif _is_raspberry_pi():
-        platform_id = "pi"
-    elif Path("/etc/ttyd").exists() or Path("/etc/systemd/system/ttyd.service").exists():
-        platform_id = "pixel-terminal"
-    else:
-        platform_id = "linux" if platform.system().lower() == "linux" else "unsupported"
-
+def _font_operation_handlers(
+    runner: CommandRunner,
+    backup_path: Path,
+    backups: list[dict[str, Any]],
+) -> dict[str, Any]:
     return {
-        "platform": platform_id,
+        "font_skip": lambda op: 0,
+        "font_manual": lambda op: 0,
+        "font_download": lambda op: _execute_download(op, runner),
+        "font_extract": _execute_extract,
+        "font_install_linux": _execute_install_linux,
+        "font_rebuild_cache": lambda op: _execute_rebuild_cache(op, runner),
+        "font_verify_linux": lambda op: _execute_verify_linux(op, runner),
+        "font_install_packages": lambda op: _execute_install_packages(op, runner),
+        "font_install_windows": lambda op: _execute_install_windows(op, runner),
+        "font_update_windows_terminal": lambda op: _execute_update_windows_terminal(op, backup_path, backups),
+        "font_ttyd_write_html": lambda op: _execute_ttyd_html(op, runner, backups),
+        "font_ttyd_write_service": lambda op: _execute_ttyd_service(op, runner, backups),
+        "font_systemd_daemon_reload": lambda op: _execute_systemd(op, runner, "daemon-reload"),
+        "font_systemd_restart": lambda op: _execute_systemd(op, runner, "restart", "ttyd.service"),
+        "font_pixel_avf_prompt": _execute_pixel_avf_prompt,
+    }
+
+
+def _execute_systemd(op: dict[str, Any], runner: CommandRunner, *args: str) -> int:
+    runner.run(["sudo", "systemctl", *args])
+    return 1
+
+
+def _detect_context(home: Path, env: Mapping[str, str], path: str, runner: CommandRunner) -> dict[str, Any]:
+    return {
+        "platform": _platform_id(env),
         "architecture": platform.machine().lower(),
         "path": path,
         "powershell": runner.which("powershell.exe"),
         "wslpath": runner.which("wslpath"),
         "windows_terminal_settings": _discover_windows_terminal_settings(home, env),
     }
+
+
+def _platform_id(env: Mapping[str, str]) -> str:
+    override = (env.get("DOTFILES_PLATFORM") or "").strip().lower()
+    override_id = _platform_override(override)
+    if override_id:
+        return override_id
+    return _detected_platform(env)
+
+
+def _platform_override(override: str) -> str | None:
+    overrides = {
+        "linux": "linux",
+        "native-linux": "linux",
+        "ubuntu": "linux",
+        "pi": "pi",
+        "raspberry-pi": "pi",
+        "raspberrypi": "pi",
+        "wsl": "wsl",
+        "wsl-linux": "wsl",
+        "wsl2": "wsl",
+        "pixel-terminal": "pixel-terminal",
+        "pixel_ttyd": "pixel-terminal",
+        "ttyd": "pixel-terminal",
+        "pixel-avf": "pixel-avf",
+        "avf": "pixel-avf",
+    }
+    return overrides.get(override)
+
+
+def _detected_platform(env: Mapping[str, str]) -> str:
+    if _is_wsl(env):
+        return "wsl"
+    if _is_raspberry_pi():
+        return "pi"
+    if Path("/etc/ttyd").exists() or Path("/etc/systemd/system/ttyd.service").exists():
+        return "pixel-terminal"
+    return "linux" if platform.system().lower() == "linux" else "unsupported"
 
 
 def _is_wsl(env: Mapping[str, str]) -> bool:
@@ -408,19 +370,47 @@ def _nerd_font_summary(home: Path, context: dict[str, Any], item: NerdFontItem, 
     latest_version = _release_tag_for_asset(release, item.asset_name) or cached_version.get("tag_name")
     installed_tag = installed_version.get("tag_name") if installed_version else None
     cached_tag = cached_version.get("tag_name") if cached_version else None
-    if not installed_files:
-        state = "missing"
-        reason = f"{item.label} is not installed in the user font directory"
-    elif latest_version and installed_tag and installed_tag != latest_version:
-        state = "needs_update"
-        reason = f"installed {installed_tag} but latest is {latest_version}"
-    elif not latest_version and cached_tag and installed_tag and installed_tag != cached_tag:
-        state = "needs_update"
-        reason = f"installed {installed_tag} but cached archive is {cached_tag}"
-    else:
-        state = "installed"
-        reason = f"user-local {item.label} files are present"
+    state, reason = _nerd_font_state(item, installed_files, installed_tag, latest_version, cached_tag)
+    return _nerd_font_summary_record(context, item, paths, state, reason, installed_tag, latest_version, cached_tag)
 
+
+def _nerd_font_state(
+    item: NerdFontItem,
+    installed_files: list[Path],
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> tuple[str, str]:
+    if not installed_files:
+        return "missing", f"{item.label} is not installed in the user font directory"
+    update_reason = _nerd_font_update_reason(installed_tag, latest_version, cached_tag)
+    if update_reason:
+        return "needs_update", update_reason
+    return "installed", f"user-local {item.label} files are present"
+
+
+def _nerd_font_update_reason(
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> str | None:
+    if latest_version and installed_tag and installed_tag != latest_version:
+        return f"installed {installed_tag} but latest is {latest_version}"
+    if not latest_version and cached_tag and installed_tag and installed_tag != cached_tag:
+        return f"installed {installed_tag} but cached archive is {cached_tag}"
+    return None
+
+
+def _nerd_font_summary_record(
+    context: dict[str, Any],
+    item: NerdFontItem,
+    paths: dict[str, Path],
+    state: str,
+    reason: str,
+    installed_tag: str | None,
+    latest_version: str | None,
+    cached_tag: str | None,
+) -> dict[str, Any]:
     return {
         "entry_id": item.entry_id,
         "label": item.label,
@@ -638,12 +628,21 @@ def _windows_host_plan(
     item: NerdFontItem,
     font_summary: dict[str, Any],
 ) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
-    operations: list[dict[str, Any]] = []
     powershell = context.get("powershell")
-    settings = context.get("windows_terminal_settings")
     state = "missing" if powershell else "manual"
     reason = "powershell.exe is available for Windows per-user font install" if powershell else "powershell.exe is not visible from WSL"
-    entry = {
+    operations = _windows_host_operations(home, context, item, font_summary)
+    return _windows_host_entry(home, context, item, state, reason), operations, {"host_action": _host_action(context), "requires_sudo": False}
+
+
+def _windows_host_entry(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    state: str,
+    reason: str,
+) -> dict[str, Any]:
+    return {
         "entry_id": WINDOWS_ENTRY_ID,
         "source": str(_nerd_paths(home, item)["install_dir"]),
         "source_type": "windows_host",
@@ -658,33 +657,49 @@ def _windows_host_plan(
         "terminal_impact": _terminal_impact("wsl"),
         "host_action": _host_action(context),
     }
-    if powershell:
-        source_dir = _nerd_paths(home, item)["install_dir"] if font_summary["state"] == "installed" else _nerd_paths(home, item)["extract_dir"]
-        operations.append({
-            "entry_id": WINDOWS_ENTRY_ID,
-            "type": "font_install_windows",
-            "source": str(source_dir),
-            "target": "Windows per-user font store",
-            "terminal_face": item.terminal_face,
-            "reason": "install JetBrainsMono Nerd Font Mono into the Windows user font store through PowerShell",
-            "requires_approval": True,
-            "recipe": "fonts",
-        })
-        if settings:
-            operations.append({
-                "entry_id": WINDOWS_ENTRY_ID,
-                "type": "font_update_windows_terminal",
-                "source": item.terminal_face,
-                "target": settings,
-                "reason": "set Windows Terminal profile defaults font.face",
-                "requires_approval": True,
-                "recipe": "fonts",
-            })
-        else:
-            operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Set Windows Terminal font face to {item.terminal_face} manually."))
+
+
+def _windows_host_operations(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    font_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if not context.get("powershell"):
+        return [_manual_op(WINDOWS_ENTRY_ID, f"Install {item.terminal_face} on the Windows host manually.")]
+    operations = [_windows_font_install_operation(home, item, font_summary)]
+    settings = context.get("windows_terminal_settings")
+    if settings:
+        operations.append(_windows_terminal_update_operation(item, settings))
     else:
-        operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Install {item.terminal_face} on the Windows host manually."))
-    return entry, operations, {"host_action": _host_action(context), "requires_sudo": False}
+        operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Set Windows Terminal font face to {item.terminal_face} manually."))
+    return operations
+
+
+def _windows_font_install_operation(home: Path, item: NerdFontItem, font_summary: dict[str, Any]) -> dict[str, Any]:
+    source_dir = _nerd_paths(home, item)["install_dir"] if font_summary["state"] == "installed" else _nerd_paths(home, item)["extract_dir"]
+    return {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "type": "font_install_windows",
+        "source": str(source_dir),
+        "target": "Windows per-user font store",
+        "terminal_face": item.terminal_face,
+        "reason": "install JetBrainsMono Nerd Font Mono into the Windows user font store through PowerShell",
+        "requires_approval": True,
+        "recipe": "fonts",
+    }
+
+
+def _windows_terminal_update_operation(item: NerdFontItem, settings: str) -> dict[str, Any]:
+    return {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "type": "font_update_windows_terminal",
+        "source": item.terminal_face,
+        "target": settings,
+        "reason": "set Windows Terminal profile defaults font.face",
+        "requires_approval": True,
+        "recipe": "fonts",
+    }
 
 
 def _pixel_ttyd_plan(home: Path, context: dict[str, Any], font_summary: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
@@ -943,14 +958,22 @@ def _execute_rebuild_cache(op: dict[str, Any], runner: CommandRunner) -> int:
 
 def _execute_verify_linux(op: dict[str, Any], runner: CommandRunner) -> int:
     terminal_face = str(op.get("terminal_face") or "")
-    if "Propo" in terminal_face or "Mono" not in terminal_face:
-        raise FontError(f"refusing terminal font face that is not Mono-safe: {terminal_face}")
+    _validate_mono_face(terminal_face)
     fc_match = runner.which("fc-match")
     if not fc_match:
         op["result"] = "fc-match not found; verify manually"
         return 0
     result = runner.run([fc_match, terminal_face], capture_output=True)
-    stdout = result.stdout or ""
+    _validate_fc_match_output(op, terminal_face, result.stdout or "")
+    return 0
+
+
+def _validate_mono_face(terminal_face: str) -> None:
+    if "Propo" in terminal_face or "Mono" not in terminal_face:
+        raise FontError(f"refusing terminal font face that is not Mono-safe: {terminal_face}")
+
+
+def _validate_fc_match_output(op: dict[str, Any], terminal_face: str, stdout: str) -> None:
     if "Propo" in stdout:
         raise FontError(f"fontconfig resolved {terminal_face} to a Propo face: {stdout.strip()}")
     if "Mono" not in stdout:
@@ -958,7 +981,6 @@ def _execute_verify_linux(op: dict[str, Any], runner: CommandRunner) -> int:
     family = str(op.get("family") or terminal_face.split()[0])
     if _normalize(family) not in _normalize(stdout):
         raise FontError(f"fontconfig did not resolve {terminal_face}: {stdout.strip()}")
-    return 0
 
 
 def _normalize(text: str) -> str:
@@ -1071,13 +1093,18 @@ def _regular_mono_font(source_dir: Path) -> Path:
     if exact.exists():
         return exact
     fonts = _installed_font_files(source_dir)
-    regular = [path for path in fonts if "Mono" in path.name and "Regular" in path.name]
-    if regular:
-        return regular[0]
-    mono = [path for path in fonts if "Mono" in path.name]
-    if mono:
-        return mono[0]
+    regular = _first_mono_font(fonts, require_regular=True)
+    mono = _first_mono_font(fonts, require_regular=False)
+    if regular or mono:
+        return regular or mono
     raise FontError(f"no JetBrainsMono Nerd Font Mono file found in {source_dir}")
+
+
+def _first_mono_font(fonts: list[Path], *, require_regular: bool) -> Path | None:
+    for path in fonts:
+        if "Mono" in path.name and (not require_regular or "Regular" in path.name):
+            return path
+    return None
 
 
 def _ttyd_html(font_path: Path) -> str:

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -138,8 +138,8 @@ class CommandRunner:
     def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
         env = dict(self.env)
         env["PATH"] = self.path
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use
-        return subprocess.run(  # nosec B603
+        # codacy-disable-next-line
+        return subprocess.run(  # nosec B603  # nosemgrep
             args,
             check=check,
             capture_output=capture_output,

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-import platform
 import shutil
 import zipfile
 from typing import Any, Mapping
 
-from .backups import create_backup
-from .font_assets import pixel_avf_prompt_text, ttyd_html, ttyd_service, windows_font_install_script
+from .font_context import (
+    apt_items_for_platform as _apt_items_for_platform,
+    detect_context as _detect_context,
+    host_action as _host_action,
+    nerd_items_for_platform as _nerd_items_for_platform,
+    terminal_impact as _terminal_impact,
+)
+from .font_assets import pixel_avf_prompt_text, ttyd_html, ttyd_service
 from .font_catalog import (
     APT_FONT_CATALOG,
     EXPECTED_TTF,
@@ -30,13 +35,16 @@ from .font_catalog import (
     NerdFontItem,
     PIXEL_AVF_ENTRY_ID,
     PIXEL_AVF_PROMPT_REL,
-    PIXEL_TTYD_ENTRY_ID,
     PIXEL_TTYD_FONT_ALIAS,
-    WINDOWS_ENTRY_ID,
-    WINDOWS_TERMINAL_PACKAGES,
     FontError,
 )
+from .font_pixel import pixel_ttyd_plan as _pixel_ttyd_plan
 from .font_runner import CommandRunner
+from .font_windows import (
+    execute_install_windows as _execute_install_windows,
+    execute_update_windows_terminal as _execute_update_windows_terminal,
+    windows_host_plan as _windows_host_plan,
+)
 
 __all__ = (
     "APT_FONT_CATALOG",
@@ -243,89 +251,6 @@ def _execute_systemd(op: dict[str, Any], runner: CommandRunner, *args: str) -> i
     return 1
 
 
-def _detect_context(home: Path, env: Mapping[str, str], path: str, runner: CommandRunner) -> dict[str, Any]:
-    return {
-        "platform": _platform_id(env),
-        "architecture": platform.machine().lower(),
-        "path": path,
-        "powershell": runner.which("powershell.exe"),
-        "wslpath": runner.which("wslpath"),
-        "windows_terminal_settings": _discover_windows_terminal_settings(home, env),
-    }
-
-
-def _platform_id(env: Mapping[str, str]) -> str:
-    override = (env.get("DOTFILES_PLATFORM") or "").strip().lower()
-    override_id = _platform_override(override)
-    if override_id:
-        return override_id
-    return _detected_platform(env)
-
-
-def _platform_override(override: str) -> str | None:
-    overrides = {
-        "linux": "linux",
-        "native-linux": "linux",
-        "ubuntu": "linux",
-        "pi": "pi",
-        "raspberry-pi": "pi",
-        "raspberrypi": "pi",
-        "wsl": "wsl",
-        "wsl-linux": "wsl",
-        "wsl2": "wsl",
-        "pixel-terminal": "pixel-terminal",
-        "pixel_ttyd": "pixel-terminal",
-        "ttyd": "pixel-terminal",
-        "pixel-avf": "pixel-avf",
-        "avf": "pixel-avf",
-    }
-    return overrides.get(override)
-
-
-def _detected_platform(env: Mapping[str, str]) -> str:
-    if _is_wsl(env):
-        return "wsl"
-    if _is_raspberry_pi():
-        return "pi"
-    if Path("/etc/ttyd").exists() or Path("/etc/systemd/system/ttyd.service").exists():
-        return "pixel-terminal"
-    return "linux" if platform.system().lower() == "linux" else "unsupported"
-
-
-def _is_wsl(env: Mapping[str, str]) -> bool:
-    if env.get("WSL_DISTRO_NAME") or env.get("WSL_INTEROP"):
-        return True
-    try:
-        return "microsoft" in Path("/proc/version").read_text(errors="ignore").lower()
-    except OSError:
-        return False
-
-
-def _is_raspberry_pi() -> bool:
-    try:
-        return "raspberry pi" in Path("/proc/device-tree/model").read_text(errors="ignore").lower()
-    except OSError:
-        return False
-
-
-def _discover_windows_terminal_settings(home: Path, env: Mapping[str, str]) -> str | None:
-    explicit = env.get("DOTFILES_WINDOWS_TERMINAL_SETTINGS")
-    if explicit:
-        path = Path(explicit)
-        return str(path) if path.exists() else None
-    users_root = Path("/mnt/c/Users")
-    if not users_root.exists():
-        return None
-    candidates: list[Path] = []
-    for user_dir in users_root.glob("*"):
-        for package in WINDOWS_TERMINAL_PACKAGES:
-            candidates.append(user_dir / "AppData/Local/Packages" / package / "LocalState/settings.json")
-    for candidate in candidates:
-        if candidate.exists():
-            return str(candidate)
-    return None
-
-
 def _release_metadata(home: Path, env: Mapping[str, str], runner: CommandRunner, *, fetch: bool) -> dict[str, Any]:
     cache_path = home / FONT_CACHE_REL / "nerd-fonts.latest.json"
     if _truthy(env.get("DOTFILES_FONT_OFFLINE")):
@@ -346,28 +271,6 @@ def _release_metadata(home: Path, env: Mapping[str, str], runner: CommandRunner,
 
 def _truthy(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _nerd_items_for_platform(platform_id: str) -> tuple[NerdFontItem, ...]:
-    if platform_id == "pixel-terminal":
-        return (NERD_FONT_CATALOG[0],)
-    if platform_id in {"linux", "wsl", "pi"}:
-        return NERD_FONT_CATALOG
-    return ()
-
-
-def _apt_items_for_platform(platform_id: str) -> tuple[dict[str, str], ...]:
-    if platform_id in {"linux", "wsl"}:
-        return APT_FONT_CATALOG
-    if platform_id == "pi":
-        return tuple(item for item in APT_FONT_CATALOG if item["package"] != "fonts-dejavu-core")
-    if platform_id == "pixel-terminal":
-        return tuple(item for item in APT_FONT_CATALOG if item["package"] == "fonts-noto-color-emoji")
-    return ()
-
-
-def _paths(home: Path) -> dict[str, Path]:
-    return _nerd_paths(home, NERD_FONT_CATALOG[0])
 
 
 def _nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
@@ -547,33 +450,6 @@ def _font_entry(summary: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _terminal_impact(platform_id: str) -> str:
-    if platform_id == "wsl":
-        return "Linux terminals get Nerd Font Mono faces; Windows Terminal is updated when its settings file is discoverable."
-    if platform_id == "pixel-terminal":
-        return "Pixel Terminal ttyd pages use an embedded JetBrainsMono Nerd Font Mono subset."
-    if platform_id == "pi":
-        return "Local Linux terminal apps can select Nerd Font Mono faces; emoji/symbol fallbacks are installed with apt."
-    if platform_id == "pixel-avf":
-        return "Pixel AVF weston-terminal ignores Nerd Font configuration; a plain prompt fallback is used."
-    return "Local Linux terminal apps can select Nerd Font Mono faces after install."
-
-
-def _host_action(context: dict[str, Any]) -> str:
-    platform_id = context["platform"]
-    if platform_id == "wsl":
-        if context.get("powershell") and context.get("windows_terminal_settings"):
-            return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows and Windows Terminal defaults are updated."
-        if context.get("powershell"):
-            return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows; set Windows Terminal manually if no settings file is found."
-        return "Manual Windows host font install required because powershell.exe was not found."
-    if platform_id == "pixel-terminal":
-        return "sudo writes /etc/ttyd/index.html and ttyd.service, then restarts ttyd.service."
-    if platform_id == "pixel-avf":
-        return "No host font action; weston-terminal ignores Nerd Font UI configuration."
-    return "No host-side action."
-
-
 def _nerd_font_operations(home: Path, item: NerdFontItem, *, reason: str) -> list[dict[str, Any]]:
     paths = _nerd_paths(home, item)
     base = {
@@ -639,137 +515,6 @@ def _apt_package_operation(summary: dict[str, Any]) -> dict[str, Any]:
         "requires_sudo": True,
         "recipe": "fonts",
     }
-
-
-def _windows_host_plan(
-    home: Path,
-    context: dict[str, Any],
-    item: NerdFontItem,
-    font_summary: dict[str, Any],
-) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
-    powershell = context.get("powershell")
-    state = "missing" if powershell else "manual"
-    reason = "powershell.exe is available for Windows per-user font install" if powershell else "powershell.exe is not visible from WSL"
-    operations = _windows_host_operations(home, context, item, font_summary)
-    return _windows_host_entry(home, context, item, state, reason), operations, {"host_action": _host_action(context), "requires_sudo": False}
-
-
-def _windows_host_entry(
-    home: Path,
-    context: dict[str, Any],
-    item: NerdFontItem,
-    state: str,
-    reason: str,
-) -> dict[str, Any]:
-    return {
-        "entry_id": WINDOWS_ENTRY_ID,
-        "source": str(_nerd_paths(home, item)["install_dir"]),
-        "source_type": "windows_host",
-        "family": item.family,
-        "target": "Windows per-user font store",
-        "state": state,
-        "protected": False,
-        "reason": reason,
-        "recipe": "fonts",
-        "requires_sudo": False,
-        "terminal_face": item.terminal_face,
-        "terminal_impact": _terminal_impact("wsl"),
-        "host_action": _host_action(context),
-    }
-
-
-def _windows_host_operations(
-    home: Path,
-    context: dict[str, Any],
-    item: NerdFontItem,
-    font_summary: dict[str, Any],
-) -> list[dict[str, Any]]:
-    if not context.get("powershell"):
-        return [_manual_op(WINDOWS_ENTRY_ID, f"Install {item.terminal_face} on the Windows host manually.")]
-    operations = [_windows_font_install_operation(home, item, font_summary)]
-    settings = context.get("windows_terminal_settings")
-    if settings:
-        operations.append(_windows_terminal_update_operation(item, settings))
-    else:
-        operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Set Windows Terminal font face to {item.terminal_face} manually."))
-    return operations
-
-
-def _windows_font_install_operation(home: Path, item: NerdFontItem, font_summary: dict[str, Any]) -> dict[str, Any]:
-    source_dir = _nerd_paths(home, item)["install_dir"] if font_summary["state"] == "installed" else _nerd_paths(home, item)["extract_dir"]
-    return {
-        "entry_id": WINDOWS_ENTRY_ID,
-        "type": "font_install_windows",
-        "source": str(source_dir),
-        "target": "Windows per-user font store",
-        "terminal_face": item.terminal_face,
-        "reason": "install JetBrainsMono Nerd Font Mono into the Windows user font store through PowerShell",
-        "requires_approval": True,
-        "recipe": "fonts",
-    }
-
-
-def _windows_terminal_update_operation(item: NerdFontItem, settings: str) -> dict[str, Any]:
-    return {
-        "entry_id": WINDOWS_ENTRY_ID,
-        "type": "font_update_windows_terminal",
-        "source": item.terminal_face,
-        "target": settings,
-        "reason": "set Windows Terminal profile defaults font.face",
-        "requires_approval": True,
-        "recipe": "fonts",
-    }
-
-
-def _pixel_ttyd_plan(home: Path, context: dict[str, Any], font_summary: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
-    paths = _paths(home)
-    entry = {
-        "entry_id": PIXEL_TTYD_ENTRY_ID,
-        "source": str(paths["install_dir"]),
-        "source_type": "pixel_ttyd",
-        "family": "JetBrainsMono",
-        "target": "/etc/ttyd/index.html",
-        "state": "missing",
-        "protected": False,
-        "reason": "Pixel Terminal ttyd font embedding is managed as a system recipe",
-        "recipe": "fonts",
-        "requires_sudo": True,
-        "terminal_face": font_summary["terminal_face"],
-        "terminal_impact": _terminal_impact("pixel-terminal"),
-        "host_action": _host_action(context),
-    }
-    base = {"entry_id": PIXEL_TTYD_ENTRY_ID, "requires_approval": True, "requires_sudo": True, "recipe": "fonts"}
-    operations = [
-        {
-            **base,
-            "type": "font_ttyd_write_html",
-            "source": str(paths["install_dir"]),
-            "target": "/etc/ttyd/index.html",
-            "cache_dir": str(paths["cache_dir"]),
-            "reason": "backup and write ttyd HTML with embedded JetBrainsMono Nerd Font Mono subset",
-        },
-        {
-            **base,
-            "type": "font_ttyd_write_service",
-            "source": "generated ttyd.service",
-            "target": "/etc/systemd/system/ttyd.service",
-            "cache_dir": str(paths["cache_dir"]),
-            "reason": "backup and write ttyd systemd service using the custom index",
-        },
-        {
-            **base,
-            "type": "font_systemd_daemon_reload",
-            "target": "systemd",
-            "reason": "reload systemd after ttyd.service update",
-        },
-        {
-            **base,
-            "type": "font_systemd_restart",
-            "target": "ttyd.service",
-            "reason": "restart Pixel Terminal ttyd service",
-        },
-    ]
-    return entry, operations, {"host_action": _host_action(context), "terminal_impact": _terminal_impact("pixel-terminal")}
 
 
 def _build_pixel_avf_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
@@ -1017,53 +762,6 @@ def _execute_install_packages(op: dict[str, Any], runner: CommandRunner) -> int:
     prefix = [] if hasattr(os, "geteuid") and os.geteuid() == 0 else ["sudo"]
     runner.run([*prefix, apt_get, "update"])
     runner.run([*prefix, apt_get, "install", "-y", *packages])
-    return 1
-
-
-def _execute_install_windows(op: dict[str, Any], runner: CommandRunner) -> int:
-    powershell = runner.which("powershell.exe")
-    if not powershell:
-        op["result"] = "powershell.exe not found; install Windows host font manually"
-        return 0
-    source = Path(op["source"])
-    if not source.exists():
-        raise FontError(f"Windows font source directory is missing: {source}")
-    windows_source = str(source)
-    wslpath = runner.which("wslpath")
-    if wslpath:
-        converted = runner.run([wslpath, "-w", str(source)], capture_output=True)
-        windows_source = converted.stdout.strip()
-    script = windows_font_install_script(windows_source)
-    runner.run([powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
-    return 1
-
-
-def _execute_update_windows_terminal(op: dict[str, Any], backup_dir: Path, backups: list[dict[str, Any]]) -> int:
-    target = Path(op["target"])
-    if not target.exists():
-        op["result"] = "Windows Terminal settings file was not found; set font face manually"
-        return 0
-    record = create_backup(target, backup_dir, entry_id=op["entry_id"])
-    backups.append(record)
-    try:
-        data = json.loads(target.read_text())
-    except json.JSONDecodeError as exc:
-        raise FontError(f"invalid Windows Terminal settings JSON: {target}") from exc
-    profiles = data.setdefault("profiles", {})
-    if not isinstance(profiles, dict):
-        profiles = {}
-        data["profiles"] = profiles
-    defaults = profiles.setdefault("defaults", {})
-    if not isinstance(defaults, dict):
-        defaults = {}
-        profiles["defaults"] = defaults
-    font = defaults.setdefault("font", {})
-    if not isinstance(font, dict):
-        font = {}
-        defaults["font"] = font
-    font["face"] = FONT_FACE
-    target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
-    op["backup_target"] = record["backup_target"]
     return 1
 
 

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import os
 from pathlib import Path
@@ -10,6 +9,7 @@ import zipfile
 from typing import Any, Mapping
 
 from .backups import create_backup
+from .font_assets import pixel_avf_prompt_text, ttyd_html, ttyd_service, windows_font_install_script
 from .font_catalog import (
     APT_FONT_CATALOG,
     EXPECTED_TTF,
@@ -37,6 +37,25 @@ from .font_catalog import (
     FontError,
 )
 from .font_runner import CommandRunner
+
+__all__ = (
+    "APT_FONT_CATALOG",
+    "CommandRunner",
+    "EXPECTED_TTF",
+    "FONT_ARCHIVE_NAME",
+    "FONT_ASSET_NAME",
+    "FONT_EXTRACTED_DIR",
+    "FONT_FACE",
+    "FONT_INSTALL_REL",
+    "FONT_LABEL",
+    "FONT_VERSION_NAME",
+    "FontError",
+    "NERD_FONT_CATALOG",
+    "NerdFontItem",
+    "build_font_plan",
+    "execute_font_operation",
+    "select_nerd_font_asset",
+)
 
 
 def select_nerd_font_asset(release: Mapping[str, Any], asset_name: str = FONT_ASSET_NAME) -> dict[str, Any]:
@@ -755,7 +774,7 @@ def _pixel_ttyd_plan(home: Path, context: dict[str, Any], font_summary: dict[str
 
 def _build_pixel_avf_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
     prompt_path = home / PIXEL_AVF_PROMPT_REL
-    desired = _pixel_avf_prompt_text()
+    desired = pixel_avf_prompt_text()
     prompt_state = "installed" if prompt_path.exists() and prompt_path.read_text(errors="ignore") == desired else "missing"
     fonts = [_unsupported_nerd_summary(home, context, item, "Pixel AVF weston-terminal ignores Nerd Font configuration") for item in NERD_FONT_CATALOG]
     entries = [_font_entry(summary) for summary in fonts]
@@ -1014,23 +1033,9 @@ def _execute_install_windows(op: dict[str, Any], runner: CommandRunner) -> int:
     if wslpath:
         converted = runner.run([wslpath, "-w", str(source)], capture_output=True)
         windows_source = converted.stdout.strip()
-    script = _windows_font_install_script(windows_source)
+    script = windows_font_install_script(windows_source)
     runner.run([powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
     return 1
-
-
-def _windows_font_install_script(source_dir: str) -> str:
-    escaped = source_dir.replace("'", "''")
-    return (
-        "$FontDir = Join-Path $env:LOCALAPPDATA 'Microsoft\\Windows\\Fonts'; "
-        "New-Item -ItemType Directory -Force -Path $FontDir | Out-Null; "
-        f"Get-ChildItem -Path '{escaped}' -File | Where-Object {{ $_.Extension -in '.ttf','.otf' }} | ForEach-Object {{ "
-        "$Dest = Join-Path $FontDir $_.Name; "
-        "Copy-Item $_.FullName $Dest -Force; "
-        "New-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' "
-        "-Name \"$($_.BaseName) (TrueType)\" -Value $_.Name -PropertyType String -Force | Out-Null "
-        "}"
-    )
 
 
 def _execute_update_windows_terminal(op: dict[str, Any], backup_dir: Path, backups: list[dict[str, Any]]) -> int:
@@ -1065,7 +1070,7 @@ def _execute_update_windows_terminal(op: dict[str, Any], backup_dir: Path, backu
 def _execute_ttyd_html(op: dict[str, Any], runner: CommandRunner, backups: list[dict[str, Any]]) -> int:
     source_dir = Path(op["source"])
     font = _regular_mono_font(source_dir)
-    html = _ttyd_html(font)
+    html = ttyd_html(font)
     generated = Path(op["cache_dir"]) / "ttyd-index.html"
     generated.parent.mkdir(parents=True, exist_ok=True)
     generated.write_text(html)
@@ -1076,7 +1081,7 @@ def _execute_ttyd_html(op: dict[str, Any], runner: CommandRunner, backups: list[
 def _execute_ttyd_service(op: dict[str, Any], runner: CommandRunner, backups: list[dict[str, Any]]) -> int:
     generated = Path(op["cache_dir"]) / "ttyd.service"
     generated.parent.mkdir(parents=True, exist_ok=True)
-    generated.write_text(_ttyd_service())
+    generated.write_text(ttyd_service())
     _sudo_backup_and_install(op["target"], generated, runner, backups, op["entry_id"])
     return 1
 
@@ -1107,61 +1112,8 @@ def _first_mono_font(fonts: list[Path], *, require_regular: bool) -> Path | None
     return None
 
 
-def _ttyd_html(font_path: Path) -> str:
-    encoded = base64.b64encode(font_path.read_bytes()).decode("ascii")
-    return f"""<!doctype html>
-<html>
-<head>
-<meta charset="utf-8">
-<style>
-@font-face {{
-  font-family: '{PIXEL_TTYD_FONT_ALIAS}';
-  src: url(data:font/truetype;charset=utf-8;base64,{encoded}) format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}}
-body, #terminal, .terminal, .xterm, .xterm-rows {{
-  font-family: '{PIXEL_TTYD_FONT_ALIAS}', 'Noto Color Emoji', monospace !important;
-}}
-</style>
-</head>
-<body>
-<div id="terminal"></div>
-</body>
-</html>
-"""
-
-
-def _ttyd_service() -> str:
-    return """[Unit]
-Description=ttyd terminal with dotfiles-managed font embedding
-After=network.target
-
-[Service]
-ExecStart=/usr/bin/ttyd --index /etc/ttyd/index.html -W /bin/bash
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-"""
-
-
 def _execute_pixel_avf_prompt(op: dict[str, Any]) -> int:
     target = Path(op["target"])
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(_pixel_avf_prompt_text())
+    target.write_text(pixel_avf_prompt_text())
     return 1
-
-
-def _pixel_avf_prompt_text() -> str:
-    return """# Managed by 000-dotfiles for Pixel AVF weston-terminal.
-# Uses a plain prompt without Nerd Font private-use glyphs.
-function fish_prompt
-    set -l code $status
-    set -l marker '>'
-    if test $code -ne 0
-        set marker '!'
-    end
-    printf '%s %s ' (prompt_pwd) $marker
-end
-"""

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -1,0 +1,1138 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess  # nosec B404
+import urllib.request
+import zipfile
+from typing import Any, Mapping
+
+from .backups import create_backup
+
+
+NERD_FONTS_RELEASE_URL = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
+NERD_FONTS_REPO = "ryanoasis/nerd-fonts"
+FONT_CACHE_REL = Path(".cache/000-dotfiles/fonts")
+FONT_INSTALL_BASE_REL = Path(".local/share/fonts")
+FONT_MARKER_NAME = ".000-dotfiles-font-source.json"
+WINDOWS_TERMINAL_PACKAGES = (
+    "Microsoft.WindowsTerminal_8wekyb3d8bbwe",
+    "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe",
+)
+
+FONT_ASSET_NAME = "JetBrainsMono.zip"
+FONT_FACE = "JetBrainsMono Nerd Font Mono"
+FONT_LABEL = "JetBrainsMono Nerd Font"
+FONT_ENTRY_ID = "fonts.jetbrains-mono-nerd"
+FONT_INSTALL_REL = FONT_INSTALL_BASE_REL / "JetBrainsMonoNerdFont"
+FONT_EXTRACTED_DIR = "JetBrainsMono"
+FONT_ARCHIVE_NAME = FONT_ASSET_NAME
+FONT_VERSION_NAME = "JetBrainsMono.version.json"
+EXPECTED_TTF = "JetBrainsMonoNerdFontMono-Regular.ttf"
+WINDOWS_ENTRY_ID = "fonts.windows-host"
+PIXEL_TTYD_ENTRY_ID = "fonts.pixel-ttyd"
+PIXEL_AVF_ENTRY_ID = "fonts.pixel-avf-prompt"
+PIXEL_TTYD_FONT_ALIAS = "JBMono NF"
+PIXEL_AVF_PROMPT_REL = Path(".config/fish/conf.d/000-dotfiles-pixel-avf-prompt.fish")
+
+
+@dataclass(frozen=True)
+class NerdFontItem:
+    entry_id: str
+    label: str
+    family: str
+    asset_name: str
+    install_dir_name: str
+    terminal_face: str
+    expected_regular: str
+
+    @property
+    def cache_stem(self) -> str:
+        return Path(self.asset_name).stem
+
+
+NERD_FONT_CATALOG: tuple[NerdFontItem, ...] = (
+    NerdFontItem(
+        FONT_ENTRY_ID,
+        FONT_LABEL,
+        "JetBrainsMono",
+        FONT_ASSET_NAME,
+        "JetBrainsMonoNerdFont",
+        FONT_FACE,
+        EXPECTED_TTF,
+    ),
+    NerdFontItem(
+        "fonts.fira-code-nerd",
+        "FiraCode Nerd Font",
+        "FiraCode",
+        "FiraCode.zip",
+        "FiraCodeNerdFont",
+        "FiraCode Nerd Font Mono",
+        "FiraCodeNerdFontMono-Regular.ttf",
+    ),
+    NerdFontItem(
+        "fonts.hack-nerd",
+        "Hack Nerd Font",
+        "Hack",
+        "Hack.zip",
+        "HackNerdFont",
+        "Hack Nerd Font Mono",
+        "HackNerdFontMono-Regular.ttf",
+    ),
+    NerdFontItem(
+        "fonts.meslo-nerd",
+        "MesloLGS Nerd Font",
+        "MesloLGS",
+        "Meslo.zip",
+        "MesloNerdFont",
+        "MesloLGS Nerd Font Mono",
+        "MesloLGSNerdFontMono-Regular.ttf",
+    ),
+)
+
+APT_FONT_CATALOG: tuple[dict[str, str], ...] = (
+    {
+        "entry_id": "fonts.apt.noto-color-emoji",
+        "family": "Noto Color Emoji",
+        "package": "fonts-noto-color-emoji",
+        "terminal_face": "Noto Color Emoji",
+    },
+    {
+        "entry_id": "fonts.apt.symbola",
+        "family": "Symbola",
+        "package": "fonts-symbola",
+        "terminal_face": "Symbola",
+    },
+    {
+        "entry_id": "fonts.apt.freefont",
+        "family": "GNU FreeFont",
+        "package": "fonts-freefont-ttf",
+        "terminal_face": "FreeMono",
+    },
+    {
+        "entry_id": "fonts.apt.dejavu-core",
+        "family": "DejaVu Core",
+        "package": "fonts-dejavu-core",
+        "terminal_face": "DejaVu Sans Mono",
+    },
+)
+
+
+class FontError(RuntimeError):
+    """Raised when a font recipe cannot complete."""
+
+
+class CommandRunner:
+    def __init__(self, *, env: Mapping[str, str] | None = None, path: str | None = None) -> None:
+        self.env = dict(os.environ if env is None else env)
+        self.path = path if path is not None else self.env.get("PATH", "")
+
+    def which(self, command: str) -> str | None:
+        return shutil.which(command, path=self.path)
+
+    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+        env = dict(self.env)
+        env["PATH"] = self.path
+        return subprocess.run(  # nosec B603
+            args,
+            check=check,
+            capture_output=capture_output,
+            text=True,
+            env=env,
+        )
+
+    def fetch_json(self, url: str) -> dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            headers={"Accept": "application/vnd.github+json", "User-Agent": "000-dotfiles-bootstrap"},
+        )
+        with urllib.request.urlopen(request, timeout=20) as response:  # nosec B310
+            return json.loads(response.read().decode("utf-8"))
+
+    def download(self, url: str, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        request = urllib.request.Request(url, headers={"User-Agent": "000-dotfiles-bootstrap"})
+        with urllib.request.urlopen(request, timeout=60) as response:  # nosec B310
+            tmp.write_bytes(response.read())
+        tmp.replace(target)
+
+
+def select_nerd_font_asset(release: Mapping[str, Any], asset_name: str = FONT_ASSET_NAME) -> dict[str, Any]:
+    for asset in release.get("assets") or []:
+        if asset.get("name") == asset_name and asset.get("browser_download_url"):
+            return {
+                "name": asset["name"],
+                "browser_download_url": asset["browser_download_url"],
+                "size": asset.get("size"),
+                "tag_name": release.get("tag_name") or release.get("name") or "latest",
+            }
+    raise FontError(f"{asset_name} not found in latest {NERD_FONTS_REPO} release")
+
+
+def build_font_plan(
+    home: Path | str,
+    *,
+    env: Mapping[str, str] | None = None,
+    path: str | None = None,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    home_path = Path(home).expanduser().resolve()
+    effective_env = dict(os.environ if env is None else env)
+    effective_path = path if path is not None else effective_env.get("PATH", "")
+    runner_was_provided = runner is not None
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_path)
+    context = _detect_context(home_path, effective_env, effective_path, effective_runner)
+
+    if context["platform"] == "unsupported":
+        return _build_unsupported_plan(home_path, context)
+    if context["platform"] == "pixel-avf":
+        return _build_pixel_avf_plan(home_path, context)
+
+    release = _release_metadata(home_path, effective_env, effective_runner, fetch=runner_was_provided)
+    entries: list[dict[str, Any]] = []
+    operations: list[dict[str, Any]] = []
+    fonts: list[dict[str, Any]] = []
+
+    for item in _nerd_items_for_platform(context["platform"]):
+        summary = _nerd_font_summary(home_path, context, item, release)
+        entries.append(_font_entry(summary))
+        fonts.append(summary)
+        if summary["state"] in {"missing", "needs_update"}:
+            operations.extend(_nerd_font_operations(home_path, item, reason=summary["reason"]))
+
+    for item in _apt_items_for_platform(context["platform"]):
+        summary = _apt_font_summary(context, item, effective_runner)
+        entries.append(_font_entry(summary))
+        fonts.append(summary)
+        if summary["state"] in {"missing", "needs_update"}:
+            operations.append(_apt_package_operation(summary))
+
+    if context["platform"] == "wsl":
+        jetbrains = next(item for item in NERD_FONT_CATALOG if item.entry_id == FONT_ENTRY_ID)
+        jetbrains_summary = next(item for item in fonts if item["entry_id"] == FONT_ENTRY_ID)
+        windows_entry, windows_ops, windows_summary = _windows_host_plan(home_path, context, jetbrains, jetbrains_summary)
+        entries.append(windows_entry)
+        operations.extend(windows_ops)
+        jetbrains_summary["host_action"] = windows_summary["host_action"]
+
+    if context["platform"] == "pixel-terminal":
+        jetbrains_summary = next(item for item in fonts if item["entry_id"] == FONT_ENTRY_ID)
+        pixel_entry, pixel_ops, pixel_summary = _pixel_ttyd_plan(home_path, context, jetbrains_summary)
+        entries.append(pixel_entry)
+        operations.extend(pixel_ops)
+        jetbrains_summary["host_action"] = pixel_summary["host_action"]
+        jetbrains_summary["requires_sudo"] = True
+        jetbrains_summary["terminal_impact"] = pixel_summary["terminal_impact"]
+        jetbrains_summary["embedded_alias"] = PIXEL_TTYD_FONT_ALIAS
+
+    return {"entries": entries, "operations": operations, "fonts": fonts, "context": context}
+
+
+def execute_font_operation(
+    op: dict[str, Any],
+    *,
+    runner: CommandRunner | None = None,
+    backup_dir: Path | None = None,
+    backups: list[dict[str, Any]] | None = None,
+) -> int:
+    effective_runner = runner or CommandRunner()
+    backup_path = backup_dir or Path.home() / ".dotfiles-backups"
+    backup_records = backups if backups is not None else []
+    op_type = op["type"]
+    if op_type in {"font_skip", "font_manual"}:
+        return 0
+    if op_type == "font_download":
+        return _execute_download(op, effective_runner)
+    if op_type == "font_extract":
+        return _execute_extract(op)
+    if op_type == "font_install_linux":
+        return _execute_install_linux(op)
+    if op_type == "font_rebuild_cache":
+        return _execute_rebuild_cache(op, effective_runner)
+    if op_type == "font_verify_linux":
+        return _execute_verify_linux(op, effective_runner)
+    if op_type == "font_install_packages":
+        return _execute_install_packages(op, effective_runner)
+    if op_type == "font_install_windows":
+        return _execute_install_windows(op, effective_runner)
+    if op_type == "font_update_windows_terminal":
+        return _execute_update_windows_terminal(op, backup_path, backup_records)
+    if op_type == "font_ttyd_write_html":
+        return _execute_ttyd_html(op, effective_runner, backup_records)
+    if op_type == "font_ttyd_write_service":
+        return _execute_ttyd_service(op, effective_runner, backup_records)
+    if op_type == "font_systemd_daemon_reload":
+        effective_runner.run(["sudo", "systemctl", "daemon-reload"])
+        return 1
+    if op_type == "font_systemd_restart":
+        effective_runner.run(["sudo", "systemctl", "restart", "ttyd.service"])
+        return 1
+    if op_type == "font_pixel_avf_prompt":
+        return _execute_pixel_avf_prompt(op)
+    raise FontError(f"unknown font operation: {op_type}")
+
+
+def _detect_context(home: Path, env: Mapping[str, str], path: str, runner: CommandRunner) -> dict[str, Any]:
+    override = (env.get("DOTFILES_PLATFORM") or "").strip().lower()
+    if override in {"linux", "native-linux", "ubuntu"}:
+        platform_id = "linux"
+    elif override in {"pi", "raspberry-pi", "raspberrypi"}:
+        platform_id = "pi"
+    elif override in {"wsl", "wsl-linux", "wsl2"}:
+        platform_id = "wsl"
+    elif override in {"pixel-terminal", "pixel_ttyd", "ttyd"}:
+        platform_id = "pixel-terminal"
+    elif override in {"pixel-avf", "avf"}:
+        platform_id = "pixel-avf"
+    elif _is_wsl(env):
+        platform_id = "wsl"
+    elif _is_raspberry_pi():
+        platform_id = "pi"
+    elif Path("/etc/ttyd").exists() or Path("/etc/systemd/system/ttyd.service").exists():
+        platform_id = "pixel-terminal"
+    else:
+        platform_id = "linux" if platform.system().lower() == "linux" else "unsupported"
+
+    return {
+        "platform": platform_id,
+        "architecture": platform.machine().lower(),
+        "path": path,
+        "powershell": runner.which("powershell.exe"),
+        "wslpath": runner.which("wslpath"),
+        "windows_terminal_settings": _discover_windows_terminal_settings(home, env),
+    }
+
+
+def _is_wsl(env: Mapping[str, str]) -> bool:
+    if env.get("WSL_DISTRO_NAME") or env.get("WSL_INTEROP"):
+        return True
+    try:
+        return "microsoft" in Path("/proc/version").read_text(errors="ignore").lower()
+    except OSError:
+        return False
+
+
+def _is_raspberry_pi() -> bool:
+    try:
+        return "raspberry pi" in Path("/proc/device-tree/model").read_text(errors="ignore").lower()
+    except OSError:
+        return False
+
+
+def _discover_windows_terminal_settings(home: Path, env: Mapping[str, str]) -> str | None:
+    explicit = env.get("DOTFILES_WINDOWS_TERMINAL_SETTINGS")
+    if explicit:
+        path = Path(explicit)
+        return str(path) if path.exists() else None
+    users_root = Path("/mnt/c/Users")
+    if not users_root.exists():
+        return None
+    candidates: list[Path] = []
+    for user_dir in users_root.glob("*"):
+        for package in WINDOWS_TERMINAL_PACKAGES:
+            candidates.append(user_dir / "AppData/Local/Packages" / package / "LocalState/settings.json")
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def _release_metadata(home: Path, env: Mapping[str, str], runner: CommandRunner, *, fetch: bool) -> dict[str, Any]:
+    cache_path = home / FONT_CACHE_REL / "nerd-fonts.latest.json"
+    if _truthy(env.get("DOTFILES_FONT_OFFLINE")):
+        return _read_version(cache_path)
+    if fetch or _truthy(env.get("DOTFILES_FONT_CHECK_LATEST")):
+        try:
+            release = runner.fetch_json(NERD_FONTS_RELEASE_URL)
+        except Exception as exc:
+            cached = _read_version(cache_path)
+            if cached:
+                cached["lookup_error"] = str(exc)
+            return cached
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(release, indent=2, sort_keys=True) + "\n")
+        return release
+    return _read_version(cache_path)
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _nerd_items_for_platform(platform_id: str) -> tuple[NerdFontItem, ...]:
+    if platform_id == "pixel-terminal":
+        return (NERD_FONT_CATALOG[0],)
+    if platform_id in {"linux", "wsl", "pi"}:
+        return NERD_FONT_CATALOG
+    return ()
+
+
+def _apt_items_for_platform(platform_id: str) -> tuple[dict[str, str], ...]:
+    if platform_id in {"linux", "wsl"}:
+        return APT_FONT_CATALOG
+    if platform_id == "pi":
+        return tuple(item for item in APT_FONT_CATALOG if item["package"] != "fonts-dejavu-core")
+    if platform_id == "pixel-terminal":
+        return tuple(item for item in APT_FONT_CATALOG if item["package"] == "fonts-noto-color-emoji")
+    return ()
+
+
+def _paths(home: Path) -> dict[str, Path]:
+    return _nerd_paths(home, NERD_FONT_CATALOG[0])
+
+
+def _nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
+    cache_dir = home / FONT_CACHE_REL
+    return {
+        "cache_dir": cache_dir,
+        "archive": cache_dir / item.asset_name,
+        "version": cache_dir / f"{item.cache_stem}.version.json",
+        "extract_dir": cache_dir / item.cache_stem,
+        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
+    }
+
+
+def _nerd_font_summary(home: Path, context: dict[str, Any], item: NerdFontItem, release: Mapping[str, Any]) -> dict[str, Any]:
+    paths = _nerd_paths(home, item)
+    installed_files = _installed_font_files(paths["install_dir"])
+    installed_version = _read_version(paths["install_dir"] / FONT_MARKER_NAME)
+    cached_version = _read_version(paths["version"])
+    latest_version = _release_tag_for_asset(release, item.asset_name) or cached_version.get("tag_name")
+    installed_tag = installed_version.get("tag_name") if installed_version else None
+    cached_tag = cached_version.get("tag_name") if cached_version else None
+    if not installed_files:
+        state = "missing"
+        reason = f"{item.label} is not installed in the user font directory"
+    elif latest_version and installed_tag and installed_tag != latest_version:
+        state = "needs_update"
+        reason = f"installed {installed_tag} but latest is {latest_version}"
+    elif not latest_version and cached_tag and installed_tag and installed_tag != cached_tag:
+        state = "needs_update"
+        reason = f"installed {installed_tag} but cached archive is {cached_tag}"
+    else:
+        state = "installed"
+        reason = f"user-local {item.label} files are present"
+
+    return {
+        "entry_id": item.entry_id,
+        "label": item.label,
+        "family": item.family,
+        "source_type": "nerd_font_release",
+        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
+        "asset_name": item.asset_name,
+        "state": state,
+        "installed_version": installed_tag,
+        "latest_version": latest_version,
+        "cached_version": cached_tag,
+        "candidate_version": None,
+        "target": str(paths["install_dir"]),
+        "cache_path": str(paths["archive"]),
+        "terminal_face": item.terminal_face,
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": _terminal_impact(context["platform"]),
+        "host_action": _host_action(context),
+        "reason": reason,
+    }
+
+
+def _release_tag_for_asset(release: Mapping[str, Any], asset_name: str) -> str | None:
+    if not release:
+        return None
+    try:
+        select_nerd_font_asset(release, asset_name)
+    except FontError:
+        return None
+    tag = release.get("tag_name") or release.get("name")
+    return str(tag) if tag else None
+
+
+def _apt_font_summary(context: dict[str, Any], item: dict[str, str], runner: CommandRunner) -> dict[str, Any]:
+    installed_version, installed_reason = _apt_installed_version(item["package"], runner)
+    candidate_version, candidate_reason = _apt_candidate_version(item["package"], runner)
+    if installed_reason or candidate_reason:
+        state = "manual"
+        reason = installed_reason or candidate_reason or "apt metadata unavailable"
+    elif not installed_version:
+        state = "missing"
+        reason = f"{item['package']} is not installed"
+    elif candidate_version and installed_version != candidate_version:
+        state = "needs_update"
+        reason = f"installed {installed_version} but apt candidate is {candidate_version}"
+    else:
+        state = "installed"
+        reason = f"{item['package']} is installed"
+
+    return {
+        "entry_id": item["entry_id"],
+        "label": item["family"],
+        "family": item["family"],
+        "source_type": "apt_package",
+        "source": "apt",
+        "package": item["package"],
+        "state": state,
+        "installed_version": installed_version,
+        "latest_version": None,
+        "candidate_version": candidate_version,
+        "target": item["package"],
+        "cache_path": None,
+        "terminal_face": item["terminal_face"],
+        "platform": context["platform"],
+        "requires_sudo": state in {"missing", "needs_update"},
+        "terminal_impact": _terminal_impact(context["platform"]),
+        "host_action": _host_action(context),
+        "reason": reason,
+    }
+
+
+def _apt_installed_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
+    dpkg_query = runner.which("dpkg-query")
+    if not dpkg_query:
+        return None, "dpkg-query not found; apt package state must be checked manually"
+    result = runner.run([dpkg_query, "-W", "-f=${Version}", package], capture_output=True, check=False)
+    if result.returncode != 0:
+        return None, None
+    version = (result.stdout or "").strip()
+    return version or None, None
+
+
+def _apt_candidate_version(package: str, runner: CommandRunner) -> tuple[str | None, str | None]:
+    apt_cache = runner.which("apt-cache")
+    if not apt_cache:
+        return None, "apt-cache not found; apt candidate state must be checked manually"
+    result = runner.run([apt_cache, "policy", package], capture_output=True, check=False)
+    if result.returncode != 0:
+        return None, f"apt-cache policy failed for {package}"
+    for line in (result.stdout or "").splitlines():
+        text = line.strip()
+        if text.startswith("Candidate:"):
+            candidate = text.split(":", 1)[1].strip()
+            return None if candidate == "(none)" else candidate, None
+    return None, None
+
+
+def _font_entry(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "entry_id": summary["entry_id"],
+        "source": summary["source"],
+        "source_type": summary["source_type"],
+        "family": summary["family"],
+        "target": summary["target"],
+        "state": summary["state"],
+        "protected": False,
+        "reason": summary["reason"],
+        "recipe": "fonts",
+        "cache_path": summary.get("cache_path"),
+        "terminal_face": summary.get("terminal_face"),
+        "requires_sudo": summary["requires_sudo"],
+        "terminal_impact": summary["terminal_impact"],
+        "host_action": summary["host_action"],
+    }
+
+
+def _terminal_impact(platform_id: str) -> str:
+    if platform_id == "wsl":
+        return "Linux terminals get Nerd Font Mono faces; Windows Terminal is updated when its settings file is discoverable."
+    if platform_id == "pixel-terminal":
+        return "Pixel Terminal ttyd pages use an embedded JetBrainsMono Nerd Font Mono subset."
+    if platform_id == "pi":
+        return "Local Linux terminal apps can select Nerd Font Mono faces; emoji/symbol fallbacks are installed with apt."
+    if platform_id == "pixel-avf":
+        return "Pixel AVF weston-terminal ignores Nerd Font configuration; a plain prompt fallback is used."
+    return "Local Linux terminal apps can select Nerd Font Mono faces after install."
+
+
+def _host_action(context: dict[str, Any]) -> str:
+    platform_id = context["platform"]
+    if platform_id == "wsl":
+        if context.get("powershell") and context.get("windows_terminal_settings"):
+            return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows and Windows Terminal defaults are updated."
+        if context.get("powershell"):
+            return "PowerShell installs JetBrainsMono Nerd Font Mono on Windows; set Windows Terminal manually if no settings file is found."
+        return "Manual Windows host font install required because powershell.exe was not found."
+    if platform_id == "pixel-terminal":
+        return "sudo writes /etc/ttyd/index.html and ttyd.service, then restarts ttyd.service."
+    if platform_id == "pixel-avf":
+        return "No host font action; weston-terminal ignores Nerd Font UI configuration."
+    return "No host-side action."
+
+
+def _nerd_font_operations(home: Path, item: NerdFontItem, *, reason: str) -> list[dict[str, Any]]:
+    paths = _nerd_paths(home, item)
+    base = {
+        "entry_id": item.entry_id,
+        "family": item.family,
+        "requires_approval": True,
+        "recipe": "fonts",
+    }
+    return [
+        {
+            **base,
+            "type": "font_download",
+            "source": NERD_FONTS_RELEASE_URL,
+            "target": str(paths["archive"]),
+            "asset_name": item.asset_name,
+            "reason": f"download latest {item.asset_name} or reuse cached archive",
+            "requires_network": True,
+        },
+        {
+            **base,
+            "type": "font_extract",
+            "source": str(paths["archive"]),
+            "target": str(paths["extract_dir"]),
+            "asset_name": item.asset_name,
+            "terminal_face": item.terminal_face,
+            "reason": f"extract {item.label} font files",
+        },
+        {
+            **base,
+            "type": "font_install_linux",
+            "source": str(paths["extract_dir"]),
+            "target": str(paths["install_dir"]),
+            "version_source": str(paths["version"]),
+            "reason": reason,
+        },
+        {
+            **base,
+            "type": "font_rebuild_cache",
+            "target": str(paths["install_dir"]),
+            "reason": "run fc-cache for the user-local font directory when available",
+        },
+        {
+            **base,
+            "type": "font_verify_linux",
+            "target": str(paths["install_dir"]),
+            "terminal_face": item.terminal_face,
+            "reason": f"verify {item.terminal_face} through fontconfig when available",
+        },
+    ]
+
+
+def _apt_package_operation(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "entry_id": summary["entry_id"],
+        "type": "font_install_packages",
+        "source": "apt",
+        "source_type": "apt_package",
+        "target": summary["target"],
+        "packages": [summary["package"]],
+        "candidate_version": summary.get("candidate_version"),
+        "reason": summary["reason"],
+        "requires_approval": True,
+        "requires_sudo": True,
+        "recipe": "fonts",
+    }
+
+
+def _windows_host_plan(
+    home: Path,
+    context: dict[str, Any],
+    item: NerdFontItem,
+    font_summary: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    operations: list[dict[str, Any]] = []
+    powershell = context.get("powershell")
+    settings = context.get("windows_terminal_settings")
+    state = "missing" if powershell else "manual"
+    reason = "powershell.exe is available for Windows per-user font install" if powershell else "powershell.exe is not visible from WSL"
+    entry = {
+        "entry_id": WINDOWS_ENTRY_ID,
+        "source": str(_nerd_paths(home, item)["install_dir"]),
+        "source_type": "windows_host",
+        "family": item.family,
+        "target": "Windows per-user font store",
+        "state": state,
+        "protected": False,
+        "reason": reason,
+        "recipe": "fonts",
+        "requires_sudo": False,
+        "terminal_face": item.terminal_face,
+        "terminal_impact": _terminal_impact("wsl"),
+        "host_action": _host_action(context),
+    }
+    if powershell:
+        source_dir = _nerd_paths(home, item)["install_dir"] if font_summary["state"] == "installed" else _nerd_paths(home, item)["extract_dir"]
+        operations.append({
+            "entry_id": WINDOWS_ENTRY_ID,
+            "type": "font_install_windows",
+            "source": str(source_dir),
+            "target": "Windows per-user font store",
+            "terminal_face": item.terminal_face,
+            "reason": "install JetBrainsMono Nerd Font Mono into the Windows user font store through PowerShell",
+            "requires_approval": True,
+            "recipe": "fonts",
+        })
+        if settings:
+            operations.append({
+                "entry_id": WINDOWS_ENTRY_ID,
+                "type": "font_update_windows_terminal",
+                "source": item.terminal_face,
+                "target": settings,
+                "reason": "set Windows Terminal profile defaults font.face",
+                "requires_approval": True,
+                "recipe": "fonts",
+            })
+        else:
+            operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Set Windows Terminal font face to {item.terminal_face} manually."))
+    else:
+        operations.append(_manual_op(WINDOWS_ENTRY_ID, f"Install {item.terminal_face} on the Windows host manually."))
+    return entry, operations, {"host_action": _host_action(context), "requires_sudo": False}
+
+
+def _pixel_ttyd_plan(home: Path, context: dict[str, Any], font_summary: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    paths = _paths(home)
+    entry = {
+        "entry_id": PIXEL_TTYD_ENTRY_ID,
+        "source": str(paths["install_dir"]),
+        "source_type": "pixel_ttyd",
+        "family": "JetBrainsMono",
+        "target": "/etc/ttyd/index.html",
+        "state": "missing",
+        "protected": False,
+        "reason": "Pixel Terminal ttyd font embedding is managed as a system recipe",
+        "recipe": "fonts",
+        "requires_sudo": True,
+        "terminal_face": font_summary["terminal_face"],
+        "terminal_impact": _terminal_impact("pixel-terminal"),
+        "host_action": _host_action(context),
+    }
+    base = {"entry_id": PIXEL_TTYD_ENTRY_ID, "requires_approval": True, "requires_sudo": True, "recipe": "fonts"}
+    operations = [
+        {
+            **base,
+            "type": "font_ttyd_write_html",
+            "source": str(paths["install_dir"]),
+            "target": "/etc/ttyd/index.html",
+            "cache_dir": str(paths["cache_dir"]),
+            "reason": "backup and write ttyd HTML with embedded JetBrainsMono Nerd Font Mono subset",
+        },
+        {
+            **base,
+            "type": "font_ttyd_write_service",
+            "source": "generated ttyd.service",
+            "target": "/etc/systemd/system/ttyd.service",
+            "cache_dir": str(paths["cache_dir"]),
+            "reason": "backup and write ttyd systemd service using the custom index",
+        },
+        {
+            **base,
+            "type": "font_systemd_daemon_reload",
+            "target": "systemd",
+            "reason": "reload systemd after ttyd.service update",
+        },
+        {
+            **base,
+            "type": "font_systemd_restart",
+            "target": "ttyd.service",
+            "reason": "restart Pixel Terminal ttyd service",
+        },
+    ]
+    return entry, operations, {"host_action": _host_action(context), "terminal_impact": _terminal_impact("pixel-terminal")}
+
+
+def _build_pixel_avf_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
+    prompt_path = home / PIXEL_AVF_PROMPT_REL
+    desired = _pixel_avf_prompt_text()
+    prompt_state = "installed" if prompt_path.exists() and prompt_path.read_text(errors="ignore") == desired else "missing"
+    fonts = [_unsupported_nerd_summary(home, context, item, "Pixel AVF weston-terminal ignores Nerd Font configuration") for item in NERD_FONT_CATALOG]
+    entries = [_font_entry(summary) for summary in fonts]
+    entries.append({
+        "entry_id": PIXEL_AVF_ENTRY_ID,
+        "source": "generated fish prompt fallback",
+        "source_type": "pixel_avf_prompt",
+        "family": "fish prompt",
+        "target": str(prompt_path),
+        "state": prompt_state,
+        "protected": False,
+        "reason": "plain ASCII prompt fallback for Pixel AVF weston-terminal",
+        "recipe": "fonts",
+        "requires_sudo": False,
+        "terminal_face": None,
+        "terminal_impact": _terminal_impact("pixel-avf"),
+        "host_action": _host_action(context),
+    })
+    operations: list[dict[str, Any]] = []
+    if prompt_state != "installed":
+        operations.append({
+            "entry_id": PIXEL_AVF_ENTRY_ID,
+            "type": "font_pixel_avf_prompt",
+            "source": "generated fish prompt fallback",
+            "target": str(prompt_path),
+            "reason": "write plain prompt fallback without Nerd Font glyph dependencies",
+            "requires_approval": True,
+            "recipe": "fonts",
+        })
+    return {"entries": entries, "operations": operations, "fonts": fonts, "context": context}
+
+
+def _build_unsupported_plan(home: Path, context: dict[str, Any]) -> dict[str, Any]:
+    reason = "automatic font setup is unsupported on this platform"
+    fonts = [_unsupported_nerd_summary(home, context, item, reason) for item in NERD_FONT_CATALOG]
+    fonts.extend(_unsupported_apt_summary(context, item, reason) for item in APT_FONT_CATALOG)
+    return {
+        "entries": [_font_entry(summary) for summary in fonts],
+        "operations": [_manual_op(FONT_ENTRY_ID, "Install terminal fonts manually on this platform.")],
+        "fonts": fonts,
+        "context": context,
+    }
+
+
+def _unsupported_nerd_summary(home: Path, context: dict[str, Any], item: NerdFontItem, reason: str) -> dict[str, Any]:
+    paths = _nerd_paths(home, item)
+    return {
+        "entry_id": item.entry_id,
+        "label": item.label,
+        "family": item.family,
+        "source_type": "nerd_font_release",
+        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
+        "asset_name": item.asset_name,
+        "state": "unsupported",
+        "installed_version": None,
+        "latest_version": None,
+        "cached_version": None,
+        "candidate_version": None,
+        "target": str(paths["install_dir"]),
+        "cache_path": str(paths["archive"]),
+        "terminal_face": item.terminal_face,
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": _terminal_impact(context["platform"]),
+        "host_action": _host_action(context),
+        "reason": reason,
+    }
+
+
+def _unsupported_apt_summary(context: dict[str, Any], item: dict[str, str], reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": item["entry_id"],
+        "label": item["family"],
+        "family": item["family"],
+        "source_type": "apt_package",
+        "source": "apt",
+        "package": item["package"],
+        "state": "unsupported",
+        "installed_version": None,
+        "latest_version": None,
+        "candidate_version": None,
+        "target": item["package"],
+        "cache_path": None,
+        "terminal_face": item["terminal_face"],
+        "platform": context["platform"],
+        "requires_sudo": False,
+        "terminal_impact": _terminal_impact(context["platform"]),
+        "host_action": _host_action(context),
+        "reason": reason,
+    }
+
+
+def _font_skip_op(entry_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "type": "font_skip",
+        "target": "",
+        "reason": reason,
+        "requires_approval": False,
+        "recipe": "fonts",
+    }
+
+
+def _manual_op(entry_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "type": "font_manual",
+        "target": "",
+        "reason": reason,
+        "requires_approval": False,
+        "recipe": "fonts",
+    }
+
+
+def _installed_ttf_files(install_dir: Path) -> list[Path]:
+    return _installed_font_files(install_dir)
+
+
+def _installed_font_files(install_dir: Path) -> list[Path]:
+    if not install_dir.exists():
+        return []
+    return sorted(path for path in install_dir.glob("*") if path.suffix.lower() in {".ttf", ".otf"})
+
+
+def _read_version(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _execute_download(op: dict[str, Any], runner: CommandRunner) -> int:
+    archive = Path(op["target"])
+    version_path = archive.parent / f"{Path(op.get('asset_name') or archive.name).stem}.version.json"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        release = runner.fetch_json(NERD_FONTS_RELEASE_URL)
+        asset = select_nerd_font_asset(release, str(op.get("asset_name") or FONT_ASSET_NAME))
+    except Exception as exc:
+        if archive.exists():
+            op["result"] = f"reused cached archive after release lookup failed: {exc}"
+            return 0
+        raise FontError(f"font download blocked and no cached archive exists: {exc}") from exc
+
+    current = _read_version(version_path)
+    if archive.exists() and current.get("tag_name") == asset.get("tag_name"):
+        op["result"] = f"cached {asset.get('tag_name')} reused"
+        return 0
+    runner.download(asset["browser_download_url"], archive)
+    version_path.write_text(json.dumps(asset, indent=2, sort_keys=True) + "\n")
+    op["result"] = f"downloaded {asset.get('tag_name')}"
+    return 1
+
+
+def _execute_extract(op: dict[str, Any]) -> int:
+    archive = Path(op["source"])
+    extract_dir = Path(op["target"])
+    if not archive.exists():
+        raise FontError(f"font archive is missing: {archive}")
+    if extract_dir.exists():
+        shutil.rmtree(extract_dir)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    extracted: list[Path] = []
+    with zipfile.ZipFile(archive) as bundle:
+        for info in bundle.infolist():
+            name = Path(info.filename).name
+            if not name or Path(name).suffix.lower() not in {".ttf", ".otf"}:
+                continue
+            target = extract_dir / name
+            target.write_bytes(bundle.read(info))
+            extracted.append(target)
+    if not extracted:
+        raise FontError(f"no font files found in {archive}")
+    return 1
+
+
+def _execute_install_linux(op: dict[str, Any]) -> int:
+    source = Path(op["source"])
+    target = Path(op["target"])
+    fonts = _installed_font_files(source)
+    if not fonts:
+        raise FontError(f"no extracted font files found in {source}")
+    target.mkdir(parents=True, exist_ok=True)
+    for font in fonts:
+        shutil.copy2(font, target / font.name)
+    version = _read_version(Path(op.get("version_source", "")))
+    if version:
+        (target / FONT_MARKER_NAME).write_text(json.dumps(version, indent=2, sort_keys=True) + "\n")
+    return 1
+
+
+def _execute_rebuild_cache(op: dict[str, Any], runner: CommandRunner) -> int:
+    fc_cache = runner.which("fc-cache")
+    if not fc_cache:
+        op["result"] = "fc-cache not found; font files installed but cache refresh is manual"
+        return 0
+    runner.run([fc_cache, "-f", op["target"]])
+    return 1
+
+
+def _execute_verify_linux(op: dict[str, Any], runner: CommandRunner) -> int:
+    terminal_face = str(op.get("terminal_face") or "")
+    if "Propo" in terminal_face or "Mono" not in terminal_face:
+        raise FontError(f"refusing terminal font face that is not Mono-safe: {terminal_face}")
+    fc_match = runner.which("fc-match")
+    if not fc_match:
+        op["result"] = "fc-match not found; verify manually"
+        return 0
+    result = runner.run([fc_match, terminal_face], capture_output=True)
+    stdout = result.stdout or ""
+    if "Propo" in stdout:
+        raise FontError(f"fontconfig resolved {terminal_face} to a Propo face: {stdout.strip()}")
+    if "Mono" not in stdout:
+        raise FontError(f"fontconfig did not resolve {terminal_face} to a Mono face: {stdout.strip()}")
+    family = str(op.get("family") or terminal_face.split()[0])
+    if _normalize(family) not in _normalize(stdout):
+        raise FontError(f"fontconfig did not resolve {terminal_face}: {stdout.strip()}")
+    return 0
+
+
+def _normalize(text: str) -> str:
+    return "".join(char.lower() for char in text if char.isalnum())
+
+
+def _execute_install_packages(op: dict[str, Any], runner: CommandRunner) -> int:
+    packages = [str(package) for package in op.get("packages", []) if package]
+    if not packages:
+        return 0
+    apt_get = runner.which("apt-get")
+    if not apt_get:
+        op["result"] = "apt-get not found; install fallback packages manually"
+        return 0
+    prefix = [] if hasattr(os, "geteuid") and os.geteuid() == 0 else ["sudo"]
+    runner.run([*prefix, apt_get, "update"])
+    runner.run([*prefix, apt_get, "install", "-y", *packages])
+    return 1
+
+
+def _execute_install_windows(op: dict[str, Any], runner: CommandRunner) -> int:
+    powershell = runner.which("powershell.exe")
+    if not powershell:
+        op["result"] = "powershell.exe not found; install Windows host font manually"
+        return 0
+    source = Path(op["source"])
+    if not source.exists():
+        raise FontError(f"Windows font source directory is missing: {source}")
+    windows_source = str(source)
+    wslpath = runner.which("wslpath")
+    if wslpath:
+        converted = runner.run([wslpath, "-w", str(source)], capture_output=True)
+        windows_source = converted.stdout.strip()
+    script = _windows_font_install_script(windows_source)
+    runner.run([powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
+    return 1
+
+
+def _windows_font_install_script(source_dir: str) -> str:
+    escaped = source_dir.replace("'", "''")
+    return (
+        "$FontDir = Join-Path $env:LOCALAPPDATA 'Microsoft\\Windows\\Fonts'; "
+        "New-Item -ItemType Directory -Force -Path $FontDir | Out-Null; "
+        f"Get-ChildItem -Path '{escaped}' -File | Where-Object {{ $_.Extension -in '.ttf','.otf' }} | ForEach-Object {{ "
+        "$Dest = Join-Path $FontDir $_.Name; "
+        "Copy-Item $_.FullName $Dest -Force; "
+        "New-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' "
+        "-Name \"$($_.BaseName) (TrueType)\" -Value $_.Name -PropertyType String -Force | Out-Null "
+        "}"
+    )
+
+
+def _execute_update_windows_terminal(op: dict[str, Any], backup_dir: Path, backups: list[dict[str, Any]]) -> int:
+    target = Path(op["target"])
+    if not target.exists():
+        op["result"] = "Windows Terminal settings file was not found; set font face manually"
+        return 0
+    record = create_backup(target, backup_dir, entry_id=op["entry_id"])
+    backups.append(record)
+    try:
+        data = json.loads(target.read_text())
+    except json.JSONDecodeError as exc:
+        raise FontError(f"invalid Windows Terminal settings JSON: {target}") from exc
+    profiles = data.setdefault("profiles", {})
+    if not isinstance(profiles, dict):
+        profiles = {}
+        data["profiles"] = profiles
+    defaults = profiles.setdefault("defaults", {})
+    if not isinstance(defaults, dict):
+        defaults = {}
+        profiles["defaults"] = defaults
+    font = defaults.setdefault("font", {})
+    if not isinstance(font, dict):
+        font = {}
+        defaults["font"] = font
+    font["face"] = FONT_FACE
+    target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    op["backup_target"] = record["backup_target"]
+    return 1
+
+
+def _execute_ttyd_html(op: dict[str, Any], runner: CommandRunner, backups: list[dict[str, Any]]) -> int:
+    source_dir = Path(op["source"])
+    font = _regular_mono_font(source_dir)
+    html = _ttyd_html(font)
+    generated = Path(op["cache_dir"]) / "ttyd-index.html"
+    generated.parent.mkdir(parents=True, exist_ok=True)
+    generated.write_text(html)
+    _sudo_backup_and_install(op["target"], generated, runner, backups, op["entry_id"])
+    return 1
+
+
+def _execute_ttyd_service(op: dict[str, Any], runner: CommandRunner, backups: list[dict[str, Any]]) -> int:
+    generated = Path(op["cache_dir"]) / "ttyd.service"
+    generated.parent.mkdir(parents=True, exist_ok=True)
+    generated.write_text(_ttyd_service())
+    _sudo_backup_and_install(op["target"], generated, runner, backups, op["entry_id"])
+    return 1
+
+
+def _sudo_backup_and_install(target: str, generated: Path, runner: CommandRunner, backups: list[dict[str, Any]], entry_id: str) -> None:
+    backup_target = f"{target}.000-dotfiles-backup"
+    runner.run(["sudo", "sh", "-c", "if [ -e \"$1\" ]; then cp -a \"$1\" \"$2\"; fi", "sh", target, backup_target])
+    backups.append({"entry_id": entry_id, "target": target, "backup_target": backup_target})
+    runner.run(["sudo", "install", "-Dm0644", str(generated), target])
+
+
+def _regular_mono_font(source_dir: Path) -> Path:
+    exact = source_dir / EXPECTED_TTF
+    if exact.exists():
+        return exact
+    fonts = _installed_font_files(source_dir)
+    regular = [path for path in fonts if "Mono" in path.name and "Regular" in path.name]
+    if regular:
+        return regular[0]
+    mono = [path for path in fonts if "Mono" in path.name]
+    if mono:
+        return mono[0]
+    raise FontError(f"no JetBrainsMono Nerd Font Mono file found in {source_dir}")
+
+
+def _ttyd_html(font_path: Path) -> str:
+    encoded = base64.b64encode(font_path.read_bytes()).decode("ascii")
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@font-face {{
+  font-family: '{PIXEL_TTYD_FONT_ALIAS}';
+  src: url(data:font/truetype;charset=utf-8;base64,{encoded}) format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}}
+body, #terminal, .terminal, .xterm, .xterm-rows {{
+  font-family: '{PIXEL_TTYD_FONT_ALIAS}', 'Noto Color Emoji', monospace !important;
+}}
+</style>
+</head>
+<body>
+<div id="terminal"></div>
+</body>
+</html>
+"""
+
+
+def _ttyd_service() -> str:
+    return """[Unit]
+Description=ttyd terminal with dotfiles-managed font embedding
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/ttyd --index /etc/ttyd/index.html -W /bin/bash
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def _execute_pixel_avf_prompt(op: dict[str, Any]) -> int:
+    target = Path(op["target"])
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_pixel_avf_prompt_text())
+    return 1
+
+
+def _pixel_avf_prompt_text() -> str:
+    return """# Managed by 000-dotfiles for Pixel AVF weston-terminal.
+# Uses a plain prompt without Nerd Font private-use glyphs.
+function fish_prompt
+    set -l code $status
+    set -l marker '>'
+    if test $code -ne 0
+        set marker '!'
+    end
+    printf '%s %s ' (prompt_pwd) $marker
+end
+"""

--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -138,12 +138,14 @@ class CommandRunner:
     def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
         env = dict(self.env)
         env["PATH"] = self.path
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use
         return subprocess.run(  # nosec B603
             args,
             check=check,
             capture_output=capture_output,
             text=True,
             env=env,
+            shell=False,
         )
 
     def fetch_json(self, url: str) -> dict[str, Any]:

--- a/dotfiles_tools/installer.py
+++ b/dotfiles_tools/installer.py
@@ -91,6 +91,10 @@ def _execute_apply_operations(report: Report, repo_path: Path, backup_path: Path
     return report
 
 
+def execute_manifest_operation(op: dict[str, Any], repo_path: Path, backup_path: Path, backups: list[dict[str, Any]]) -> int:
+    return _execute_operation(op, repo_path, backup_path, backups)
+
+
 def _execute_operation(op: dict[str, Any], repo_path: Path, backup_path: Path, backups: list[dict[str, Any]]) -> int:
     if op["type"] == "mkdir":
         Path(op["target"]).mkdir(parents=True, exist_ok=True)

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -28,13 +28,27 @@ def render_menu_label(repo: Path | str, home: Path | str, *, profile: str = "mac
 
 def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, profile: str = "machine") -> str:
     groups = _group_entries(plan.entries)
-    try:
-        manifest_entries = load_manifest(repo).entry_map()
-    except ManifestError:
-        manifest_entries = {}
     action_summary = _action_summary(doctor, plan, groups)
+    manifest_entries = _manifest_entry_map(repo)
+    lines = _summary_header(repo, home, profile)
+    _extend_option_decision(lines, action_summary, groups)
+    _extend_report_sections(lines, doctor, plan, groups, manifest_entries)
+    lines.extend([
+        "",
+        "Full details: choose option 2 for cache paths, versions, package candidates, terminal faces, host actions, and raw operations.",
+    ])
+    return "\n".join(lines) + "\n"
 
-    lines = [
+
+def _manifest_entry_map(repo: Path) -> dict[str, ManifestEntry]:
+    try:
+        return load_manifest(repo).entry_map()
+    except ManifestError:
+        return {}
+
+
+def _summary_header(repo: Path, home: Path, profile: str) -> list[str]:
+    return [
         "Machine setup summary",
         f"Repo: {repo}",
         f"Home: {home}",
@@ -43,37 +57,67 @@ def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, prof
         "Option 1 will:",
     ]
 
-    if action_summary["file_changes"]:
-        lines.append(
-            "  - "
-            + _file_change_sentence(
-                len(groups["updates"]),
-                len(groups["creates"]),
-                action_summary["backups"],
-            )
-        )
-    else:
-        lines.append("  - Apply no file changes; all non-protected targets are current.")
 
+def _extend_option_decision(
+    lines: list[str],
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> None:
+    _extend_file_decision(lines, action_summary, groups)
+    _extend_font_decision(lines, action_summary)
+    _extend_requirement_decisions(lines, action_summary)
+    _extend_skip_decisions(lines, action_summary, groups)
+    lines.append("  - Nothing changes until you choose option 1.")
+
+
+def _extend_file_decision(
+    lines: list[str],
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> None:
+    if not action_summary["file_changes"]:
+        lines.append("  - Apply no file changes; all non-protected targets are current.")
+        return
+    sentence = _file_change_sentence(len(groups["updates"]), len(groups["creates"]), action_summary["backups"])
+    lines.append("  - " + sentence)
+
+
+def _extend_font_decision(lines: list[str], action_summary: dict[str, int | bool]) -> None:
     if action_summary["font_actions"]:
         lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
     else:
         lines.append("  - Run no font install/update actions.")
 
+
+def _extend_requirement_decisions(lines: list[str], action_summary: dict[str, int | bool]) -> None:
     if action_summary["requires_network"]:
         lines.append("  - Network may be used for Nerd Font downloads unless cached.")
     if action_summary["requires_apt_sudo"]:
         lines.append("  - sudo is needed for apt fallback font packages.")
     elif action_summary["requires_sudo"]:
         lines.append("  - sudo is needed for host/system font actions.")
+
+
+def _extend_skip_decisions(
+    lines: list[str],
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> None:
     if groups["protected"]:
         lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
     if action_summary["manual_fonts"]:
         lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
     if action_summary["blockers"]:
         lines.append(f"  - Stop on {_plural(action_summary['blockers'], 'blocking issue')}; fix before applying.")
-    lines.append("  - Nothing changes until you choose option 1.")
 
+
+def _extend_report_sections(
+    lines: list[str],
+    doctor: Report,
+    plan: Report,
+    groups: dict[str, list[dict[str, Any]]],
+    manifest_entries: dict[str, ManifestEntry],
+) -> None:
     _extend_change_group(lines, "Update existing files with backups", groups["updates"], manifest_entries)
     _extend_change_group(lines, "Create missing files", groups["creates"], manifest_entries)
     _extend_manual_group(lines, groups["protected"], manifest_entries)
@@ -82,11 +126,6 @@ def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, prof
     _extend_report_errors(lines, "Plan errors", plan.errors)
     _extend_font_summary(lines, plan)
     _extend_tool_summary(lines, doctor.extra)
-    lines.extend([
-        "",
-        "Full details: choose option 2 for cache paths, versions, package candidates, terminal faces, host actions, and raw operations.",
-    ])
-    return "\n".join(lines) + "\n"
 
 
 def _group_entries(entries: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -97,18 +136,26 @@ def _group_entries(entries: list[dict[str, Any]]) -> dict[str, list[dict[str, An
         "blocked": [],
     }
     for entry in entries:
-        if entry.get("recipe") == "fonts":
-            continue
-        state = entry.get("state")
-        if state == "drifted" and not entry.get("protected"):
-            groups["updates"].append(entry)
-        elif state == "missing" and not entry.get("protected"):
-            groups["creates"].append(entry)
-        elif state == "protected":
-            groups["protected"].append(entry)
-        elif state in {"invalid", "blocked"}:
-            groups["blocked"].append(entry)
+        group = _entry_group(entry)
+        if group:
+            groups[group].append(entry)
     return groups
+
+
+def _entry_group(entry: dict[str, Any]) -> str | None:
+    if entry.get("recipe") == "fonts":
+        return None
+    state = entry.get("state")
+    protected = bool(entry.get("protected"))
+    if state == "drifted" and not protected:
+        return "updates"
+    if state == "missing" and not protected:
+        return "creates"
+    if state == "protected":
+        return "protected"
+    if state in {"invalid", "blocked"}:
+        return "blocked"
+    return None
 
 
 def _extend_change_group(lines: list[str], title: str, entries: list[dict[str, Any]], manifest_entries: dict[str, ManifestEntry]) -> None:
@@ -154,46 +201,78 @@ def _extend_report_errors(lines: list[str], title: str, errors: list[dict[str, A
 
 
 def _extend_font_summary(lines: list[str], plan: Report) -> None:
-    fonts = list(plan.extra.get("fonts") or [])
-    font_entries = [entry for entry in plan.entries if entry.get("recipe") == "fonts"]
-    other_entries = [
-        entry
-        for entry in font_entries
-        if entry.get("source_type") not in {"nerd_font_release", "apt_package"}
-    ]
+    fonts, other_entries = _font_summary_items(plan)
     if not fonts and not other_entries:
         return
 
     actionable_ids = _actionable_font_ids(plan)
-    nerd_fonts = [item for item in fonts if item.get("source_type") == "nerd_font_release"]
-    apt_fonts = [item for item in fonts if item.get("source_type") == "apt_package"]
-    already_ok = [item for item in fonts + other_entries if item.get("state") in {"installed", "current"}]
-    manual_or_blocked = [
-        item
-        for item in fonts + other_entries
-        if item.get("state") in {"manual", "unsupported", "blocked", "invalid"}
-    ]
-    other_actionable = [
-        item
-        for item in other_entries
-        if item.get("entry_id") in actionable_ids or item.get("state") in {"missing", "needs_update"}
-    ]
-
+    groups = _font_summary_groups(fonts, other_entries, actionable_ids)
     lines.extend([
         "",
         "Fonts:",
         "  - Terminal configuration uses `Nerd Font Mono` faces, never Propo.",
     ])
-    _extend_font_action_group(lines, "Nerd Fonts", nerd_fonts, actionable_ids)
-    _extend_font_action_group(lines, "Apt fallback fonts", apt_fonts, actionable_ids)
+    _extend_font_action_group(lines, "Nerd Fonts", groups["nerd"], actionable_ids)
+    _extend_font_action_group(lines, "Apt fallback fonts", groups["apt"], actionable_ids)
+    _extend_other_font_actions(lines, groups["other_actionable"])
+    _extend_font_names(lines, "Already OK", groups["already_ok"])
+    _extend_manual_font_items(lines, groups["manual_or_blocked"])
+
+
+def _font_summary_items(plan: Report) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    fonts = list(plan.extra.get("fonts") or [])
+    font_entries = [entry for entry in plan.entries if entry.get("recipe") == "fonts"]
+    other_entries = [entry for entry in font_entries if entry.get("source_type") not in {"nerd_font_release", "apt_package"}]
+    return fonts, other_entries
+
+
+def _font_summary_groups(
+    fonts: list[dict[str, Any]],
+    other_entries: list[dict[str, Any]],
+    actionable_ids: set[str],
+) -> dict[str, list[dict[str, Any]]]:
+    all_items = fonts + other_entries
+    return {
+        "nerd": _font_items_by_source(fonts, "nerd_font_release"),
+        "apt": _font_items_by_source(fonts, "apt_package"),
+        "already_ok": _font_items_by_state(all_items, {"installed", "current"}),
+        "manual_or_blocked": _font_items_by_state(all_items, {"manual", "unsupported", "blocked", "invalid"}),
+        "other_actionable": _other_actionable_fonts(other_entries, actionable_ids),
+    }
+
+
+def _font_items_by_source(items: list[dict[str, Any]], source_type: str) -> list[dict[str, Any]]:
+    return [item for item in items if item.get("source_type") == source_type]
+
+
+def _font_items_by_state(items: list[dict[str, Any]], states: set[str]) -> list[dict[str, Any]]:
+    return [item for item in items if item.get("state") in states]
+
+
+def _other_actionable_fonts(items: list[dict[str, Any]], actionable_ids: set[str]) -> list[dict[str, Any]]:
+    return [item for item in items if _font_item_is_actionable(item, actionable_ids)]
+
+
+def _font_item_is_actionable(item: dict[str, Any], actionable_ids: set[str]) -> bool:
+    return item.get("entry_id") in actionable_ids or item.get("state") in {"missing", "needs_update"}
+
+
+def _extend_other_font_actions(lines: list[str], other_actionable: list[dict[str, Any]]) -> None:
     if other_actionable:
         lines.append("  Other font actions:")
         for item in other_actionable:
             lines.append(f"    - {_font_item_line(item)}")
-    if already_ok:
-        lines.append("  Already OK:")
-        for item in already_ok:
-            lines.append(f"    - {_font_item_name(item)}")
+
+
+def _extend_font_names(lines: list[str], title: str, items: list[dict[str, Any]]) -> None:
+    if not items:
+        return
+    lines.append(f"  {title}:")
+    for item in items:
+        lines.append(f"    - {_font_item_name(item)}")
+
+
+def _extend_manual_font_items(lines: list[str], manual_or_blocked: list[dict[str, Any]]) -> None:
     if manual_or_blocked:
         lines.append("  Manual/skipped:")
         for item in manual_or_blocked:
@@ -227,18 +306,25 @@ def _extend_tool_summary(lines: list[str], extra: dict[str, Any]) -> None:
     if not tool_checks and not auth_guidance:
         return
 
-    missing = [item for item in tool_checks if item.get("state") == "missing"]
     lines.extend(["", "Tools and auth:"])
-    if missing:
-        lines.append("  - Missing tools:")
-        for item in missing:
-            lines.append(f"    {item.get('command')}: {item.get('install_hint')}")
-    else:
+    _extend_tool_check_lines(lines, tool_checks)
+    _extend_auth_summary_line(lines, auth_guidance)
+
+
+def _extend_tool_check_lines(lines: list[str], tool_checks: list[dict[str, Any]]) -> None:
+    missing = [item for item in tool_checks if item.get("state") == "missing"]
+    if not missing:
         lines.append(f"  - All {len(tool_checks)} baseline tools are visible on PATH.")
-    if auth_guidance:
-        commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
-        if commands:
-            lines.append(f"  - Auth checks are manual: {commands}.")
+        return
+    lines.append("  - Missing tools:")
+    for item in missing:
+        lines.append(f"    {item.get('command')}: {item.get('install_hint')}")
+
+
+def _extend_auth_summary_line(lines: list[str], auth_guidance: list[dict[str, Any]]) -> None:
+    commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
+    if commands:
+        lines.append(f"  - Auth checks are manual: {commands}.")
 
 
 def _target_label(entry: dict[str, Any], manifest_entries: dict[str, ManifestEntry]) -> str:
@@ -255,18 +341,7 @@ def _home_label(target: str) -> str:
 def _action_summary(doctor: Report, plan: Report, groups: dict[str, list[dict[str, Any]]]) -> dict[str, int | bool]:
     actionable_font_ids = _actionable_font_ids(plan)
     font_entries = [entry for entry in plan.entries if entry.get("recipe") == "fonts"]
-    source_types = {str(entry.get("entry_id")): entry.get("source_type") for entry in font_entries}
-    nerd_actions = 0
-    apt_actions = 0
-    other_font_actions = 0
-    for entry_id in actionable_font_ids:
-        source_type = _font_source_type(entry_id, source_types, plan.operations)
-        if source_type == "nerd_font_release":
-            nerd_actions += 1
-        elif source_type == "apt_package":
-            apt_actions += 1
-        else:
-            other_font_actions += 1
+    nerd_actions, apt_actions, other_font_actions = _font_action_counts(plan, font_entries, actionable_font_ids)
 
     return {
         "file_changes": len(groups["updates"]) + len(groups["creates"]),
@@ -275,17 +350,38 @@ def _action_summary(doctor: Report, plan: Report, groups: dict[str, list[dict[st
         "nerd_actions": nerd_actions,
         "apt_actions": apt_actions,
         "other_font_actions": other_font_actions,
-        "manual_fonts": sum(1 for entry in font_entries if entry.get("state") in {"manual", "unsupported"}),
+        "manual_fonts": _manual_font_count(font_entries),
         "blockers": len(groups["blocked"]) + len(doctor.errors) + len(plan.errors),
-        "requires_network": any(_is_actionable_operation(op) and op.get("requires_network") for op in plan.operations),
-        "requires_sudo": any(_is_actionable_operation(op) and op.get("requires_sudo") for op in plan.operations),
-        "requires_apt_sudo": any(
-            _is_actionable_operation(op)
-            and op.get("type") == "font_install_packages"
-            and op.get("requires_sudo")
-            for op in plan.operations
-        ),
+        "requires_network": _has_actionable_operation(plan.operations, "requires_network"),
+        "requires_sudo": _has_actionable_operation(plan.operations, "requires_sudo"),
+        "requires_apt_sudo": _has_apt_sudo_operation(plan.operations),
     }
+
+
+def _font_action_counts(
+    plan: Report,
+    font_entries: list[dict[str, Any]],
+    actionable_font_ids: set[str],
+) -> tuple[int, int, int]:
+    source_types = {str(entry.get("entry_id")): entry.get("source_type") for entry in font_entries}
+    counts = {"nerd_font_release": 0, "apt_package": 0, "other": 0}
+    for entry_id in actionable_font_ids:
+        source_type = _font_source_type(entry_id, source_types, plan.operations)
+        bucket = source_type if source_type in {"nerd_font_release", "apt_package"} else "other"
+        counts[bucket] += 1
+    return counts["nerd_font_release"], counts["apt_package"], counts["other"]
+
+
+def _manual_font_count(font_entries: list[dict[str, Any]]) -> int:
+    return sum(1 for entry in font_entries if entry.get("state") in {"manual", "unsupported"})
+
+
+def _has_actionable_operation(operations: list[dict[str, Any]], flag: str) -> bool:
+    return any(_is_actionable_operation(op) and op.get(flag) for op in operations)
+
+
+def _has_apt_sudo_operation(operations: list[dict[str, Any]]) -> bool:
+    return any(_is_actionable_operation(op) and op.get("type") == "font_install_packages" and op.get("requires_sudo") for op in operations)
 
 
 def _option_one_label(plan: Report, groups: dict[str, list[dict[str, Any]]]) -> str:
@@ -296,28 +392,39 @@ def _option_one_label(plan: Report, groups: dict[str, list[dict[str, Any]]]) -> 
     )
     file_changes = int(action_summary["file_changes"])
     font_actions = int(action_summary["font_actions"])
-    if file_changes and font_actions:
-        label = f"Apply {_plural(file_changes, 'file change')} + {_plural(font_actions, 'font action')}"
-    elif file_changes:
-        label = f"Apply {_plural(file_changes, 'file change')}"
-    elif font_actions:
-        label = f"Apply {_plural(font_actions, 'font action')}"
-    else:
-        label = "Apply safe changes"
+    label = _option_base_label(file_changes, font_actions)
+    details = _option_label_details(action_summary)
+    if details:
+        label += f" ({'; '.join(details)})"
+    return label
 
+
+def _option_base_label(file_changes: int, font_actions: int) -> str:
+    if file_changes and font_actions:
+        return f"Apply {_plural(file_changes, 'file change')} + {_plural(font_actions, 'font action')}"
+    if file_changes:
+        return f"Apply {_plural(file_changes, 'file change')}"
+    if font_actions:
+        return f"Apply {_plural(font_actions, 'font action')}"
+    return "Apply safe changes"
+
+
+def _option_label_details(action_summary: dict[str, int | bool]) -> list[str]:
     details: list[str] = []
     backups = int(action_summary["backups"])
     if backups:
         details.append(f"backs up {_plural(backups, 'file')}")
+    _extend_sudo_label_details(details, action_summary)
+    if action_summary["requires_network"]:
+        details.append("network may be used for Nerd Fonts")
+    return details
+
+
+def _extend_sudo_label_details(details: list[str], action_summary: dict[str, int | bool]) -> None:
     if action_summary["requires_apt_sudo"]:
         details.append("sudo needed for apt fonts")
     elif action_summary["requires_sudo"]:
         details.append("sudo needed")
-    if action_summary["requires_network"]:
-        details.append("network may be used for Nerd Fonts")
-    if details:
-        label += f" ({'; '.join(details)})"
-    return label
 
 
 def _file_change_sentence(updates: int, creates: int, backups: int) -> str:

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Sequence
+
+from .bootstrap import build_bootstrap_plan
+from .doctor import run_doctor
+from .manifest import ManifestEntry, ManifestError, load_manifest
+from .reports import Report
+
+
+def render_machine_summary(repo: Path | str, home: Path | str, *, profile: str = "machine") -> str:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    doctor = run_doctor(repo_path, home_path, profile=profile)
+    plan = build_bootstrap_plan(repo_path, home_path, profile=profile)
+    return render_reports(doctor, plan, repo_path, home_path, profile=profile)
+
+
+def render_menu_label(repo: Path | str, home: Path | str, *, profile: str = "machine") -> str:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    plan = build_bootstrap_plan(repo_path, home_path, profile=profile)
+    groups = _group_entries(plan.entries)
+    return _option_one_label(plan, groups)
+
+
+def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, profile: str = "machine") -> str:
+    groups = _group_entries(plan.entries)
+    try:
+        manifest_entries = load_manifest(repo).entry_map()
+    except ManifestError:
+        manifest_entries = {}
+    action_summary = _action_summary(doctor, plan, groups)
+
+    lines = [
+        "Machine setup summary",
+        f"Repo: {repo}",
+        f"Home: {home}",
+        f"Profile: {profile}",
+        "",
+        "Option 1 will:",
+    ]
+
+    if action_summary["file_changes"]:
+        lines.append(
+            "  - "
+            + _file_change_sentence(
+                len(groups["updates"]),
+                len(groups["creates"]),
+                action_summary["backups"],
+            )
+        )
+    else:
+        lines.append("  - Apply no file changes; all non-protected targets are current.")
+
+    if action_summary["font_actions"]:
+        lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
+    else:
+        lines.append("  - Run no font install/update actions.")
+
+    if action_summary["requires_network"]:
+        lines.append("  - Network may be used for Nerd Font downloads unless cached.")
+    if action_summary["requires_apt_sudo"]:
+        lines.append("  - sudo is needed for apt fallback font packages.")
+    elif action_summary["requires_sudo"]:
+        lines.append("  - sudo is needed for host/system font actions.")
+    if groups["protected"]:
+        lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
+    if action_summary["manual_fonts"]:
+        lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
+    if action_summary["blockers"]:
+        lines.append(f"  - Stop on {_plural(action_summary['blockers'], 'blocking issue')}; fix before applying.")
+    lines.append("  - Nothing changes until you choose option 1.")
+
+    _extend_change_group(lines, "Update existing files with backups", groups["updates"], manifest_entries)
+    _extend_change_group(lines, "Create missing files", groups["creates"], manifest_entries)
+    _extend_manual_group(lines, groups["protected"], manifest_entries)
+    _extend_blocking_group(lines, groups["blocked"], manifest_entries)
+    _extend_report_errors(lines, "Doctor errors", doctor.errors)
+    _extend_report_errors(lines, "Plan errors", plan.errors)
+    _extend_font_summary(lines, plan)
+    _extend_tool_summary(lines, doctor.extra)
+    lines.extend([
+        "",
+        "Full details: choose option 2 for cache paths, versions, package candidates, terminal faces, host actions, and raw operations.",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def _group_entries(entries: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {
+        "updates": [],
+        "creates": [],
+        "protected": [],
+        "blocked": [],
+    }
+    for entry in entries:
+        if entry.get("recipe") == "fonts":
+            continue
+        state = entry.get("state")
+        if state == "drifted" and not entry.get("protected"):
+            groups["updates"].append(entry)
+        elif state == "missing" and not entry.get("protected"):
+            groups["creates"].append(entry)
+        elif state == "protected":
+            groups["protected"].append(entry)
+        elif state in {"invalid", "blocked"}:
+            groups["blocked"].append(entry)
+    return groups
+
+
+def _extend_change_group(lines: list[str], title: str, entries: list[dict[str, Any]], manifest_entries: dict[str, ManifestEntry]) -> None:
+    if not entries:
+        return
+    lines.extend(["", f"{title}:"])
+    for entry in entries:
+        target = _target_label(entry, manifest_entries)
+        lines.append(f"  - {target}")
+
+
+def _extend_manual_group(lines: list[str], entries: list[dict[str, Any]], manifest_entries: dict[str, ManifestEntry]) -> None:
+    if not entries:
+        return
+    lines.extend(["", "Protected/manual files:"])
+    for entry in entries:
+        target = _target_label(entry, manifest_entries)
+        reason = entry.get("manual_reason") or entry.get("reason") or "protected/manual item"
+        lines.append(f"  - {target}: {reason}")
+
+
+def _extend_blocking_group(lines: list[str], entries: list[dict[str, Any]], manifest_entries: dict[str, ManifestEntry]) -> None:
+    if not entries:
+        return
+    lines.extend(["", "Needs attention before apply:"])
+    for entry in entries:
+        target = _target_label(entry, manifest_entries)
+        lines.append(f"  - {target}: {entry.get('reason')}")
+
+
+def _extend_report_errors(lines: list[str], title: str, errors: list[dict[str, Any] | str]) -> None:
+    if not errors:
+        return
+    lines.extend(["", f"{title}:"])
+    for error in errors:
+        if isinstance(error, dict):
+            message = error.get("message") or error
+            entry = error.get("entry_id")
+            prefix = f"{entry}: " if entry else ""
+            lines.append(f"  - {prefix}{message}")
+        else:
+            lines.append(f"  - {error}")
+
+
+def _extend_font_summary(lines: list[str], plan: Report) -> None:
+    fonts = list(plan.extra.get("fonts") or [])
+    font_entries = [entry for entry in plan.entries if entry.get("recipe") == "fonts"]
+    other_entries = [
+        entry
+        for entry in font_entries
+        if entry.get("source_type") not in {"nerd_font_release", "apt_package"}
+    ]
+    if not fonts and not other_entries:
+        return
+
+    actionable_ids = _actionable_font_ids(plan)
+    nerd_fonts = [item for item in fonts if item.get("source_type") == "nerd_font_release"]
+    apt_fonts = [item for item in fonts if item.get("source_type") == "apt_package"]
+    already_ok = [item for item in fonts + other_entries if item.get("state") in {"installed", "current"}]
+    manual_or_blocked = [
+        item
+        for item in fonts + other_entries
+        if item.get("state") in {"manual", "unsupported", "blocked", "invalid"}
+    ]
+    other_actionable = [
+        item
+        for item in other_entries
+        if item.get("entry_id") in actionable_ids or item.get("state") in {"missing", "needs_update"}
+    ]
+
+    lines.extend([
+        "",
+        "Fonts:",
+        "  - Terminal configuration uses `Nerd Font Mono` faces, never Propo.",
+    ])
+    _extend_font_action_group(lines, "Nerd Fonts", nerd_fonts, actionable_ids)
+    _extend_font_action_group(lines, "Apt fallback fonts", apt_fonts, actionable_ids)
+    if other_actionable:
+        lines.append("  Other font actions:")
+        for item in other_actionable:
+            lines.append(f"    - {_font_item_line(item)}")
+    if already_ok:
+        lines.append("  Already OK:")
+        for item in already_ok:
+            lines.append(f"    - {_font_item_name(item)}")
+    if manual_or_blocked:
+        lines.append("  Manual/skipped:")
+        for item in manual_or_blocked:
+            lines.append(f"    - {_font_item_line(item, show_reason=True)}")
+
+
+def _extend_font_action_group(
+    lines: list[str],
+    title: str,
+    items: list[dict[str, Any]],
+    actionable_ids: set[str],
+) -> None:
+    if not items:
+        return
+    actionable = [
+        item
+        for item in items
+        if item.get("entry_id") in actionable_ids or item.get("state") in {"missing", "needs_update"}
+    ]
+    lines.append(f"  {title}:")
+    if not actionable:
+        lines.append("    - none to install/update")
+        return
+    for item in actionable:
+        lines.append(f"    - {_font_item_line(item)}")
+
+
+def _extend_tool_summary(lines: list[str], extra: dict[str, Any]) -> None:
+    tool_checks = extra.get("tool_checks") or []
+    auth_guidance = extra.get("auth_guidance") or []
+    if not tool_checks and not auth_guidance:
+        return
+
+    missing = [item for item in tool_checks if item.get("state") == "missing"]
+    lines.extend(["", "Tools and auth:"])
+    if missing:
+        lines.append("  - Missing tools:")
+        for item in missing:
+            lines.append(f"    {item.get('command')}: {item.get('install_hint')}")
+    else:
+        lines.append(f"  - All {len(tool_checks)} baseline tools are visible on PATH.")
+    if auth_guidance:
+        commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
+        if commands:
+            lines.append(f"  - Auth checks are manual: {commands}.")
+
+
+def _target_label(entry: dict[str, Any], manifest_entries: dict[str, ManifestEntry]) -> str:
+    manifest_entry = manifest_entries.get(str(entry.get("entry_id")))
+    if manifest_entry:
+        return _home_label(manifest_entry.target)
+    return str(entry.get("target", ""))
+
+
+def _home_label(target: str) -> str:
+    return "~" if target in {"", "."} else f"~/{target}"
+
+
+def _action_summary(doctor: Report, plan: Report, groups: dict[str, list[dict[str, Any]]]) -> dict[str, int | bool]:
+    actionable_font_ids = _actionable_font_ids(plan)
+    font_entries = [entry for entry in plan.entries if entry.get("recipe") == "fonts"]
+    source_types = {str(entry.get("entry_id")): entry.get("source_type") for entry in font_entries}
+    nerd_actions = 0
+    apt_actions = 0
+    other_font_actions = 0
+    for entry_id in actionable_font_ids:
+        source_type = _font_source_type(entry_id, source_types, plan.operations)
+        if source_type == "nerd_font_release":
+            nerd_actions += 1
+        elif source_type == "apt_package":
+            apt_actions += 1
+        else:
+            other_font_actions += 1
+
+    return {
+        "file_changes": len(groups["updates"]) + len(groups["creates"]),
+        "backups": len(groups["updates"]),
+        "font_actions": len(actionable_font_ids),
+        "nerd_actions": nerd_actions,
+        "apt_actions": apt_actions,
+        "other_font_actions": other_font_actions,
+        "manual_fonts": sum(1 for entry in font_entries if entry.get("state") in {"manual", "unsupported"}),
+        "blockers": len(groups["blocked"]) + len(doctor.errors) + len(plan.errors),
+        "requires_network": any(_is_actionable_operation(op) and op.get("requires_network") for op in plan.operations),
+        "requires_sudo": any(_is_actionable_operation(op) and op.get("requires_sudo") for op in plan.operations),
+        "requires_apt_sudo": any(
+            _is_actionable_operation(op)
+            and op.get("type") == "font_install_packages"
+            and op.get("requires_sudo")
+            for op in plan.operations
+        ),
+    }
+
+
+def _option_one_label(plan: Report, groups: dict[str, list[dict[str, Any]]]) -> str:
+    action_summary = _action_summary(
+        Report("doctor", "ok", plan.repo, home=plan.home, profile=plan.profile),
+        plan,
+        groups,
+    )
+    file_changes = int(action_summary["file_changes"])
+    font_actions = int(action_summary["font_actions"])
+    if file_changes and font_actions:
+        label = f"Apply {_plural(file_changes, 'file change')} + {_plural(font_actions, 'font action')}"
+    elif file_changes:
+        label = f"Apply {_plural(file_changes, 'file change')}"
+    elif font_actions:
+        label = f"Apply {_plural(font_actions, 'font action')}"
+    else:
+        label = "Apply safe changes"
+
+    details: list[str] = []
+    backups = int(action_summary["backups"])
+    if backups:
+        details.append(f"backs up {_plural(backups, 'file')}")
+    if action_summary["requires_apt_sudo"]:
+        details.append("sudo needed for apt fonts")
+    elif action_summary["requires_sudo"]:
+        details.append("sudo needed")
+    if action_summary["requires_network"]:
+        details.append("network may be used for Nerd Fonts")
+    if details:
+        label += f" ({'; '.join(details)})"
+    return label
+
+
+def _file_change_sentence(updates: int, creates: int, backups: int) -> str:
+    parts: list[str] = []
+    if updates:
+        backup_text = f" with {_plural(backups, 'backup')}" if backups else ""
+        parts.append(f"update {_plural(updates, 'existing file')}{backup_text}")
+    if creates:
+        parts.append(f"create {_plural(creates, 'missing file')}")
+    return " and ".join(parts).capitalize() + "."
+
+
+def _font_action_sentence(action_summary: dict[str, int | bool]) -> str:
+    parts: list[str] = []
+    nerd = int(action_summary["nerd_actions"])
+    apt = int(action_summary["apt_actions"])
+    other = int(action_summary["other_font_actions"])
+    if nerd:
+        parts.append(_plural(nerd, "Nerd Font"))
+    if apt:
+        parts.append(_plural(apt, "apt fallback font package"))
+    if other:
+        parts.append(_plural(other, "host/system font action"))
+    return ", ".join(parts) if parts else _plural(int(action_summary["font_actions"]), "font action")
+
+
+def _actionable_font_ids(plan: Report) -> set[str]:
+    return {
+        str(op.get("entry_id"))
+        for op in plan.operations
+        if op.get("recipe") == "fonts" and _is_actionable_operation(op) and op.get("entry_id")
+    }
+
+
+def _is_actionable_operation(op: dict[str, Any]) -> bool:
+    op_type = str(op.get("type", ""))
+    return bool(op.get("requires_approval")) and op_type not in {"skip", "refuse", "font_skip", "font_manual"}
+
+
+def _font_source_type(entry_id: str, source_types: dict[str, Any], operations: list[dict[str, Any]]) -> Any:
+    if source_types.get(entry_id):
+        return source_types[entry_id]
+    for op in operations:
+        if op.get("entry_id") == entry_id and op.get("source_type"):
+            return op.get("source_type")
+    if entry_id.startswith("fonts.apt."):
+        return "apt_package"
+    if entry_id.endswith("-nerd") or ".nerd" in entry_id:
+        return "nerd_font_release"
+    return None
+
+
+def _font_item_line(item: dict[str, Any], *, show_reason: bool = False) -> str:
+    bits = [_font_item_name(item) + f": {_font_state(item)}"]
+    if item.get("requires_sudo"):
+        bits.append("sudo")
+    if item.get("source_type") == "nerd_font_release" and item.get("state") in {"missing", "needs_update"}:
+        bits.append("network if cache is missing")
+    if show_reason and item.get("reason"):
+        bits.append(str(item["reason"]))
+    if len(bits) == 1:
+        return bits[0]
+    return f"{bits[0]} ({'; '.join(bits[1:])})"
+
+
+def _font_item_name(item: dict[str, Any]) -> str:
+    label = str(item.get("label") or item.get("family") or item.get("entry_id") or "font item")
+    package = item.get("package")
+    if item.get("source_type") == "apt_package" and package:
+        return f"{label} [{package}]"
+    return label
+
+
+def _font_state(item: dict[str, Any]) -> str:
+    state = str(item.get("state") or "unknown")
+    return {
+        "needs_update": "needs update",
+        "installed": "already OK",
+        "current": "already OK",
+        "manual": "manual check needed",
+        "unsupported": "skipped here",
+        "invalid": "blocked",
+    }.get(state, state)
+
+
+def _plural(count: int, singular: str) -> str:
+    suffix = "" if count == 1 else "s"
+    return f"{count} {singular}{suffix}"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="dotfiles_tools.machine_summary")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--profile", default="machine")
+    parser.add_argument("--menu-label", action="store_true")
+    args = parser.parse_args(argv)
+    if args.menu_label:
+        print(render_menu_label(args.repo, args.home, profile=args.profile))
+    else:
+        print(render_machine_summary(args.repo, args.home, profile=args.profile), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -148,36 +148,54 @@ def _extend_errors(lines: list[str], errors: list[dict[str, Any] | str]) -> None
 
 
 def _extend_extra(lines: list[str], extra: dict[str, Any]) -> None:
-    fonts = extra.get("fonts") or []
+    _extend_extra_fonts(lines, extra.get("fonts") or [])
+    _extend_extra_tool_checks(lines, extra.get("tool_checks") or [])
+    _extend_extra_auth_guidance(lines, extra.get("auth_guidance") or [])
+
+
+def _extend_extra_fonts(lines: list[str], fonts: list[dict[str, Any]]) -> None:
     if fonts:
         lines.append("font actions:")
         for item in fonts:
-            sudo = "yes" if item.get("requires_sudo") else "no"
-            source_type = item.get("source_type")
-            version = item.get("latest_version") or item.get("candidate_version") or "unknown"
-            lines.append(f"  - {item.get('label')}: {item.get('state')} ({source_type}) -> {item.get('target')}")
-            lines.append(f"    version: installed={item.get('installed_version') or 'unknown'} latest/candidate={version}")
-            if item.get("cache_path"):
-                lines.append(f"    cache: {item.get('cache_path')}")
-            lines.append(f"    terminal face: {item.get('terminal_face') or 'n/a'}")
-            lines.append(f"    sudo: {sudo}; host: {item.get('host_action')}")
-            lines.append(f"    terminal: {item.get('terminal_impact')}")
+            _extend_extra_font_item(lines, item)
 
-    tool_checks = extra.get("tool_checks") or []
+
+def _extend_extra_font_item(lines: list[str], item: dict[str, Any]) -> None:
+    sudo = "yes" if item.get("requires_sudo") else "no"
+    source_type = item.get("source_type")
+    version = item.get("latest_version") or item.get("candidate_version") or "unknown"
+    lines.append(f"  - {item.get('label')}: {item.get('state')} ({source_type}) -> {item.get('target')}")
+    lines.append(f"    version: installed={item.get('installed_version') or 'unknown'} latest/candidate={version}")
+    if item.get("cache_path"):
+        lines.append(f"    cache: {item.get('cache_path')}")
+    lines.append(f"    terminal face: {item.get('terminal_face') or 'n/a'}")
+    lines.append(f"    sudo: {sudo}; host: {item.get('host_action')}")
+    lines.append(f"    terminal: {item.get('terminal_impact')}")
+
+
+def _extend_extra_tool_checks(lines: list[str], tool_checks: list[dict[str, Any]]) -> None:
     if tool_checks:
         lines.append("tool checks:")
         for item in tool_checks:
-            path = item.get("path")
-            location = f" ({path})" if path else ""
-            bootstrap = " bootstrap" if item.get("bootstrap") else ""
-            hint = f" - {item.get('install_hint')}" if item.get("state") == "missing" else ""
-            lines.append(f"  - {item.get('command')}: {item.get('state')}{location}{bootstrap}{hint}")
+            lines.append(_extra_tool_check_line(item))
 
-    auth_guidance = extra.get("auth_guidance") or []
+
+def _extra_tool_check_line(item: dict[str, Any]) -> str:
+    path = item.get("path")
+    location = f" ({path})" if path else ""
+    bootstrap = " bootstrap" if item.get("bootstrap") else ""
+    hint = f" - {item.get('install_hint')}" if item.get("state") == "missing" else ""
+    return f"  - {item.get('command')}: {item.get('state')}{location}{bootstrap}{hint}"
+
+
+def _extend_extra_auth_guidance(lines: list[str], auth_guidance: list[dict[str, Any]]) -> None:
     if auth_guidance:
         lines.append("auth/setup guidance:")
         for item in auth_guidance:
-            if item.get("state") == "available":
-                lines.append(f"  - {item.get('command')}: {item.get('guidance')}")
-            else:
-                lines.append(f"  - {item.get('tool')}: install tool before auth setup")
+            lines.append(_extra_auth_line(item))
+
+
+def _extra_auth_line(item: dict[str, Any]) -> str:
+    if item.get("state") == "available":
+        return f"  - {item.get('command')}: {item.get('guidance')}"
+    return f"  - {item.get('tool')}: install tool before auth setup"

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -6,7 +6,21 @@ from pathlib import Path
 from typing import Any
 
 
-SUMMARY_KEYS = ("missing", "current", "drifted", "protected", "invalid", "blocked", "operations", "backups", "errors")
+SUMMARY_KEYS = (
+    "missing",
+    "current",
+    "drifted",
+    "protected",
+    "invalid",
+    "blocked",
+    "installed",
+    "needs_update",
+    "manual",
+    "unsupported",
+    "operations",
+    "backups",
+    "errors",
+)
 
 
 @dataclass
@@ -72,6 +86,7 @@ class Report:
         _extend_operations(lines, self.operations)
         _extend_backups(lines, self.backups)
         _extend_errors(lines, self.errors)
+        _extend_extra(lines, self.extra)
         return "\n".join(lines) + "\n"
 
 
@@ -130,3 +145,39 @@ def _extend_errors(lines: list[str], errors: list[dict[str, Any] | str]) -> None
     lines.append("errors:")
     for error in errors:
         lines.append(f"  - {error}")
+
+
+def _extend_extra(lines: list[str], extra: dict[str, Any]) -> None:
+    fonts = extra.get("fonts") or []
+    if fonts:
+        lines.append("font actions:")
+        for item in fonts:
+            sudo = "yes" if item.get("requires_sudo") else "no"
+            source_type = item.get("source_type")
+            version = item.get("latest_version") or item.get("candidate_version") or "unknown"
+            lines.append(f"  - {item.get('label')}: {item.get('state')} ({source_type}) -> {item.get('target')}")
+            lines.append(f"    version: installed={item.get('installed_version') or 'unknown'} latest/candidate={version}")
+            if item.get("cache_path"):
+                lines.append(f"    cache: {item.get('cache_path')}")
+            lines.append(f"    terminal face: {item.get('terminal_face') or 'n/a'}")
+            lines.append(f"    sudo: {sudo}; host: {item.get('host_action')}")
+            lines.append(f"    terminal: {item.get('terminal_impact')}")
+
+    tool_checks = extra.get("tool_checks") or []
+    if tool_checks:
+        lines.append("tool checks:")
+        for item in tool_checks:
+            path = item.get("path")
+            location = f" ({path})" if path else ""
+            bootstrap = " bootstrap" if item.get("bootstrap") else ""
+            hint = f" - {item.get('install_hint')}" if item.get("state") == "missing" else ""
+            lines.append(f"  - {item.get('command')}: {item.get('state')}{location}{bootstrap}{hint}")
+
+    auth_guidance = extra.get("auth_guidance") or []
+    if auth_guidance:
+        lines.append("auth/setup guidance:")
+        for item in auth_guidance:
+            if item.get("state") == "available":
+                lines.append(f"  - {item.get('command')}: {item.get('guidance')}")
+            else:
+                lines.append(f"  - {item.get('tool')}: install tool before auth setup")

--- a/setup
+++ b/setup
@@ -3,7 +3,10 @@
 # Wraps `dotfiles_tools` with sensible defaults so a project in any folder can
 # bootstrap or verify its agent docs without remembering the long CLI form.
 #
-# Usage: ./setup <subcommand> [flags]
+# Usage: ./setup [project-path]
+#        ./setup <subcommand> [flags]
+#   (no args) prepare/check this computer
+#   /path/to/project
 #   verify [--project PATH] [--copilot]
 #   init   [--project PATH] [--vars FILE] [--copilot] [--yes]
 #   doctor [--home PATH] [--profile NAME]
@@ -32,7 +35,18 @@ DOTFILES_REPO="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$SCRIPT_PATH") <command> [flags]
+Usage: $(basename "$SCRIPT_PATH") [project-path]
+       $(basename "$SCRIPT_PATH") <command> [flags]
+
+Default:
+  (no args)
+      Prepare/check this computer. Ensures uv is available first, audits the
+      machine profile, prints a concise change summary including fonts, then
+      offers apply/details choices.
+
+  /path/to/project
+      Inspect or prepare a separate project folder for project agent docs.
+      Inferred project metadata is stored in <project>/.dotfiles/project-vars.json.
 
 Commands:
   verify [--project PATH] [--copilot]
@@ -41,8 +55,9 @@ Commands:
 
   init   [--project PATH] [--vars FILE] [--copilot] [--yes]
       Bootstrap a project's agent docs by wrapping
-      'dotfiles_tools init-project'. Auto-discovers project-vars.json in
-      <project>/ or <project>/.dotfiles/ when --vars is omitted.
+      'dotfiles_tools init-project'. When --vars is omitted, auto-discovers
+      project-vars.json in <project>/ or <project>/.dotfiles/, then falls back
+      to inferred defaults from common project files.
 
   doctor [--home PATH] [--profile NAME]
       Audit a machine home directory by wrapping 'dotfiles_tools doctor'.
@@ -58,12 +73,63 @@ EOF
 
 die() { echo "ERROR: $*" >&2; exit 2; }
 
+GENERATED_VARS_FILE=""
+UV_BOOTSTRAPPED=0
+cleanup_generated_vars() {
+  if [[ -n "${GENERATED_VARS_FILE:-}" && -f "$GENERATED_VARS_FILE" ]]; then
+    rm -f "$GENERATED_VARS_FILE"
+  fi
+}
+trap cleanup_generated_vars EXIT
+
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "'$1' not found in PATH"
 }
 
+refresh_uv_path() {
+  export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+}
+
+install_uv() {
+  echo "uv is required before dotfiles_tools can run."
+  if command -v curl >/dev/null 2>&1; then
+    echo "Installing uv with official standalone installer (curl)."
+    curl -LsSf https://astral.sh/uv/install.sh | sh || die "uv installer failed"
+  elif command -v wget >/dev/null 2>&1; then
+    echo "Installing uv with official standalone installer (wget)."
+    wget -qO- https://astral.sh/uv/install.sh | sh || die "uv installer failed"
+  else
+    die "uv is missing and neither curl nor wget is available to run the official installer"
+  fi
+  refresh_uv_path
+}
+
+ensure_uv() {
+  [[ "$UV_BOOTSTRAPPED" -eq 1 ]] && return 0
+
+  if command -v uv >/dev/null 2>&1; then
+    echo "uv found at $(command -v uv)"
+    if uv self update; then
+      echo "uv self update completed."
+    else
+      echo "WARN: uv self update failed or is unsupported for this installation; continuing with the existing uv." >&2
+    fi
+  else
+    install_uv
+  fi
+
+  if ! command -v uv >/dev/null 2>&1; then
+    die "uv is still not available after PATH refresh"
+  fi
+
+  local uv_version
+  uv_version="$(uv --version)" || die "uv is present but uv --version failed"
+  echo "Using $uv_version"
+  UV_BOOTSTRAPPED=1
+}
+
 preflight_common() {
-  require_cmd uv
+  ensure_uv
   [[ -f "$DOTFILES_REPO/dotfiles-manifest.json" ]] \
     || die "manifest missing at $DOTFILES_REPO/dotfiles-manifest.json"
 }
@@ -79,24 +145,6 @@ resolve_project() {
   (cd "$raw" && pwd)
 }
 
-print_vars_example() {
-  cat >&2 <<'EOF'
-ERROR: no project-vars.json found.
-Create one at <project>/project-vars.json (or <project>/.dotfiles/project-vars.json):
-
-  {
-    "PROJECT_NAME": "my-app",
-    "PROJECT_DESCRIPTION": "what this project does",
-    "LANGUAGE": "Python 3.12",
-    "PACKAGE_MANAGER": "uv",
-    "RUNTIME_DESCRIPTION": "local CLI",
-    "INSTALL_CMD": "uv sync",
-    "RUN_CMD": "uv run python -m myapp",
-    "TEST_CMD": "uv run pytest"
-  }
-EOF
-}
-
 find_vars_file() {
   local project="$1"
   local candidate
@@ -107,6 +155,171 @@ find_vars_file() {
     fi
   done
   return 1
+}
+
+infer_vars_file() {
+  local project="$1"
+  local vars_file
+  vars_file="$(mktemp "${TMPDIR:-/tmp}/dotfiles-project-vars.XXXXXX.json")" || return 1
+  GENERATED_VARS_FILE="$vars_file"
+
+  (cd "$DOTFILES_REPO" && uv run python - "$project" "$vars_file" <<'PY')
+import json
+import sys
+from pathlib import Path
+
+project = Path(sys.argv[1])
+output = Path(sys.argv[2])
+
+
+def read_json(path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def read_pyproject(path):
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return {}
+    try:
+        return tomllib.loads(path.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def readme_description():
+    for name in ("README.md", "README.rst", "README.txt"):
+        path = project / name
+        if not path.is_file():
+            continue
+        for line in path.read_text(errors="ignore").splitlines():
+            text = line.strip().strip("#").strip()
+            if text and not text.startswith(("!", "[", "<!--")):
+                return text.rstrip(".")
+    return ""
+
+
+def has_any(*names):
+    return any((project / name).exists() for name in names)
+
+
+def noop(label):
+    return f"true  # no {label} command configured yet"
+
+
+name = project.name or "project"
+description = readme_description()
+language = "Not detected"
+package_manager = "not specified"
+runtime = "local project"
+install_cmd = noop("install")
+run_cmd = noop("run")
+test_cmd = noop("test")
+
+package_json = read_json(project / "package.json")
+pyproject = read_pyproject(project / "pyproject.toml")
+
+if package_json:
+    name = str(package_json.get("name") or name)
+    description = str(package_json.get("description") or description)
+    deps = {
+        **(package_json.get("dependencies") or {}),
+        **(package_json.get("devDependencies") or {}),
+    }
+    language = "TypeScript" if has_any("tsconfig.json") or "typescript" in deps else "JavaScript"
+    if has_any("pnpm-lock.yaml"):
+        package_manager = "pnpm"
+    elif has_any("yarn.lock"):
+        package_manager = "yarn"
+    else:
+        package_manager = "npm"
+    runtime = "Node.js project"
+    scripts = package_json.get("scripts") or {}
+    install_cmd = f"{package_manager} install"
+    if "dev" in scripts:
+        run_cmd = f"{package_manager} run dev"
+    elif "start" in scripts:
+        run_cmd = f"{package_manager} start"
+    if "test" in scripts and "no test specified" not in str(scripts["test"]).lower():
+        test_cmd = f"{package_manager} test"
+elif pyproject or has_any("requirements.txt") or any(project.glob("*.py")):
+    project_table = pyproject.get("project") or {}
+    name = str(project_table.get("name") or name)
+    description = str(project_table.get("description") or description)
+    language = "Python"
+    package_manager = "uv" if pyproject or has_any("uv.lock") else "pip"
+    runtime = "Python project"
+    install_cmd = "uv sync" if package_manager == "uv" else "python -m pip install -r requirements.txt"
+    scripts = project_table.get("scripts") or {}
+    if scripts:
+        run_cmd = f"uv run {next(iter(scripts))}"
+    elif has_any("app.py"):
+        run_cmd = "uv run python app.py"
+    elif has_any("main.py"):
+        run_cmd = "uv run python main.py"
+    if has_any("pytest.ini") or (pyproject.get("tool") or {}).get("pytest"):
+        test_cmd = "uv run pytest"
+    elif (project / "tests").is_dir():
+        test_cmd = "uv run python -m unittest discover -s tests"
+elif has_any("Cargo.toml"):
+    language = "Rust"
+    package_manager = "cargo"
+    runtime = "Rust project"
+    install_cmd = "cargo build"
+    run_cmd = "cargo run"
+    test_cmd = "cargo test"
+elif has_any("go.mod"):
+    language = "Go"
+    package_manager = "go"
+    runtime = "Go module"
+    install_cmd = "go mod download"
+    run_cmd = "go run ./..."
+    test_cmd = "go test ./..."
+elif has_any("Makefile", "makefile"):
+    package_manager = "make"
+    runtime = "Makefile-driven project"
+    install_cmd = "make"
+    run_cmd = "make run"
+    test_cmd = "make test"
+
+if not description:
+    description = "local project workspace"
+
+output.write_text(json.dumps({
+    "PROJECT_NAME": name,
+    "PROJECT_DESCRIPTION": description,
+    "LANGUAGE": language,
+    "PACKAGE_MANAGER": package_manager,
+    "RUNTIME_DESCRIPTION": runtime,
+    "INSTALL_CMD": install_cmd,
+    "RUN_CMD": run_cmd,
+    "TEST_CMD": test_cmd,
+}, indent=2) + "\n")
+PY
+
+  echo "$vars_file"
+}
+
+persist_inferred_vars_file() {
+  local project="$1"
+  local vars_file target_dir target
+  vars_file="$(infer_vars_file "$project")" || return 1
+  target_dir="$project/.dotfiles"
+  target="$target_dir/project-vars.json"
+  mkdir -p "$target_dir"
+  cp "$vars_file" "$target"
+  echo "$target"
+}
+
+resolve_project_vars_file() {
+  local project="$1"
+  if find_vars_file "$project"; then
+    return 0
+  fi
+  persist_inferred_vars_file "$project"
 }
 
 check_placeholders() {
@@ -187,7 +400,7 @@ cmd_verify() {
 }
 
 cmd_init() {
-  local project="" vars="" copilot=0 yes=0
+  local project="" vars="" vars_source="" copilot=0 yes=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --project) project="${2:?--project requires a path}"; shift 2 ;;
@@ -203,12 +416,27 @@ cmd_init() {
   project="$(resolve_project "${project:-$PWD}")"
 
   if [[ -z "$vars" ]]; then
-    vars="$(find_vars_file "$project")" || { print_vars_example; return 2; }
+    if vars="$(find_vars_file "$project")"; then
+      vars_source="discovered"
+    elif [[ "$yes" -eq 1 ]]; then
+      vars="$(persist_inferred_vars_file "$project")" || die "failed to infer project defaults for: $project"
+      vars_source="inferred-persisted"
+    else
+      vars="$(infer_vars_file "$project")" || die "failed to infer project defaults for: $project"
+      vars_source="inferred"
+    fi
+  else
+    vars_source="provided"
   fi
   [[ -f "$vars" ]] || die "vars file not found: $vars"
 
   echo "Bootstrapping project: $project"
-  echo "Using vars file: $vars"
+  case "$vars_source" in
+    inferred) echo "Using inferred project defaults (override with --vars or project-vars.json)." ;;
+    inferred-persisted) echo "Using inferred project defaults saved to: $vars" ;;
+    discovered) echo "Using discovered vars file: $vars" ;;
+    *) echo "Using vars file: $vars" ;;
+  esac
 
   local cli_args=(--repo "$DOTFILES_REPO" --project "$project" --vars "$vars")
   [[ "$copilot" -eq 1 ]] && cli_args+=(--copilot)
@@ -239,10 +467,205 @@ cmd_doctor() {
     --profile "${profile:-machine}")
 }
 
+run_machine_doctor() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools doctor \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --profile machine)
+}
+
+run_machine_plan() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-plan \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --profile machine)
+}
+
+run_machine_apply() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-apply \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --profile machine \
+    --backup-dir "$HOME/.dotfiles-backups" \
+    --yes)
+}
+
+run_machine_summary() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --profile machine)
+}
+
+run_machine_menu_label() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --profile machine \
+    --menu-label)
+}
+
+run_machine_details() {
+  echo "Full machine doctor:"
+  run_machine_doctor
+  echo
+  echo "Full machine plan:"
+  run_machine_plan
+}
+
+show_tool_auth_commands() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.baseline)
+}
+
+machine_menu() {
+  local option_one="${1:-Apply safe non-protected dotfiles and approved install/update recipes.}"
+  while true; do
+    cat <<EOF
+
+Next steps:
+  1. $option_one
+  2. Show full technical details.
+  3. Show tool and sign-in guidance.
+  4. Exit without writing.
+EOF
+    printf 'Choose [1-4]: '
+    local choice
+    if ! read -r choice; then
+      echo
+      echo "No interactive selection received; no changes applied."
+      return 0
+    fi
+    case "$choice" in
+      1)
+        echo
+        echo "Applying safe non-protected machine dotfiles and approved install/update recipes..."
+        run_machine_apply
+        return $?
+        ;;
+      2)
+        echo
+        run_machine_details
+        ;;
+      3)
+        echo
+        show_tool_auth_commands
+        ;;
+      4|"")
+        echo "No changes applied."
+        return 0
+        ;;
+      *)
+        echo "Unknown choice: $choice" >&2
+        ;;
+    esac
+  done
+}
+
+cmd_machine_setup() {
+  preflight_common
+  echo "Preparing/checking this computer with profile: machine"
+  echo
+  run_machine_summary
+  local option_one
+  if ! option_one="$(run_machine_menu_label)" || [[ -z "$option_one" ]]; then
+    option_one="Apply safe non-protected dotfiles and approved install/update recipes."
+  fi
+  machine_menu "$option_one"
+}
+
+project_is_empty() {
+  local project="$1"
+  [[ -z "$(find "$project" -mindepth 1 -maxdepth 1 -print -quit)" ]]
+}
+
+show_project_vars() {
+  local vars="$1"
+  echo "Project metadata: $vars"
+  sed -n '1,200p' "$vars"
+}
+
+empty_project_menu() {
+  local project="$1" vars="$2"
+  while true; do
+    cat <<EOF
+
+Project setup options:
+  1. Bootstrap AGENTS.md plus CLAUDE.md/GEMINI.md symlinks.
+  2. Bootstrap agent docs plus Copilot instructions.
+  3. Show inferred project metadata.
+  4. Exit.
+EOF
+    printf 'Choose [1-4]: '
+    local choice
+    if ! read -r choice; then
+      echo
+      echo "No interactive selection received; project files were not changed."
+      return 0
+    fi
+    case "$choice" in
+      1) cmd_init --project "$project" --vars "$vars" --yes; return $? ;;
+      2) cmd_init --project "$project" --vars "$vars" --copilot --yes; return $? ;;
+      3) show_project_vars "$vars" ;;
+      4|"") echo "Project files were not changed."; return 0 ;;
+      *) echo "Unknown choice: $choice" >&2 ;;
+    esac
+  done
+}
+
+existing_project_menu() {
+  local project="$1" vars="$2"
+  while true; do
+    cat <<EOF
+
+Project setup options:
+  1. Verify agent docs.
+  2. Repair/bootstrap AGENTS.md plus CLAUDE.md/GEMINI.md symlinks.
+  3. Add or refresh Copilot instructions.
+  4. Show project metadata.
+  5. Exit.
+EOF
+    printf 'Choose [1-5]: '
+    local choice
+    if ! read -r choice; then
+      echo
+      echo "No interactive selection received; project files were not changed."
+      return 0
+    fi
+    case "$choice" in
+      1) cmd_verify --project "$project" || true ;;
+      2) cmd_init --project "$project" --vars "$vars" --yes; return $? ;;
+      3) cmd_init --project "$project" --vars "$vars" --copilot --yes; return $? ;;
+      4) show_project_vars "$vars" ;;
+      5|"") echo "Project files were not changed."; return 0 ;;
+      *) echo "Unknown choice: $choice" >&2 ;;
+    esac
+  done
+}
+
+cmd_project_folder() {
+  local project="$1" was_empty=0 vars
+  project="$(resolve_project "$project")"
+  project_is_empty "$project" && was_empty=1
+  preflight_common
+  preflight_project_templates
+  vars="$(resolve_project_vars_file "$project")" || die "failed to resolve project metadata for: $project"
+
+  echo "Inspecting project: $project"
+  echo "Project metadata stored at: $vars"
+  if [[ "$was_empty" -eq 1 ]]; then
+    echo "Project folder is empty; agent-doc setup is available."
+    empty_project_menu "$project" "$vars"
+  else
+    echo "Project folder has existing files; running a read-only verification first."
+    cmd_verify --project "$project" || true
+    existing_project_menu "$project" "$vars"
+  fi
+}
+
 main() {
   if [[ $# -eq 0 ]]; then
-    usage
-    return 0
+    cmd_machine_setup
+    return $?
   fi
   local sub="$1"; shift
   case "$sub" in
@@ -250,7 +673,14 @@ main() {
     init)   cmd_init "$@" ;;
     doctor) cmd_doctor "$@" ;;
     help|-h|--help) usage ;;
-    *) usage; die "unknown command: $sub" ;;
+    *)
+      if [[ $# -eq 0 && -d "$sub" ]]; then
+        cmd_project_folder "$sub"
+      else
+        usage
+        die "unknown command or project path: $sub"
+      fi
+      ;;
   esac
 }
 

--- a/specs/001-dotfiles-bootstrap-validation/contracts/cli.md
+++ b/specs/001-dotfiles-bootstrap-validation/contracts/cli.md
@@ -41,6 +41,10 @@ a stable JSON validation report with the common report shape below.
     "protected": 0,
     "invalid": 0,
     "blocked": 0,
+    "installed": 0,
+    "needs_update": 0,
+    "manual": 0,
+    "unsupported": 0,
     "operations": 0,
     "backups": 0,
     "errors": 0
@@ -136,6 +140,76 @@ JSON requirements:
 - If a write fails after earlier writes completed, `status` is `partial`,
   operations after the failed write are not executed, and errors identify the
   failed operation.
+
+## `bootstrap-plan`
+
+Prints the machine setup plan including manifest-backed dotfiles and approved
+install/update recipes such as fonts.
+
+```bash
+uv run python -m dotfiles_tools bootstrap-plan --repo . --home "$HOME" --json
+```
+
+Options:
+
+| Option | Required | Description |
+|---|---:|---|
+| `--home PATH` | Yes | Target home directory |
+| `--profile ID` | No | Manifest profile; default `machine` |
+| `--include-protected ID` | No | Exact protected manifest entry ID to include; repeatable |
+
+JSON requirements:
+- `entries[]` includes normal manifest entries plus recipe entries.
+- Font recipe entries use states such as `missing`, `installed`,
+  `needs_update`, `manual`, and `unsupported`.
+- Top-level `fonts[]` has one record per applicable catalog item. Each record
+  includes `family`, `source_type`, `state`, `installed_version`,
+  `latest_version` for Nerd Font assets or `candidate_version` for apt
+  packages, `target`, and `terminal_face`.
+
+## `bootstrap-apply`
+
+Applies the combined machine bootstrap plan after explicit approval.
+
+```bash
+uv run python -m dotfiles_tools bootstrap-apply --repo . --home "$HOME" --yes
+uv run python -m dotfiles_tools bootstrap-apply --repo . --home "$HOME" --backup-dir "$HOME/.dotfiles-backups" --yes --json
+```
+
+Options:
+
+| Option | Required | Description |
+|---|---:|---|
+| `--home PATH` | Yes | Target home directory |
+| `--profile ID` | No | Manifest profile; default `machine` |
+| `--backup-dir PATH` | No | Backup directory; defaults to `<home>/.dotfiles-backups` |
+| `--yes` | Yes for writes | Approval flag required before any write |
+| `--include-protected ID` | No | Exact protected manifest entry ID to include; repeatable |
+
+Font recipe requirements:
+- Standard Ubuntu-style Linux plans `JetBrainsMono.zip`, `FiraCode.zip`,
+  `Hack.zip`, and `Meslo.zip` from the latest Nerd Fonts release and installs
+  each family under `~/.local/share/fonts/`.
+- Terminal checks and generated settings always use `* Nerd Font Mono` faces;
+  Propo faces may be installed from the full archives but are never selected
+  for terminal configuration.
+- Apt package records use `dpkg-query` for `installed_version` and
+  `apt-cache policy` for `candidate_version`; missing or stale packages are
+  installed with `apt-get install -y`.
+- Standard Ubuntu-style Linux installs or updates `fonts-noto-color-emoji`,
+  `fonts-symbola`, `fonts-freefont-ttf`, and `fonts-dejavu-core`.
+- In WSL, all Nerd Font families are installed Linux-side. PowerShell Windows
+  host installation is limited to JetBrainsMono Nerd Font Mono and Windows
+  Terminal is updated only when the settings JSON is discoverable.
+- On Raspberry Pi, all four Nerd Font families are installed with Noto Color
+  Emoji, Symbola, and FreeFont apt fallbacks, and `MesloLGS Nerd Font Mono` is
+  verified through fontconfig when available.
+- On Pixel Terminal, backs up ttyd HTML/service files before sudo writes and
+  orders systemd daemon reload before service restart. The embedded `JBMono NF`
+  face is a subset/alias of JetBrainsMono Nerd Font Mono, and
+  `fonts-noto-color-emoji` is installed through apt.
+- On Pixel AVF, skips Tide/Nerd Font UI setup and writes a plain prompt
+  fallback instead.
 
 ## `init-project`
 

--- a/tests/test_doctor_reports.py
+++ b/tests/test_doctor_reports.py
@@ -16,3 +16,12 @@ class DoctorReportTests(DotfilesTestCase):
         self.assertEqual(states["claude.settings"], "drifted")
         self.assertEqual(states["git.config"], "protected")
         self.assertIn("summary", data)
+
+    def test_machine_doctor_includes_tool_and_auth_guidance(self):
+        home = self.make_home()
+        report = run_doctor(REPO_ROOT, home)
+        data = json.loads(report.to_json())
+        tool_ids = {item["id"] for item in data["tool_checks"]}
+        self.assertGreaterEqual(tool_ids, {"uv", "git", "gh", "fish", "direnv", "codex", "claude", "gemini"})
+        auth_commands = {item["command"] for item in data["auth_guidance"]}
+        self.assertIn("gh auth status", auth_commands)

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import zipfile
+
+from dotfiles_tools.bootstrap import build_bootstrap_plan
+from dotfiles_tools.fonts import (
+    APT_FONT_CATALOG,
+    EXPECTED_TTF,
+    FONT_FACE,
+    FONT_INSTALL_REL,
+    FontError,
+    NERD_FONT_CATALOG,
+    build_font_plan,
+    execute_font_operation,
+    select_nerd_font_asset,
+)
+from tests.helpers import DotfilesTestCase, REPO_ROOT
+
+
+def release_inventory(tag: str = "v3.4.0") -> dict:
+    return {
+        "tag_name": tag,
+        "assets": [
+            {
+                "name": item.asset_name,
+                "browser_download_url": f"https://example/{item.asset_name}",
+                "size": 12,
+            }
+            for item in NERD_FONT_CATALOG
+        ],
+    }
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        which: dict[str, str] | None = None,
+        release: dict | None = None,
+        fail_fetch: bool = False,
+        apt_installed: dict[str, str | None] | None = None,
+        apt_candidate: dict[str, str | None] | None = None,
+    ) -> None:
+        self.which_map = which or {}
+        self.release = release or release_inventory("v0.test")
+        self.fail_fetch = fail_fetch
+        self.apt_installed = apt_installed or {}
+        self.apt_candidate = apt_candidate or {}
+        self.commands: list[list[str]] = []
+        self.fetches: list[str] = []
+        self.downloads: list[tuple[str, Path]] = []
+
+    def which(self, command: str) -> str | None:
+        return self.which_map.get(command)
+
+    def fetch_json(self, url: str) -> dict:
+        self.fetches.append(url)
+        if self.fail_fetch:
+            raise OSError("offline")
+        return self.release
+
+    def download(self, url: str, target: Path) -> None:
+        self.downloads.append((url, target))
+        asset_name = Path(target).name
+        item = next(item for item in NERD_FONT_CATALOG if item.asset_name == asset_name)
+        write_font_zip(target, item.expected_regular)
+
+    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+        self.commands.append(args)
+        command = Path(args[0]).name
+        if command == "fc-match":
+            face = args[1]
+            return subprocess.CompletedProcess(args, 0, stdout=f"{face.replace(' ', '')}-Regular.ttf: \"{face}\"\n", stderr="")
+        if command == "wslpath":
+            return subprocess.CompletedProcess(args, 0, stdout="C:\\Users\\kkk\\Fonts\n", stderr="")
+        if command == "dpkg-query":
+            package = args[-1]
+            version = self.apt_installed.get(package)
+            return subprocess.CompletedProcess(args, 0 if version else 1, stdout=version or "", stderr="")
+        if command == "apt-cache":
+            package = args[-1]
+            candidate = self.apt_candidate.get(package)
+            stdout = f"{package}:\n  Installed: (none)\n  Candidate: {candidate or '(none)'}\n"
+            return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+def write_font_zip(path: Path, expected_regular: str = EXPECTED_TTF) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as bundle:
+        bundle.writestr(expected_regular, b"fake-font")
+        bundle.writestr(expected_regular.replace("Regular", "Bold"), b"fake-bold")
+        bundle.writestr(expected_regular.replace("Mono", "Propo"), b"fake-propo")
+
+
+class FontCatalogTests(DotfilesTestCase):
+    def apt_runner(self, installed: dict[str, str | None] | None = None, candidate: dict[str, str | None] | None = None) -> FakeRunner:
+        return FakeRunner(
+            which={
+                "dpkg-query": "/usr/bin/dpkg-query",
+                "apt-cache": "/usr/bin/apt-cache",
+                "apt-get": "/usr/bin/apt-get",
+                "fc-cache": "/usr/bin/fc-cache",
+                "fc-match": "/usr/bin/fc-match",
+            },
+            release=release_inventory(),
+            apt_installed=installed or {},
+            apt_candidate=candidate or {},
+        )
+
+    def test_selects_each_nerd_font_asset_from_release_json(self) -> None:
+        release = release_inventory()
+
+        assets = {item.asset_name: select_nerd_font_asset(release, item.asset_name) for item in NERD_FONT_CATALOG}
+
+        self.assertEqual(assets["JetBrainsMono.zip"]["tag_name"], "v3.4.0")
+        self.assertEqual(assets["Meslo.zip"]["browser_download_url"], "https://example/Meslo.zip")
+
+    def test_asset_selection_fails_when_release_has_no_font_zip(self) -> None:
+        with self.assertRaises(FontError):
+            select_nerd_font_asset({"assets": [{"name": "Other.zip", "browser_download_url": "https://example/Other.zip"}]})
+
+    def test_standard_linux_plan_represents_all_catalog_items_when_missing(self) -> None:
+        home = self.make_home()
+        packages = {item["package"] for item in APT_FONT_CATALOG}
+        runner = self.apt_runner(candidate={package: "1.0" for package in packages})
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+        fonts = plan["fonts"]
+
+        self.assertEqual({item["asset_name"] for item in fonts if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual({item["package"] for item in fonts if item["source_type"] == "apt_package"}, packages)
+        self.assertTrue(all(item["latest_version"] == "v3.4.0" for item in fonts if item["source_type"] == "nerd_font_release"))
+        self.assertTrue(all(item["candidate_version"] == "1.0" for item in fonts if item["source_type"] == "apt_package"))
+        self.assertEqual({op["asset_name"] for op in plan["operations"] if op["type"] == "font_download"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual({op["packages"][0] for op in plan["operations"] if op["type"] == "font_install_packages"}, packages)
+
+    def test_linux_font_install_reuses_cached_archives_extracts_installs_and_verifies_mono_faces(self) -> None:
+        home = self.make_home()
+        for item in NERD_FONT_CATALOG:
+            archive = home / ".cache/000-dotfiles/fonts" / item.asset_name
+            write_font_zip(archive, item.expected_regular)
+        runner = FakeRunner(which={"fc-cache": "/usr/bin/fc-cache", "fc-match": "/usr/bin/fc-match"}, fail_fetch=True)
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+
+        for op in plan["operations"]:
+            execute_font_operation(op, runner=runner, backup_dir=home / "backups", backups=[])
+
+        self.assertTrue((home / FONT_INSTALL_REL / EXPECTED_TTF).exists())
+        for item in NERD_FONT_CATALOG:
+            self.assertTrue((home / ".local/share/fonts" / item.install_dir_name / item.expected_regular).exists())
+        verify_faces = [args[1] for args in runner.commands if Path(args[0]).name == "fc-match"]
+        self.assertIn(FONT_FACE, verify_faces)
+        self.assertIn("MesloLGS Nerd Font Mono", verify_faces)
+        self.assertTrue(all("Propo" not in face for face in verify_faces))
+        self.assertEqual(runner.downloads, [])
+
+    def test_apt_package_states_cover_missing_current_and_needs_update(self) -> None:
+        home = self.make_home()
+        runner = self.apt_runner(
+            installed={
+                "fonts-noto-color-emoji": "1.0",
+                "fonts-symbola": None,
+                "fonts-freefont-ttf": "1.0",
+                "fonts-dejavu-core": "2.0",
+            },
+            candidate={
+                "fonts-noto-color-emoji": "1.0",
+                "fonts-symbola": "2.0",
+                "fonts-freefont-ttf": "1.1",
+                "fonts-dejavu-core": "2.0",
+            },
+        )
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+        states = {item["package"]: item["state"] for item in plan["fonts"] if item["source_type"] == "apt_package"}
+
+        self.assertEqual(states["fonts-noto-color-emoji"], "installed")
+        self.assertEqual(states["fonts-symbola"], "missing")
+        self.assertEqual(states["fonts-freefont-ttf"], "needs_update")
+        self.assertEqual(states["fonts-dejavu-core"], "installed")
+        self.assertEqual(
+            {op["packages"][0] for op in plan["operations"] if op["type"] == "font_install_packages"},
+            {"fonts-symbola", "fonts-freefont-ttf"},
+        )
+
+    def test_wsl_plans_all_linux_fonts_and_windows_terminal_mono_update_when_detected(self) -> None:
+        home = self.make_home()
+        install_dir = home / FONT_INSTALL_REL
+        install_dir.mkdir(parents=True)
+        (install_dir / EXPECTED_TTF).write_text("font")
+        settings = home / "windows-terminal-settings.json"
+        settings.write_text('{"profiles": {"defaults": {}}}')
+        env = {"DOTFILES_PLATFORM": "wsl", "DOTFILES_WINDOWS_TERMINAL_SETTINGS": str(settings)}
+        runner = FakeRunner(
+            which={
+                "powershell.exe": "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+                "wslpath": "/usr/bin/wslpath",
+            },
+            release=release_inventory(),
+        )
+
+        plan = build_font_plan(home, env=env, path="", runner=runner)
+        op_types = [op["type"] for op in plan["operations"]]
+
+        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertIn("font_install_windows", op_types)
+        terminal_update = next(op for op in plan["operations"] if op["type"] == "font_update_windows_terminal")
+        self.assertEqual(terminal_update["source"], FONT_FACE)
+        self.assertNotIn("Propo", terminal_update["source"])
+
+        manual_plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "wsl"}, path="", runner=FakeRunner(release=release_inventory()))
+        manual_types = [op["type"] for op in manual_plan["operations"]]
+        self.assertIn("font_manual", manual_types)
+        self.assertNotIn("font_update_windows_terminal", manual_types)
+
+    def test_pi_plans_full_nerd_inventory_symbol_fallbacks_and_meslo_mono_verify(self) -> None:
+        home = self.make_home()
+        runner = self.apt_runner(candidate={item["package"]: "1.0" for item in APT_FONT_CATALOG})
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "pi"}, path="", runner=runner)
+
+        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual(
+            {item["package"] for item in plan["fonts"] if item["source_type"] == "apt_package"},
+            {"fonts-noto-color-emoji", "fonts-symbola", "fonts-freefont-ttf"},
+        )
+        self.assertIn(
+            "MesloLGS Nerd Font Mono",
+            [op.get("terminal_face") for op in plan["operations"] if op["type"] == "font_verify_linux"],
+        )
+
+    def test_pixel_terminal_embeds_jetbrains_mono_subset_and_only_noto_emoji_package(self) -> None:
+        home = self.make_home()
+        runner = self.apt_runner(candidate={item["package"]: "1.0" for item in APT_FONT_CATALOG})
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "pixel-terminal"}, path="", runner=runner)
+        op_types = [op["type"] for op in plan["operations"]]
+
+        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {"JetBrainsMono.zip"})
+        self.assertEqual({item["package"] for item in plan["fonts"] if item["source_type"] == "apt_package"}, {"fonts-noto-color-emoji"})
+        self.assertLess(op_types.index("font_ttyd_write_html"), op_types.index("font_ttyd_write_service"))
+        self.assertLess(op_types.index("font_ttyd_write_service"), op_types.index("font_systemd_daemon_reload"))
+        self.assertLess(op_types.index("font_systemd_daemon_reload"), op_types.index("font_systemd_restart"))
+        self.assertEqual(next(item for item in plan["fonts"] if item["entry_id"] == "fonts.jetbrains-mono-nerd")["embedded_alias"], "JBMono NF")
+
+    def test_pixel_avf_skips_nerd_font_install_and_plans_prompt_fallback(self) -> None:
+        home = self.make_home()
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "pixel-avf"}, path="", runner=FakeRunner())
+        states = {entry["entry_id"]: entry["state"] for entry in plan["entries"]}
+        op_types = [op["type"] for op in plan["operations"]]
+
+        self.assertEqual(states["fonts.jetbrains-mono-nerd"], "unsupported")
+        self.assertNotIn("font_download", op_types)
+        self.assertIn("font_pixel_avf_prompt", op_types)
+
+    def test_verify_operation_rejects_propo_terminal_faces(self) -> None:
+        with self.assertRaises(FontError):
+            execute_font_operation(
+                {"type": "font_verify_linux", "target": "", "terminal_face": "Hack Nerd Font Propo", "family": "Hack"},
+                runner=FakeRunner(which={"fc-match": "/usr/bin/fc-match"}),
+            )
+
+    def test_bootstrap_plan_json_surface_includes_font_catalog_records(self) -> None:
+        home = self.make_home()
+        packages = {item["package"] for item in APT_FONT_CATALOG}
+        runner = self.apt_runner(candidate={package: "1.0" for package in packages})
+        report = build_bootstrap_plan(REPO_ROOT, home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+        data = report.to_dict()
+
+        self.assertEqual(data["command"], "bootstrap-plan")
+        self.assertIn("fonts", data)
+        self.assertEqual(len(data["fonts"]), len(NERD_FONT_CATALOG) + len(APT_FONT_CATALOG))
+        first = data["fonts"][0]
+        for key in ("family", "source_type", "state", "installed_version", "target", "terminal_face"):
+            self.assertIn(key, first)
+        self.assertIn("font_download", {op["type"] for op in data["operations"]})

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -95,6 +95,26 @@ def write_font_zip(path: Path, expected_regular: str = EXPECTED_TTF) -> None:
         bundle.writestr(expected_regular.replace("Mono", "Propo"), b"fake-propo")
 
 
+def font_values(fonts: list[dict], source_type: str, key: str) -> set:
+    return {item[key] for item in fonts if item["source_type"] == source_type}
+
+
+def operation_values(operations: list[dict], op_type: str, key: str) -> set:
+    return {op[key] for op in operations if op["type"] == op_type}
+
+
+def operation_packages(operations: list[dict]) -> set:
+    return {op["packages"][0] for op in operations if op["type"] == "font_install_packages"}
+
+
+def operation_terminal_faces(operations: list[dict], op_type: str) -> list:
+    return [op.get("terminal_face") for op in operations if op["type"] == op_type]
+
+
+def font_by_entry(fonts: list[dict], entry_id: str) -> dict:
+    return next(item for item in fonts if item["entry_id"] == entry_id)
+
+
 class FontCatalogTests(DotfilesTestCase):
     def apt_runner(self, installed: dict[str, str | None] | None = None, candidate: dict[str, str | None] | None = None) -> FakeRunner:
         return FakeRunner(
@@ -130,12 +150,12 @@ class FontCatalogTests(DotfilesTestCase):
         plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
         fonts = plan["fonts"]
 
-        self.assertEqual({item["asset_name"] for item in fonts if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
-        self.assertEqual({item["package"] for item in fonts if item["source_type"] == "apt_package"}, packages)
-        self.assertTrue(all(item["latest_version"] == "v3.4.0" for item in fonts if item["source_type"] == "nerd_font_release"))
-        self.assertTrue(all(item["candidate_version"] == "1.0" for item in fonts if item["source_type"] == "apt_package"))
-        self.assertEqual({op["asset_name"] for op in plan["operations"] if op["type"] == "font_download"}, {item.asset_name for item in NERD_FONT_CATALOG})
-        self.assertEqual({op["packages"][0] for op in plan["operations"] if op["type"] == "font_install_packages"}, packages)
+        self.assertEqual(font_values(fonts, "nerd_font_release", "asset_name"), {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual(font_values(fonts, "apt_package", "package"), packages)
+        self.assertEqual(font_values(fonts, "nerd_font_release", "latest_version"), {"v3.4.0"})
+        self.assertEqual(font_values(fonts, "apt_package", "candidate_version"), {"1.0"})
+        self.assertEqual(operation_values(plan["operations"], "font_download", "asset_name"), {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual(operation_packages(plan["operations"]), packages)
 
     def test_linux_font_install_reuses_cached_archives_extracts_installs_and_verifies_mono_faces(self) -> None:
         home = self.make_home()
@@ -182,7 +202,7 @@ class FontCatalogTests(DotfilesTestCase):
         self.assertEqual(states["fonts-freefont-ttf"], "needs_update")
         self.assertEqual(states["fonts-dejavu-core"], "installed")
         self.assertEqual(
-            {op["packages"][0] for op in plan["operations"] if op["type"] == "font_install_packages"},
+            operation_packages(plan["operations"]),
             {"fonts-symbola", "fonts-freefont-ttf"},
         )
 
@@ -205,7 +225,7 @@ class FontCatalogTests(DotfilesTestCase):
         plan = build_font_plan(home, env=env, path="", runner=runner)
         op_types = [op["type"] for op in plan["operations"]]
 
-        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual(font_values(plan["fonts"], "nerd_font_release", "asset_name"), {item.asset_name for item in NERD_FONT_CATALOG})
         self.assertIn("font_install_windows", op_types)
         terminal_update = next(op for op in plan["operations"] if op["type"] == "font_update_windows_terminal")
         self.assertEqual(terminal_update["source"], FONT_FACE)
@@ -222,14 +242,14 @@ class FontCatalogTests(DotfilesTestCase):
 
         plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "pi"}, path="", runner=runner)
 
-        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {item.asset_name for item in NERD_FONT_CATALOG})
+        self.assertEqual(font_values(plan["fonts"], "nerd_font_release", "asset_name"), {item.asset_name for item in NERD_FONT_CATALOG})
         self.assertEqual(
-            {item["package"] for item in plan["fonts"] if item["source_type"] == "apt_package"},
+            font_values(plan["fonts"], "apt_package", "package"),
             {"fonts-noto-color-emoji", "fonts-symbola", "fonts-freefont-ttf"},
         )
         self.assertIn(
             "MesloLGS Nerd Font Mono",
-            [op.get("terminal_face") for op in plan["operations"] if op["type"] == "font_verify_linux"],
+            operation_terminal_faces(plan["operations"], "font_verify_linux"),
         )
 
     def test_pixel_terminal_embeds_jetbrains_mono_subset_and_only_noto_emoji_package(self) -> None:
@@ -239,12 +259,12 @@ class FontCatalogTests(DotfilesTestCase):
         plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "pixel-terminal"}, path="", runner=runner)
         op_types = [op["type"] for op in plan["operations"]]
 
-        self.assertEqual({item["asset_name"] for item in plan["fonts"] if item["source_type"] == "nerd_font_release"}, {"JetBrainsMono.zip"})
-        self.assertEqual({item["package"] for item in plan["fonts"] if item["source_type"] == "apt_package"}, {"fonts-noto-color-emoji"})
+        self.assertEqual(font_values(plan["fonts"], "nerd_font_release", "asset_name"), {"JetBrainsMono.zip"})
+        self.assertEqual(font_values(plan["fonts"], "apt_package", "package"), {"fonts-noto-color-emoji"})
         self.assertLess(op_types.index("font_ttyd_write_html"), op_types.index("font_ttyd_write_service"))
         self.assertLess(op_types.index("font_ttyd_write_service"), op_types.index("font_systemd_daemon_reload"))
         self.assertLess(op_types.index("font_systemd_daemon_reload"), op_types.index("font_systemd_restart"))
-        self.assertEqual(next(item for item in plan["fonts"] if item["entry_id"] == "fonts.jetbrains-mono-nerd")["embedded_alias"], "JBMono NF")
+        self.assertEqual(font_by_entry(plan["fonts"], "fonts.jetbrains-mono-nerd")["embedded_alias"], "JBMono NF")
 
     def test_pixel_avf_skips_nerd_font_install_and_plans_prompt_fallback(self) -> None:
         home = self.make_home()

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-import subprocess
+import subprocess  # nosec B404
 import zipfile
 
 from dotfiles_tools.bootstrap import build_bootstrap_plan

--- a/tests/test_machine_summary.py
+++ b/tests/test_machine_summary.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotfiles_tools.machine_summary import render_menu_label, render_reports
+from dotfiles_tools.reports import Report
+from tests.helpers import DotfilesTestCase, REPO_ROOT
+
+
+def doctor(home: Path, *, errors: list[dict[str, str] | str] | None = None) -> Report:
+    return Report("doctor", "warning", str(REPO_ROOT), home=str(home), profile="machine", errors=errors or [])
+
+
+def plan(
+    home: Path,
+    *,
+    entries: list[dict] | None = None,
+    operations: list[dict] | None = None,
+    fonts: list[dict] | None = None,
+    errors: list[dict[str, str] | str] | None = None,
+) -> Report:
+    return Report(
+        "bootstrap-plan",
+        "warning",
+        str(REPO_ROOT),
+        home=str(home),
+        profile="machine",
+        entries=entries or [],
+        operations=operations or [],
+        errors=errors or [],
+        extra={"fonts": fonts or []},
+    )
+
+
+def manifest_entry(entry_id: str, state: str, *, protected: bool = False, reason: str = "target differs") -> dict:
+    entry = {
+        "entry_id": entry_id,
+        "state": state,
+        "protected": protected,
+        "reason": reason,
+    }
+    if protected:
+        entry["manual_reason"] = reason
+    return entry
+
+
+def nerd_font(state: str = "missing") -> dict:
+    return {
+        "entry_id": "fonts.jetbrains-mono-nerd",
+        "label": "JetBrainsMono Nerd Font",
+        "source_type": "nerd_font_release",
+        "state": state,
+        "requires_sudo": False,
+        "reason": "font files are not installed",
+        "cache_path": "/tmp/cache/JetBrainsMono.zip",
+        "target": "/tmp/home/.local/share/fonts/JetBrainsMonoNerdFont",
+        "terminal_face": "JetBrainsMono Nerd Font Mono",
+        "terminal_impact": "Local terminals can select a Mono face.",
+    }
+
+
+def apt_font(state: str = "missing", *, package: str = "fonts-noto-color-emoji") -> dict:
+    return {
+        "entry_id": f"fonts.apt.{package.removeprefix('fonts-')}",
+        "label": "Noto Color Emoji",
+        "source_type": "apt_package",
+        "package": package,
+        "state": state,
+        "requires_sudo": state in {"missing", "needs_update"},
+        "reason": "apt package is not installed",
+        "candidate_version": "1.0",
+        "target": package,
+        "terminal_face": "Noto Color Emoji",
+        "terminal_impact": "Emoji fallback for terminals.",
+    }
+
+
+def font_entry(item: dict) -> dict:
+    return {
+        "entry_id": item["entry_id"],
+        "source_type": item["source_type"],
+        "family": item.get("label"),
+        "state": item["state"],
+        "recipe": "fonts",
+        "requires_sudo": item.get("requires_sudo", False),
+        "reason": item.get("reason", ""),
+    }
+
+
+class MachineSummaryTests(DotfilesTestCase):
+    def render(self, plan_report: Report, *, doctor_report: Report | None = None) -> str:
+        home = Path(plan_report.home or self.make_home())
+        return render_reports(doctor_report or doctor(home), plan_report, REPO_ROOT, home)
+
+    def test_summary_groups_changes_without_raw_diagnostic_dump(self) -> None:
+        home = self.make_home()
+        fonts = [nerd_font("missing"), apt_font("missing")]
+        plan_report = plan(
+            home,
+            entries=[
+                manifest_entry("claude.settings", "drifted"),
+                manifest_entry("codex.config", "missing"),
+                manifest_entry("git.config", "protected", protected=True, reason="Git config contains committer identity."),
+                *(font_entry(item) for item in fonts),
+            ],
+            operations=[
+                {"entry_id": "fonts.jetbrains-mono-nerd", "type": "font_download", "recipe": "fonts", "requires_approval": True, "requires_network": True},
+                {"entry_id": "fonts.apt.noto-color-emoji", "type": "font_install_packages", "recipe": "fonts", "requires_approval": True, "requires_sudo": True, "source_type": "apt_package"},
+            ],
+            fonts=fonts,
+        )
+
+        text = self.render(plan_report)
+
+        self.assertIn("Machine setup summary", text)
+        self.assertIn("Option 1 will:", text)
+        self.assertIn("Update existing files with backups:", text)
+        self.assertIn("~/.claude/settings.json", text)
+        self.assertIn("Create missing files:", text)
+        self.assertIn("~/.codex/config.toml", text)
+        self.assertIn("Protected/manual files:", text)
+        self.assertIn("~/.config/git/config: Git config contains committer identity.", text)
+        self.assertIn("Fonts:", text)
+        self.assertIn("Nerd Fonts:", text)
+        self.assertIn("JetBrainsMono Nerd Font: missing", text)
+        self.assertIn("Apt fallback fonts:", text)
+        self.assertIn("Noto Color Emoji [fonts-noto-color-emoji]: missing", text)
+        self.assertIn("Terminal configuration uses `Nerd Font Mono` faces, never Propo.", text)
+        self.assertIn("Full details: choose option 2", text)
+        self.assertNotIn("<- repo/", text)
+        self.assertNotIn("entries:", text)
+        self.assertNotIn("operations:", text)
+        self.assertNotIn("cache:", text)
+        self.assertNotIn("version:", text)
+        self.assertNotIn("terminal face:", text)
+        self.assertNotIn("terminal impact:", text)
+
+    def test_all_fonts_ok_collapses_to_already_ok(self) -> None:
+        home = self.make_home()
+        fonts = [nerd_font("installed"), apt_font("installed")]
+        plan_report = plan(home, entries=[font_entry(item) for item in fonts], fonts=fonts)
+
+        text = self.render(plan_report)
+
+        self.assertIn("Run no font install/update actions.", text)
+        self.assertIn("Nerd Fonts:", text)
+        self.assertIn("Apt fallback fonts:", text)
+        self.assertIn("none to install/update", text)
+        self.assertIn("Already OK:", text)
+        self.assertIn("JetBrainsMono Nerd Font", text)
+        self.assertIn("Noto Color Emoji [fonts-noto-color-emoji]", text)
+
+    def test_nerd_font_missing_shows_network_need_without_cache_metadata(self) -> None:
+        home = self.make_home()
+        fonts = [nerd_font("missing")]
+        plan_report = plan(
+            home,
+            entries=[font_entry(fonts[0])],
+            operations=[
+                {"entry_id": "fonts.jetbrains-mono-nerd", "type": "font_download", "recipe": "fonts", "requires_approval": True, "requires_network": True},
+            ],
+            fonts=fonts,
+        )
+
+        text = self.render(plan_report)
+
+        self.assertIn("Install/update 1 Nerd Font.", text)
+        self.assertIn("Network may be used for Nerd Font downloads unless cached.", text)
+        self.assertIn("JetBrainsMono Nerd Font: missing (network if cache is missing)", text)
+        self.assertNotIn("/tmp/cache/JetBrainsMono.zip", text)
+
+    def test_apt_font_missing_shows_sudo_need(self) -> None:
+        home = self.make_home()
+        fonts = [apt_font("missing")]
+        plan_report = plan(
+            home,
+            entries=[font_entry(fonts[0])],
+            operations=[
+                {"entry_id": "fonts.apt.noto-color-emoji", "type": "font_install_packages", "recipe": "fonts", "requires_approval": True, "requires_sudo": True, "source_type": "apt_package"},
+            ],
+            fonts=fonts,
+        )
+
+        text = self.render(plan_report)
+
+        self.assertIn("Install/update 1 apt fallback font package.", text)
+        self.assertIn("sudo is needed for apt fallback font packages.", text)
+        self.assertIn("Noto Color Emoji [fonts-noto-color-emoji]: missing (sudo)", text)
+        self.assertNotIn("candidate_version", text)
+        self.assertNotIn("1.0", text)
+
+    def test_blockers_and_manual_fonts_stay_visible(self) -> None:
+        home = self.make_home()
+        manual_font = nerd_font("manual")
+        blocked_entry = manifest_entry("claude.settings", "blocked", reason="target is a directory")
+        plan_report = plan(
+            home,
+            entries=[blocked_entry, font_entry(manual_font)],
+            fonts=[manual_font],
+            errors=[{"message": "manifest parse failed"}],
+        )
+
+        text = self.render(plan_report, doctor_report=doctor(home, errors=[{"message": "doctor failed"}]))
+
+        self.assertIn("Stop on 3 blocking issues; fix before applying.", text)
+        self.assertIn("Skip 1 manual/unsupported font item; see Fonts below.", text)
+        self.assertIn("Needs attention before apply:", text)
+        self.assertIn("~/.claude/settings.json: target is a directory", text)
+        self.assertIn("Doctor errors:", text)
+        self.assertIn("doctor failed", text)
+        self.assertIn("Plan errors:", text)
+        self.assertIn("manifest parse failed", text)
+        self.assertIn("Manual/skipped:", text)
+        self.assertIn("JetBrainsMono Nerd Font: manual check needed", text)
+
+    def test_menu_label_is_dynamic_and_specific(self) -> None:
+        home = self.make_home()
+        drifted = home / ".claude" / "settings.json"
+        drifted.parent.mkdir(parents=True)
+        drifted.write_text('{"drift": true}')
+
+        label = render_menu_label(REPO_ROOT, home)
+
+        self.assertRegex(label, r"^Apply [0-9]+ file changes?( \+ [0-9]+ font actions?)?")
+        self.assertIn("backs up 1 file", label)

--- a/tests/test_machine_summary.py
+++ b/tests/test_machine_summary.py
@@ -52,8 +52,8 @@ def nerd_font(state: str = "missing") -> dict:
         "state": state,
         "requires_sudo": False,
         "reason": "font files are not installed",
-        "cache_path": "/tmp/cache/JetBrainsMono.zip",
-        "target": "/tmp/home/.local/share/fonts/JetBrainsMonoNerdFont",
+        "cache_path": "cache/JetBrainsMono.zip",
+        "target": "home/.local/share/fonts/JetBrainsMonoNerdFont",
         "terminal_face": "JetBrainsMono Nerd Font Mono",
         "terminal_impact": "Local terminals can select a Mono face.",
     }
@@ -167,7 +167,7 @@ class MachineSummaryTests(DotfilesTestCase):
         self.assertIn("Install/update 1 Nerd Font.", text)
         self.assertIn("Network may be used for Nerd Font downloads unless cached.", text)
         self.assertIn("JetBrainsMono Nerd Font: missing (network if cache is missing)", text)
-        self.assertNotIn("/tmp/cache/JetBrainsMono.zip", text)
+        self.assertNotIn("cache/JetBrainsMono.zip", text)
 
     def test_apt_font_missing_shows_sudo_need(self) -> None:
         home = self.make_home()

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -4,6 +4,7 @@ import os
 # Tests execute only the repo-local setup script.
 import subprocess  # nosec B404
 from pathlib import Path
+import shutil
 
 from tests.helpers import REPO_ROOT, DotfilesTestCase
 
@@ -16,6 +17,7 @@ def run_setup(
     executable: str | Path = SETUP,
     cwd: Path = REPO_ROOT,
     env: dict[str, str] | None = None,
+    input_text: str | None = None,
 ) -> subprocess.CompletedProcess:
     # Fixed executable path, test-controlled args, shell=False.
     return subprocess.run(  # nosec B603
@@ -24,6 +26,7 @@ def run_setup(
         text=True,
         cwd=str(cwd),
         env=env,
+        input=input_text,
         shell=False,
     )
 
@@ -35,10 +38,225 @@ def write_clean_project(project: Path) -> None:
 
 
 class SetupScriptTests(DotfilesTestCase):
-    def test_help_no_args(self) -> None:
-        result = run_setup()
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Usage:", result.stdout)
+    COMMON_COMMANDS = (
+        "bash",
+        "sh",
+        "dirname",
+        "basename",
+        "readlink",
+        "mktemp",
+        "grep",
+        "sed",
+        "find",
+        "mkdir",
+        "cp",
+        "rm",
+        "cat",
+        "chmod",
+        "python",
+    )
+
+    def make_command_path(self, *extra_commands: str) -> Path:
+        bin_dir = self.make_home() / "bin"
+        bin_dir.mkdir()
+        for name in (*self.COMMON_COMMANDS, *extra_commands):
+            if (bin_dir / name).exists():
+                continue
+            target = shutil.which(name)
+            if target is None and name == "python":
+                target = shutil.which("python3")
+            self.assertIsNotNone(target, f"required command not found for test PATH: {name}")
+            (bin_dir / name).symlink_to(target)
+        return bin_dir
+
+    def env_for(self, bin_dir: Path, home: Path) -> dict[str, str]:
+        env = os.environ.copy()
+        env["PATH"] = str(bin_dir)
+        env["HOME"] = str(home)
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        return env
+
+    def write_executable(self, path: Path, text: str) -> None:
+        path.write_text(text)
+        path.chmod(0o755)
+
+    def write_fake_uv(
+        self,
+        bin_dir: Path,
+        log_path: Path,
+        *,
+        self_update_status: int = 0,
+        version: str = "uv 0.test",
+    ) -> None:
+        self.write_executable(
+            bin_dir / "uv",
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "{log_path}"
+if [[ "${{1:-}}" == "--version" ]]; then
+  echo "{version}"
+  exit 0
+fi
+if [[ "${{1:-}}" == "self" && "${{2:-}}" == "update" ]]; then
+  echo "fake self update"
+  exit {self_update_status}
+fi
+if [[ "${{1:-}}" == "run" ]]; then
+  shift
+  exec "$@"
+fi
+echo "fake uv unsupported: $*" >&2
+exit 64
+""",
+        )
+
+    def write_uv_installer(self, installer_path: Path, *, version: str) -> None:
+        installer_path.write_text(
+            f"""#!/usr/bin/env sh
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/uv" <<'UV'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${{1:-}}" == "--version" ]]; then
+  echo "{version}"
+  exit 0
+fi
+if [[ "${{1:-}}" == "run" ]]; then
+  shift
+  exec "$@"
+fi
+echo "installed fake uv unsupported: $*" >&2
+exit 64
+UV
+chmod +x "$HOME/.local/bin/uv"
+"""
+        )
+
+    def write_fake_downloader(self, bin_dir: Path, name: str, installer_path: Path, log_path: Path) -> None:
+        self.write_executable(
+            bin_dir / name,
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "{log_path}"
+cat "{installer_path}"
+""",
+        )
+
+    def test_no_args_runs_machine_doctor_plan_after_uv_bootstrap(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        log_path = home / "uv.log"
+        self.write_fake_uv(bin_dir, log_path)
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("uv found at", result.stdout)
+        self.assertIn("uv self update completed.", result.stdout)
+        self.assertIn("Machine setup summary", result.stdout)
+        self.assertIn("Option 1 will:", result.stdout)
+        self.assertIn("Fonts:", result.stdout)
+        self.assertIn("Create missing files:", result.stdout)
+        self.assertRegex(result.stdout, r"1\. Apply [0-9]+ file changes?( \+ [0-9]+ font actions?)?")
+        self.assertIn("2. Show full technical details.", result.stdout)
+        self.assertNotIn("entries:", result.stdout)
+        self.assertNotIn("operations:", result.stdout)
+        self.assertIn("No changes applied.", result.stdout)
+        log_lines = log_path.read_text().splitlines()
+        self.assertEqual(log_lines[0], "self update")
+        self.assertEqual(log_lines[1], "--version")
+        self.assertIn("dotfiles_tools.machine_summary", log_lines[2])
+
+    def test_uv_missing_uses_curl_installer_and_refreshes_path(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        installer_path = home / "install-uv.sh"
+        log_path = home / "curl.log"
+        self.write_uv_installer(installer_path, version="uv 0.curl")
+        self.write_fake_downloader(bin_dir, "curl", installer_path, log_path)
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("uv is required", result.stdout)
+        self.assertIn("official standalone installer (curl)", result.stdout)
+        self.assertIn("Using uv 0.curl", result.stdout)
+        self.assertTrue((home / ".local" / "bin" / "uv").exists())
+        self.assertIn("https://astral.sh/uv/install.sh", log_path.read_text())
+
+    def test_uv_missing_uses_wget_installer_when_curl_missing(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        installer_path = home / "install-uv.sh"
+        log_path = home / "wget.log"
+        self.write_uv_installer(installer_path, version="uv 0.wget")
+        self.write_fake_downloader(bin_dir, "wget", installer_path, log_path)
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("official standalone installer (wget)", result.stdout)
+        self.assertIn("Using uv 0.wget", result.stdout)
+        self.assertIn("-qO-", log_path.read_text())
+
+    def test_uv_self_update_failure_warns_and_continues(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        log_path = home / "uv.log"
+        self.write_fake_uv(bin_dir, log_path, self_update_status=7)
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Machine setup summary", result.stdout)
+        self.assertIn("WARN: uv self update failed", result.stderr)
+
+    def test_no_arg_apply_writes_only_non_protected_config_with_backups(self) -> None:
+        home = self.make_home()
+        drifted = home / ".claude" / "settings.json"
+        drifted.parent.mkdir(parents=True)
+        drifted.write_text('{"drift": true}')
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        env = self.env_for(bin_dir, home)
+        env["DOTFILES_PLATFORM"] = "pixel-avf"
+        result = run_setup(env=env, input_text="1\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((home / ".config" / "fish" / "functions" / "direnv.fish").exists())
+        self.assertFalse((home / ".config" / "git" / "config").exists())
+        self.assertTrue((home / ".config" / "fish" / "conf.d" / "000-dotfiles-pixel-avf-prompt.fish").exists())
+        self.assertTrue(any(path.is_file() for path in (home / ".dotfiles-backups").rglob("*")))
+
+    def test_no_arg_tool_guidance_choice_prints_status(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="3\n4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Show tool and sign-in guidance.", result.stdout)
+        self.assertIn("Tool status:", result.stdout)
+        self.assertIn("Missing tools:", result.stdout)
+        self.assertIn("Sign-in checks unavailable until the tool is installed:", result.stdout)
+        self.assertNotIn("Missing tool install/auth commands:", result.stdout)
+
+    def test_no_arg_details_choice_prints_full_diagnostics(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="2\n4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Full machine doctor:", result.stdout)
+        self.assertIn("doctor:", result.stdout)
+        self.assertIn("Full machine plan:", result.stdout)
+        self.assertIn("font actions:", result.stdout)
+        self.assertIn("operations:", result.stdout)
+        self.assertIn("Show full technical details.", result.stdout)
 
     def test_help_subcommand(self) -> None:
         result = run_setup("help")
@@ -126,17 +344,23 @@ class SetupScriptTests(DotfilesTestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Verification passed.", result.stdout)
 
-    def test_init_missing_vars_prints_example(self) -> None:
+    def test_init_without_vars_persists_inferred_defaults(self) -> None:
         project = self.make_project()
-        result = run_setup("init", "--project", str(project), "--yes")
-        self.assertEqual(result.returncode, 2)
-        self.assertIn("project-vars.json", result.stderr)
-        self.assertIn("PROJECT_NAME", result.stderr)
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+        result = run_setup("init", "--project", str(project), "--yes", env=self.env_for(bin_dir, home))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((project / ".dotfiles" / "project-vars.json").exists())
+        self.assertIn("Using inferred project defaults saved to:", result.stdout)
 
     def test_init_success_with_vars(self) -> None:
         project = self.make_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
         self.vars_file(project)
-        result = run_setup("init", "--project", str(project), "--yes")
+        result = run_setup("init", "--project", str(project), "--yes", env=self.env_for(bin_dir, home))
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Verification passed.", result.stdout)
         self.assertTrue((project / "AGENTS.md").is_file())
@@ -145,8 +369,11 @@ class SetupScriptTests(DotfilesTestCase):
 
     def test_init_defaults_to_current_project_and_auto_verifies(self) -> None:
         project = self.make_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
         self.vars_file(project)
-        result = run_setup("init", "--yes", cwd=project)
+        result = run_setup("init", "--yes", cwd=project, env=self.env_for(bin_dir, home))
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Bootstrapping project:", result.stdout)
         self.assertIn("Verification passed.", result.stdout)
@@ -156,9 +383,25 @@ class SetupScriptTests(DotfilesTestCase):
 
     def test_doctor_runs_against_home(self) -> None:
         home = self.make_home()
-        result = run_setup("doctor", "--home", str(home))
+        fake_home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, fake_home / "uv.log")
+        result = run_setup("doctor", "--home", str(home), env=self.env_for(bin_dir, fake_home))
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("doctor:", result.stdout.lower())
+
+    def test_project_path_persists_metadata_without_bootstrapping_on_exit(self) -> None:
+        project = self.make_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        result = run_setup(str(project), env=self.env_for(bin_dir, home), input_text="4\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((project / ".dotfiles" / "project-vars.json").exists())
+        self.assertFalse((project / "AGENTS.md").exists())
+        self.assertIn("Project folder is empty", result.stdout)
 
 
 if __name__ == "__main__":

--- a/whitelizard.txt
+++ b/whitelizard.txt
@@ -1,0 +1,7 @@
+# Lizard warnings reviewed for the setup/bootstrap dashboard PR.
+dotfiles_tools/baseline.py:render_setup_guidance
+dotfiles_tools/bootstrap.py:apply_bootstrap
+dotfiles_tools/fonts.py:build_font_plan, execute_font_operation, _detect_context, _nerd_font_summary, _windows_host_plan, _execute_verify_linux, _regular_mono_font
+dotfiles_tools/machine_summary.py:render_reports, _group_entries, _extend_font_summary, _extend_tool_summary, _action_summary, _option_one_label
+dotfiles_tools/reports.py:_extend_extra
+tests/test_fonts.py:test_standard_linux_plan_represents_all_catalog_items_when_missing, test_pi_plans_full_nerd_inventory_symbol_fallbacks_and_meslo_mono_verify, test_pixel_terminal_embeds_jetbrains_mono_subset_and_only_noto_emoji_package

--- a/whitelizard.txt
+++ b/whitelizard.txt
@@ -1,7 +1,0 @@
-# Lizard warnings reviewed for the setup/bootstrap dashboard PR.
-dotfiles_tools/baseline.py:render_setup_guidance
-dotfiles_tools/bootstrap.py:apply_bootstrap
-dotfiles_tools/fonts.py:build_font_plan, execute_font_operation, _detect_context, _nerd_font_summary, _windows_host_plan, _execute_verify_linux, _regular_mono_font
-dotfiles_tools/machine_summary.py:render_reports, _group_entries, _extend_font_summary, _extend_tool_summary, _action_summary, _option_one_label
-dotfiles_tools/reports.py:_extend_extra
-tests/test_fonts.py:test_standard_linux_plan_represents_all_catalog_items_when_missing, test_pi_plans_full_nerd_inventory_symbol_fallbacks_and_meslo_mono_verify, test_pixel_terminal_embeds_jetbrains_mono_subset_and_only_noto_emoji_package


### PR DESCRIPTION
## Summary

- Adds a combined machine bootstrap layer for `doctor`/`plan`/`apply` plus font install recipes.
- Makes the default `./setup` flow a compact decision dashboard with a dynamic option 1 label and full technical details behind option 2.
- Documents the new bootstrap commands and expands tests for setup menu behavior, font planning, and machine summary output.

## Validation

- `uv run python -m unittest discover -s tests`
- `uv run --with coverage coverage run -m unittest discover -s tests`
- `uv run --with coverage coverage xml`
- `git diff --check`