### PR TITLE
feat: add ./setup option 5 to install/update developer tools

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -8,3 +8,4 @@ engines:
   metric:
     exclude_paths:
       - "dotfiles_tools/**"
+      - "tests/**"

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -11,58 +11,113 @@ TOOL_BASELINE = (
         "label": "uv",
         "command": "uv",
         "bootstrap": True,
+        "install_method": "manual",
+        "install_args": {},
+        "requires_sudo": False,
         "install_hint": "Installed automatically by ./setup when missing.",
     },
     {
         "id": "git",
         "label": "Git",
         "command": "git",
-        "bootstrap": False,
-        "install_hint": "Install git with the operating-system package manager.",
+        "bootstrap": True,
+        "install_method": "apt",
+        "install_args": {"packages": ("git",)},
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (apt).",
     },
     {
         "id": "gh",
         "label": "GitHub CLI",
         "command": "gh",
-        "bootstrap": False,
-        "install_hint": "Install the GitHub CLI, then run gh auth status.",
+        "bootstrap": True,
+        "install_method": "apt_keyring",
+        "install_args": {
+            "packages": ("gh",),
+            "keyring_url": "https://cli.github.com/packages/githubcli-archive-keyring.gpg",
+            "keyring_path": "/etc/apt/keyrings/githubcli-archive-keyring.gpg",
+            "source_line": (
+                "deb [arch={ARCH} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg]"
+                " https://cli.github.com/packages stable main"
+            ),
+            "source_path": "/etc/apt/sources.list.d/github-cli.list",
+        },
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (GitHub keyring repo).",
     },
     {
         "id": "fish",
         "label": "fish",
         "command": "fish",
-        "bootstrap": False,
-        "install_hint": "Install fish with the operating-system package manager.",
+        "bootstrap": True,
+        "install_method": "apt",
+        "install_args": {"packages": ("fish",)},
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (apt).",
     },
     {
         "id": "direnv",
         "label": "direnv",
         "command": "direnv",
-        "bootstrap": False,
-        "install_hint": "Install direnv and enable the shell hook.",
+        "bootstrap": True,
+        "install_method": "apt",
+        "install_args": {"packages": ("direnv",)},
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (apt).",
     },
     {
         "id": "codex",
         "label": "Codex CLI",
         "command": "codex",
-        "bootstrap": False,
-        "install_hint": "Install Codex CLI, then run codex auth.",
+        "bootstrap": True,
+        "install_method": "npm",
+        "install_args": {"package": "@openai/codex"},
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (npm install -g @openai/codex).",
     },
     {
         "id": "claude",
         "label": "Claude Code",
         "command": "claude",
-        "bootstrap": False,
-        "install_hint": "Install Claude Code CLI, then run claude login.",
+        "bootstrap": True,
+        "install_method": "curl_installer",
+        "install_args": {
+            "url": "https://claude.ai/install.sh",
+            "script_name": "claude-install.sh",
+        },
+        "requires_sudo": False,
+        "install_hint": "Installed by setup option 5 (claude.ai/install.sh).",
     },
     {
         "id": "gemini",
         "label": "Gemini CLI",
         "command": "gemini",
-        "bootstrap": False,
-        "install_hint": "Install Gemini CLI, then complete its login/setup flow.",
+        "bootstrap": True,
+        "install_method": "npm",
+        "install_args": {"package": "@google/gemini-cli"},
+        "requires_sudo": True,
+        "install_hint": "Installed by setup option 5 (npm install -g @google/gemini-cli).",
     },
 )
+
+
+# Grouped for readability when rendering the option-5 preview.
+# Flattened into DEV_BASE_PACKAGES at module load. All packages live in
+# Ubuntu main/universe; no third-party repos required.
+DEV_BASE_GROUPS = (
+    ("tls_keys",  ("ca-certificates", "gnupg", "apt-transport-https")),
+    ("transfer",  ("curl", "wget")),
+    ("archives",  ("unzip", "zip", "tar", "xz-utils")),
+    ("build",     ("build-essential", "pkg-config", "make")),
+    ("python",    ("python3", "python3-pip", "python3-venv")),
+    ("node",      ("nodejs", "npm")),
+    ("json_text", ("jq", "ripgrep", "fd-find")),
+    ("editors",   ("vim", "nano")),
+    ("shell",     ("tmux", "less", "man-db")),
+    ("system",    ("htop", "tree", "file")),
+    ("network",   ("openssh-client", "dnsutils", "iputils-ping", "net-tools")),
+)
+DEV_BASE_PACKAGES = tuple(pkg for _, group in DEV_BASE_GROUPS for pkg in group)
 
 
 AUTH_GUIDANCE = (
@@ -119,7 +174,11 @@ def _extend_missing_tools(lines: list[str], missing_tools: list[dict[str, Any]])
         return
     lines.append("  Missing tools:")
     for item in missing_tools:
-        lines.append(f"    - {item['command']}: {item['install_hint']}")
+        if item.get("bootstrap"):
+            hint = "Install via setup option 5 (Install / update developer tools)."
+        else:
+            hint = item["install_hint"]
+        lines.append(f"    - {item['command']}: {hint}")
 
 
 def _extend_available_auth(lines: list[str], available_auth: list[dict[str, Any]]) -> None:

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -7,6 +7,7 @@ from .backups import BackupError
 from .fonts import CommandRunner, execute_font_operation, build_font_plan
 from .installer import build_plan, execute_manifest_operation
 from .reports import Report
+from .tool_installer import build_tool_install_plan, execute_tool_install_operation
 
 
 WARNING_STATES = {"missing", "drifted", "protected", "manual", "unsupported", "needs_update"}
@@ -93,6 +94,62 @@ def apply_bootstrap(
     return _execute_bootstrap_operations(report, repo_path, backup_path, runner)
 
 
+def build_tool_install_subplan(
+    repo: Path | str,
+    home: Path | str,
+    *,
+    env: Mapping[str, str] | None = None,
+    runner: CommandRunner | None = None,
+) -> Report:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    tool_plan = build_tool_install_plan(home_path, env=env, runner=runner)
+    operations = list(tool_plan["operations"])
+    _renumber_operations(operations)
+    entries = list(tool_plan["entries"])
+    status = _status(entries, operations, [])
+    return Report(
+        "bootstrap-install-tools-plan",
+        status,
+        str(repo_path),
+        home=str(home_path),
+        profile="machine",
+        entries=entries,
+        operations=operations,
+        extra={"tools": tool_plan["tools"]},
+    )
+
+
+def apply_tool_installs(
+    repo: Path | str,
+    home: Path | str,
+    *,
+    backup_dir: Path | str | None = None,
+    yes: bool = False,
+    env: Mapping[str, str] | None = None,
+    runner: CommandRunner | None = None,
+) -> Report:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    if not yes:
+        return Report(
+            "bootstrap-install-tools",
+            "failed",
+            str(repo_path),
+            home=str(home_path),
+            profile="machine",
+            errors=[{"message": "bootstrap-install-tools requires --yes before writing"}],
+        )
+
+    plan = build_tool_install_subplan(repo_path, home_path, env=env, runner=runner)
+    plan.command = "bootstrap-install-tools"
+    if plan.errors or any(entry.get("state") in FAILED_STATES for entry in plan.entries):
+        plan.status = "failed"
+        return plan
+    return _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
+
+
 def _execute_bootstrap_operations(
     report: Report,
     repo_path: Path,
@@ -120,6 +177,9 @@ def _execute_operation(
     backups: list[dict[str, Any]],
     runner: CommandRunner | None,
 ) -> int:
+    if op.get("recipe") == "tool_installs" or str(op.get("type", "")).startswith("tool_install_"):
+        cache_dir = Path(op.get("cache_dir") or Path.home() / ".cache/000-dotfiles/tool-installers")
+        return execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
     if op.get("recipe") == "fonts" or str(op.get("type", "")).startswith("font_"):
         return execute_font_operation(op, runner=runner, backup_dir=backup_path, backups=backups)
     return execute_manifest_operation(op, repo_path, backup_path, backups)

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -7,7 +7,11 @@ from .backups import BackupError
 from .fonts import CommandRunner, execute_font_operation, build_font_plan
 from .installer import build_plan, execute_manifest_operation
 from .reports import Report
-from .tool_installer import build_tool_install_plan, execute_tool_install_operation
+from .tool_installer import (
+    TOOL_CACHE_REL,
+    build_tool_install_plan,
+    execute_tool_install_operation,
+)
 
 
 WARNING_STATES = {"missing", "drifted", "protected", "manual", "unsupported", "needs_update"}
@@ -178,7 +182,7 @@ def _execute_operation(
     runner: CommandRunner | None,
 ) -> int:
     if op.get("recipe") == "tool_installs" or str(op.get("type", "")).startswith("tool_install_"):
-        cache_dir = Path(op.get("cache_dir") or Path.home() / ".cache/000-dotfiles/tool-installers")
+        cache_dir = Path(op.get("cache_dir") or Path.home() / TOOL_CACHE_REL)
         return execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
     if op.get("recipe") == "fonts" or str(op.get("type", "")).startswith("font_"):
         return execute_font_operation(op, runner=runner, backup_dir=backup_path, backups=backups)

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -112,7 +112,21 @@ def _dispatch_command(args: argparse.Namespace, repo: Path):
             profile=args.profile, backup_dir=args.backup_dir,
             yes=args.yes, include_protected=args.include_protected,
         )
-    elif cmd == "bootstrap-plan":
+    elif cmd == "init-project":
+        report = init_project(
+            repo, args.project, args.vars,
+            backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot,
+        )
+    elif cmd.startswith("bootstrap"):
+        report = _dispatch_bootstrap(args, repo)
+    else:
+        raise SystemExit(f"unknown command: {cmd}")
+    return report
+
+
+def _dispatch_bootstrap(args: argparse.Namespace, repo: Path):
+    cmd = args.command
+    if cmd == "bootstrap-plan":
         report = build_bootstrap_plan(
             repo, args.home, profile=args.profile, include_protected=args.include_protected
         )
@@ -126,11 +140,6 @@ def _dispatch_command(args: argparse.Namespace, repo: Path):
         report = build_tool_install_subplan(repo, args.home)
     elif cmd == "bootstrap-install-tools":
         report = apply_tool_installs(repo, args.home, backup_dir=args.backup_dir, yes=args.yes)
-    elif cmd == "init-project":
-        report = init_project(
-            repo, args.project, args.vars,
-            backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot,
-        )
     else:
         raise SystemExit(f"unknown command: {cmd}")
     return report

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -93,43 +93,27 @@ def _common(parser: argparse.ArgumentParser) -> None:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    repo = Path(args.repo)
-    if args.command == "doctor":
-        report = run_doctor(repo, args.home, profile=args.profile)
-    elif args.command == "plan":
-        report = build_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
-    elif args.command == "apply":
-        report = apply_plan(
-            repo,
-            args.home,
-            profile=args.profile,
-            backup_dir=args.backup_dir,
-            yes=args.yes,
-            include_protected=args.include_protected,
-        )
-    elif args.command == "bootstrap-plan":
-        report = build_bootstrap_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
-    elif args.command == "bootstrap-apply":
-        report = apply_bootstrap(
-            repo,
-            args.home,
-            profile=args.profile,
-            backup_dir=args.backup_dir,
-            yes=args.yes,
-            include_protected=args.include_protected,
-        )
-    elif args.command == "bootstrap-install-tools-plan":
-        report = build_tool_install_subplan(repo, args.home)
-    elif args.command == "bootstrap-install-tools":
-        report = apply_tool_installs(
-            repo,
-            args.home,
-            backup_dir=args.backup_dir,
-            yes=args.yes,
-        )
-    elif args.command == "init-project":
-        report = init_project(repo, args.project, args.vars, backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot)
-    else:
-        parser.error(f"unknown command: {args.command}")
+    report = _dispatch_command(args, Path(args.repo))
     print(render(report, args.as_json), end="")
     return 1 if report.status in {"failed", "partial"} else 0
+
+
+def _dispatch_command(args: argparse.Namespace, repo: Path):  # type: ignore[return]
+    cmd = args.command
+    if cmd == "doctor":
+        return run_doctor(repo, args.home, profile=args.profile)
+    if cmd == "plan":
+        return build_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
+    if cmd == "apply":
+        return apply_plan(repo, args.home, profile=args.profile, backup_dir=args.backup_dir, yes=args.yes, include_protected=args.include_protected)
+    if cmd == "bootstrap-plan":
+        return build_bootstrap_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
+    if cmd == "bootstrap-apply":
+        return apply_bootstrap(repo, args.home, profile=args.profile, backup_dir=args.backup_dir, yes=args.yes, include_protected=args.include_protected)
+    if cmd == "bootstrap-install-tools-plan":
+        return build_tool_install_subplan(repo, args.home)
+    if cmd == "bootstrap-install-tools":
+        return apply_tool_installs(repo, args.home, backup_dir=args.backup_dir, yes=args.yes)
+    if cmd == "init-project":
+        return init_project(repo, args.project, args.vars, backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot)
+    raise SystemExit(f"unknown command: {cmd}")

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -98,22 +98,39 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 1 if report.status in {"failed", "partial"} else 0
 
 
-def _dispatch_command(args: argparse.Namespace, repo: Path):  # type: ignore[return]
+def _dispatch_command(args: argparse.Namespace, repo: Path):
     cmd = args.command
     if cmd == "doctor":
-        return run_doctor(repo, args.home, profile=args.profile)
-    if cmd == "plan":
-        return build_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
-    if cmd == "apply":
-        return apply_plan(repo, args.home, profile=args.profile, backup_dir=args.backup_dir, yes=args.yes, include_protected=args.include_protected)
-    if cmd == "bootstrap-plan":
-        return build_bootstrap_plan(repo, args.home, profile=args.profile, include_protected=args.include_protected)
-    if cmd == "bootstrap-apply":
-        return apply_bootstrap(repo, args.home, profile=args.profile, backup_dir=args.backup_dir, yes=args.yes, include_protected=args.include_protected)
-    if cmd == "bootstrap-install-tools-plan":
-        return build_tool_install_subplan(repo, args.home)
-    if cmd == "bootstrap-install-tools":
-        return apply_tool_installs(repo, args.home, backup_dir=args.backup_dir, yes=args.yes)
-    if cmd == "init-project":
-        return init_project(repo, args.project, args.vars, backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot)
-    raise SystemExit(f"unknown command: {cmd}")
+        report = run_doctor(repo, args.home, profile=args.profile)
+    elif cmd == "plan":
+        report = build_plan(
+            repo, args.home, profile=args.profile, include_protected=args.include_protected
+        )
+    elif cmd == "apply":
+        report = apply_plan(
+            repo, args.home,
+            profile=args.profile, backup_dir=args.backup_dir,
+            yes=args.yes, include_protected=args.include_protected,
+        )
+    elif cmd == "bootstrap-plan":
+        report = build_bootstrap_plan(
+            repo, args.home, profile=args.profile, include_protected=args.include_protected
+        )
+    elif cmd == "bootstrap-apply":
+        report = apply_bootstrap(
+            repo, args.home,
+            profile=args.profile, backup_dir=args.backup_dir,
+            yes=args.yes, include_protected=args.include_protected,
+        )
+    elif cmd == "bootstrap-install-tools-plan":
+        report = build_tool_install_subplan(repo, args.home)
+    elif cmd == "bootstrap-install-tools":
+        report = apply_tool_installs(repo, args.home, backup_dir=args.backup_dir, yes=args.yes)
+    elif cmd == "init-project":
+        report = init_project(
+            repo, args.project, args.vars,
+            backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot,
+        )
+    else:
+        raise SystemExit(f"unknown command: {cmd}")
+    return report

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -4,7 +4,12 @@ import argparse
 from pathlib import Path
 from typing import Sequence
 
-from .bootstrap import apply_bootstrap, build_bootstrap_plan
+from .bootstrap import (
+    apply_bootstrap,
+    apply_tool_installs,
+    build_bootstrap_plan,
+    build_tool_install_subplan,
+)
 from .doctor import run_doctor
 from .installer import apply_plan, build_plan
 from .project_init import init_project
@@ -54,6 +59,22 @@ def build_parser() -> argparse.ArgumentParser:
     bootstrap_apply.add_argument("--yes", action="store_true")
     bootstrap_apply.add_argument("--include-protected", action="append", default=[])
 
+    install_tools_plan = subparsers.add_parser(
+        "bootstrap-install-tools-plan",
+        help="Preview tool install/update actions for option 5",
+    )
+    _common(install_tools_plan)
+    install_tools_plan.add_argument("--home", required=True)
+
+    install_tools_apply = subparsers.add_parser(
+        "bootstrap-install-tools",
+        help="Apply tool install/update actions (option 5)",
+    )
+    _common(install_tools_apply)
+    install_tools_apply.add_argument("--home", required=True)
+    install_tools_apply.add_argument("--backup-dir")
+    install_tools_apply.add_argument("--yes", action="store_true")
+
     project = subparsers.add_parser("init-project", help="Initialize project-level agent docs")
     _common(project)
     project.add_argument("--project", required=True)
@@ -96,6 +117,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             backup_dir=args.backup_dir,
             yes=args.yes,
             include_protected=args.include_protected,
+        )
+    elif args.command == "bootstrap-install-tools-plan":
+        report = build_tool_install_subplan(repo, args.home)
+    elif args.command == "bootstrap-install-tools":
+        report = apply_tool_installs(
+            repo,
+            args.home,
+            backup_dir=args.backup_dir,
+            yes=args.yes,
         )
     elif args.command == "init-project":
         report = init_project(repo, args.project, args.vars, backup_dir=args.backup_dir, yes=args.yes, copilot=args.copilot)

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -151,6 +151,7 @@ def _extend_extra(lines: list[str], extra: dict[str, Any]) -> None:
     _extend_extra_fonts(lines, extra.get("fonts") or [])
     _extend_extra_tool_checks(lines, extra.get("tool_checks") or [])
     _extend_extra_auth_guidance(lines, extra.get("auth_guidance") or [])
+    _extend_extra_tools(lines, extra.get("tools") or [])
 
 
 def _extend_extra_fonts(lines: list[str], fonts: list[dict[str, Any]]) -> None:
@@ -199,3 +200,82 @@ def _extra_auth_line(item: dict[str, Any]) -> str:
     if item.get("state") == "available":
         return f"  - {item.get('command')}: {item.get('guidance')}"
     return f"  - {item.get('tool')}: install tool before auth setup"
+
+
+def _extend_extra_tools(lines: list[str], tools: list[dict[str, Any]]) -> None:
+    if not tools:
+        return
+    dev_base = next((item for item in tools if item.get("entry_id") == "tools.dev_base"), None)
+    individual = [item for item in tools if item.get("entry_id") != "tools.dev_base"]
+    lines.append("tool install/update preview:")
+    installed = [item for item in individual if item.get("state") == "installed"]
+    missing = [item for item in individual if item.get("state") == "missing"]
+    unsupported = [item for item in individual if item.get("state") == "unsupported"]
+    if installed:
+        lines.append("  Already installed (will be updated where possible):")
+        for item in installed:
+            lines.append(_tool_installed_line(item))
+    if missing:
+        lines.append("  Missing (will be installed):")
+        for item in missing:
+            lines.append(_tool_missing_line(item))
+    if unsupported:
+        lines.append("  Unsupported on this platform:")
+        for item in unsupported:
+            lines.append(f"    - {item.get('label')} ({item.get('install_method')})")
+    if dev_base is not None:
+        _extend_dev_base_summary(lines, dev_base)
+
+
+def _tool_installed_line(item: dict[str, Any]) -> str:
+    method = item.get("install_method")
+    action_label = {
+        "apt": "apt --only-upgrade",
+        "apt_keyring": "apt --only-upgrade (keyring repo)",
+        "curl_installer": "re-run installer (self-update)",
+        "npm": "npm update -g",
+    }.get(method, "skip")
+    label = item.get("label") or item.get("command") or item.get("entry_id")
+    path = item.get("current_path") or ""
+    version = item.get("current_version") or ""
+    suffix = f" {version}" if version else ""
+    return f"    - {label}: {path}{suffix} -> {action_label}"
+
+
+def _tool_missing_line(item: dict[str, Any]) -> str:
+    method = item.get("install_method")
+    method_label = {
+        "apt": "apt (sudo)",
+        "apt_keyring": "apt + keyring repo (sudo)",
+        "curl_installer": "curl installer (no sudo)",
+        "npm": "npm install -g (sudo)",
+    }.get(method, method or "manual")
+    label = item.get("label") or item.get("command") or item.get("entry_id")
+    return f"    - {label}: {method_label}"
+
+
+def _extend_dev_base_summary(lines: list[str], dev_base: dict[str, Any]) -> None:
+    total = dev_base.get("total_packages") or 0
+    missing = dev_base.get("missing_packages") or []
+    installed = dev_base.get("installed_packages") or []
+    lines.append(f"  Dev base packages ({total} total, grouped):")
+    for group in dev_base.get("groups") or []:
+        name = group.get("name", "")
+        present = len(group.get("installed") or [])
+        size = len(group.get("packages") or [])
+        missing_pkgs = group.get("missing") or []
+        if missing_pkgs:
+            lines.append(
+                f"    {name:<10s} {present}/{size} installed (missing: {', '.join(missing_pkgs)})"
+            )
+        else:
+            lines.append(f"    {name:<10s} {present}/{size} installed -> apt --only-upgrade")
+    if missing and installed:
+        lines.append(
+            f"  -> One batched apt install for {len(missing)} missing packages,"
+            f" one batched apt upgrade for {len(installed)} present packages."
+        )
+    elif missing:
+        lines.append(f"  -> One batched apt install for {len(missing)} missing packages.")
+    elif installed:
+        lines.append(f"  -> One batched apt upgrade for {len(installed)} present packages.")

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -208,23 +208,33 @@ def _extend_extra_tools(lines: list[str], tools: list[dict[str, Any]]) -> None:
     dev_base = next((item for item in tools if item.get("entry_id") == "tools.dev_base"), None)
     individual = [item for item in tools if item.get("entry_id") != "tools.dev_base"]
     lines.append("tool install/update preview:")
-    installed = [item for item in individual if item.get("state") == "installed"]
-    missing = [item for item in individual if item.get("state") == "missing"]
-    unsupported = [item for item in individual if item.get("state") == "unsupported"]
-    if installed:
-        lines.append("  Already installed (will be updated where possible):")
-        for item in installed:
-            lines.append(_tool_installed_line(item))
-    if missing:
-        lines.append("  Missing (will be installed):")
-        for item in missing:
-            lines.append(_tool_missing_line(item))
-    if unsupported:
-        lines.append("  Unsupported on this platform:")
-        for item in unsupported:
-            lines.append(f"    - {item.get('label')} ({item.get('install_method')})")
+    _extend_tool_section(lines, individual, "installed",
+                         "  Already installed (will be updated where possible):", _tool_installed_line)
+    _extend_tool_section(lines, individual, "missing",
+                         "  Missing (will be installed):", _tool_missing_line)
+    _extend_tool_section(lines, individual, "unsupported",
+                         "  Unsupported on this platform:", _tool_unsupported_line)
     if dev_base is not None:
         _extend_dev_base_summary(lines, dev_base)
+
+
+def _extend_tool_section(
+    lines: list[str],
+    items: list[dict[str, Any]],
+    state: str,
+    header: str,
+    formatter,
+) -> None:
+    matching = [item for item in items if item.get("state") == state]
+    if not matching:
+        return
+    lines.append(header)
+    for item in matching:
+        lines.append(formatter(item))
+
+
+def _tool_unsupported_line(item: dict[str, Any]) -> str:
+    return f"    - {item.get('label')} ({item.get('install_method')})"
 
 
 def _tool_installed_line(item: dict[str, Any]) -> str:
@@ -260,22 +270,30 @@ def _extend_dev_base_summary(lines: list[str], dev_base: dict[str, Any]) -> None
     installed = dev_base.get("installed_packages") or []
     lines.append(f"  Dev base packages ({total} total, grouped):")
     for group in dev_base.get("groups") or []:
-        name = group.get("name", "")
-        present = len(group.get("installed") or [])
-        size = len(group.get("packages") or [])
-        missing_pkgs = group.get("missing") or []
-        if missing_pkgs:
-            lines.append(
-                f"    {name:<10s} {present}/{size} installed (missing: {', '.join(missing_pkgs)})"
-            )
-        else:
-            lines.append(f"    {name:<10s} {present}/{size} installed -> apt --only-upgrade")
+        lines.append(_dev_base_group_line(group))
+    summary = _dev_base_summary_line(missing, installed)
+    if summary:
+        lines.append(summary)
+
+
+def _dev_base_group_line(group: dict[str, Any]) -> str:
+    name = group.get("name", "")
+    present = len(group.get("installed") or [])
+    size = len(group.get("packages") or [])
+    missing_pkgs = group.get("missing") or []
+    if missing_pkgs:
+        return f"    {name:<10s} {present}/{size} installed (missing: {', '.join(missing_pkgs)})"
+    return f"    {name:<10s} {present}/{size} installed -> apt --only-upgrade"
+
+
+def _dev_base_summary_line(missing: list[str], installed: list[str]) -> str:
     if missing and installed:
-        lines.append(
+        return (
             f"  -> One batched apt install for {len(missing)} missing packages,"
             f" one batched apt upgrade for {len(installed)} present packages."
         )
-    elif missing:
-        lines.append(f"  -> One batched apt install for {len(missing)} missing packages.")
-    elif installed:
-        lines.append(f"  -> One batched apt upgrade for {len(installed)} present packages.")
+    if missing:
+        return f"  -> One batched apt install for {len(missing)} missing packages."
+    if installed:
+        return f"  -> One batched apt upgrade for {len(installed)} present packages."
+    return ""

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -133,28 +133,19 @@ def _extend_dev_base_plan(
     package_states = {pkg: _dpkg_installed(runner, pkg) for pkg in DEV_BASE_PACKAGES}
     missing = tuple(pkg for pkg in DEV_BASE_PACKAGES if not package_states[pkg])
     installed = tuple(pkg for pkg in DEV_BASE_PACKAGES if package_states[pkg])
-    groups_summary = []
-    for name, group_pkgs in DEV_BASE_GROUPS:
-        groups_summary.append(
-            {
-                "name": name,
-                "packages": list(group_pkgs),
-                "installed": [pkg for pkg in group_pkgs if package_states[pkg]],
-                "missing": [pkg for pkg in group_pkgs if not package_states[pkg]],
-            }
-        )
+    entry = _dev_base_entry(missing, installed, package_states)
+    entries.append(entry)
+    tools.append(entry)
+    operations.extend(_dev_base_operations(missing, installed, cache_dir))
 
-    if missing and installed:
-        state = "needs_update"
-        action = "install_and_upgrade"
-    elif missing:
-        state = "missing"
-        action = "install"
-    else:
-        state = "installed"
-        action = "upgrade"
 
-    entry = {
+def _dev_base_entry(
+    missing: tuple[str, ...],
+    installed: tuple[str, ...],
+    package_states: dict[str, bool],
+) -> dict[str, Any]:
+    state, action = _dev_base_state_action(missing, installed)
+    return {
         "entry_id": DEV_BASE_ENTRY_ID,
         "recipe": "tool_installs",
         "label": "Developer base packages",
@@ -164,14 +155,39 @@ def _extend_dev_base_plan(
         "action": action,
         "missing_packages": list(missing),
         "installed_packages": list(installed),
-        "groups": groups_summary,
+        "groups": _dev_base_groups_summary(package_states),
         "total_packages": len(DEV_BASE_PACKAGES),
     }
-    entries.append(entry)
-    tools.append(entry)
 
+
+def _dev_base_state_action(missing: tuple[str, ...], installed: tuple[str, ...]) -> tuple[str, str]:
+    if missing and installed:
+        return "needs_update", "install_and_upgrade"
     if missing:
-        operations.append(
+        return "missing", "install"
+    return "installed", "upgrade"
+
+
+def _dev_base_groups_summary(package_states: dict[str, bool]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "packages": list(group_pkgs),
+            "installed": [pkg for pkg in group_pkgs if package_states[pkg]],
+            "missing": [pkg for pkg in group_pkgs if not package_states[pkg]],
+        }
+        for name, group_pkgs in DEV_BASE_GROUPS
+    ]
+
+
+def _dev_base_operations(
+    missing: tuple[str, ...],
+    installed: tuple[str, ...],
+    cache_dir: Path,
+) -> list[dict[str, Any]]:
+    ops: list[dict[str, Any]] = []
+    if missing:
+        ops.append(
             _apt_op(
                 entry_id=DEV_BASE_ENTRY_ID,
                 op_type="tool_install_apt",
@@ -182,7 +198,7 @@ def _extend_dev_base_plan(
             )
         )
     if installed:
-        operations.append(
+        ops.append(
             _apt_op(
                 entry_id=DEV_BASE_ENTRY_ID,
                 op_type="tool_install_apt_upgrade",
@@ -192,6 +208,7 @@ def _extend_dev_base_plan(
                 reason=f"upgrade {len(installed)} installed dev-base packages",
             )
         )
+    return ops
 
 
 # ---------------------------------------------------------------------------
@@ -442,12 +459,7 @@ def _execute_apt(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int
     if not apt_get:
         op["result"] = "apt-get not found; install packages manually"
         return 0
-    prefix = _sudo_prefix()
-    runner.run([*prefix, apt_get, "update"])
-    if mode == "upgrade":
-        runner.run([*prefix, apt_get, "install", "--only-upgrade", "-y", *packages])
-    else:
-        runner.run([*prefix, apt_get, "install", "-y", *packages])
+    _apt_update_then_install(runner, _sudo_prefix(), apt_get, packages, mode=mode)
     return 1
 
 
@@ -459,39 +471,52 @@ def _execute_apt_keyring(op: dict[str, Any], runner: CommandRunner, cache_dir: P
     if not apt_get:
         op["result"] = "apt-get not found; install manually"
         return 0
+    cache_dir.mkdir(parents=True, exist_ok=True)
     prefix = _sudo_prefix()
     keyring_path = Path(op["keyring_path"])
     source_path = Path(op["source_path"])
 
     if not keyring_path.exists():
-        cached_keyring = Path(cache_dir) / keyring_path.name
+        cached_keyring = cache_dir / keyring_path.name
         runner.download(op["keyring_url"], cached_keyring)
         runner.run([*prefix, "install", "-D", "-m", "0644", str(cached_keyring), str(keyring_path)])
 
-    arch = _detect_dpkg_arch(runner)
-    rendered_source = op["source_line"].replace("{ARCH}", arch)
-    cached_source = Path(cache_dir) / source_path.name
-    cached_source.parent.mkdir(parents=True, exist_ok=True)
+    rendered_source = op["source_line"].replace("{ARCH}", _detect_dpkg_arch(runner))
+    cached_source = cache_dir / source_path.name
     cached_source.write_text(rendered_source + "\n")
     runner.run([*prefix, "install", "-D", "-m", "0644", str(cached_source), str(source_path)])
 
-    runner.run([*prefix, apt_get, "update"])
-    if op.get("mode") == "upgrade":
-        runner.run([*prefix, apt_get, "install", "--only-upgrade", "-y", *packages])
-    else:
-        runner.run([*prefix, apt_get, "install", "-y", *packages])
+    _apt_update_then_install(runner, prefix, apt_get, packages, mode=op.get("mode", "install"))
     return 1
 
 
 def _execute_curl(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) -> int:
     sh = runner.which("sh") or "/bin/sh"
-    script = Path(cache_dir) / op["script_name"]
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    script = cache_dir / op["script_name"]
     runner.download(op["url"], script)
-    if script.exists():
-        script.chmod(0o755)
+    if not script.exists():
+        op["result"] = f"failed to download installer from {op['url']}"
+        return 0
+    script.chmod(0o755)
     prefix = _sudo_prefix() if op.get("requires_sudo") else []
     runner.run([*prefix, sh, str(script)])
     return 1
+
+
+def _apt_update_then_install(
+    runner: CommandRunner,
+    prefix: list[str],
+    apt_get: str,
+    packages: list[str],
+    *,
+    mode: str,
+) -> None:
+    runner.run([*prefix, apt_get, "update"])
+    if mode == "upgrade":
+        runner.run([*prefix, apt_get, "install", "--only-upgrade", "-y", *packages])
+    else:
+        runner.run([*prefix, apt_get, "install", "-y", *packages])
 
 
 def _execute_npm(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int:

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -256,59 +256,35 @@ def _plan_tool_entry(
                 "action": "upgrade",
             }
         )
-        ops = _upgrade_operations(item, cache_dir)
     else:
         base_entry.update({"state": "missing", "action": "install"})
-        ops = _install_operations(item, cache_dir)
+    ops = _tool_operations(item, cache_dir, mode="upgrade" if found_path else "install")
     return base_entry, ops
 
 
-def _install_operations(item: Mapping[str, Any], cache_dir: Path) -> list[dict[str, Any]]:
+def _tool_operations(item: Mapping[str, Any], cache_dir: Path, *, mode: str) -> list[dict[str, Any]]:
     method = item["install_method"]
     args = dict(item.get("install_args") or {})
     entry_id = f"tools.{item['id']}"
     if method == "apt":
+        op_type = "tool_install_apt_upgrade" if mode == "upgrade" else "tool_install_apt"
+        action_label = "apt --only-upgrade" if mode == "upgrade" else "apt"
         return [
             _apt_op(
                 entry_id=entry_id,
-                op_type="tool_install_apt",
+                op_type=op_type,
                 packages=list(args.get("packages") or ()),
                 requires_sudo=item.get("requires_sudo", True),
                 cache_dir=cache_dir,
-                reason=f"install {item['label']} via apt",
+                reason=f"{mode} {item['label']} via {action_label}",
             )
         ]
     if method == "apt_keyring":
-        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode="install")]
+        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode=mode)]
     if method == "curl_installer":
-        return [_curl_op(entry_id, item, args, cache_dir, mode="install")]
+        return [_curl_op(entry_id, item, args, cache_dir, mode=mode)]
     if method == "npm":
-        return [_npm_op(entry_id, item, args, cache_dir, mode="install")]
-    return []
-
-
-def _upgrade_operations(item: Mapping[str, Any], cache_dir: Path) -> list[dict[str, Any]]:
-    method = item["install_method"]
-    args = dict(item.get("install_args") or {})
-    entry_id = f"tools.{item['id']}"
-    if method == "apt":
-        return [
-            _apt_op(
-                entry_id=entry_id,
-                op_type="tool_install_apt_upgrade",
-                packages=list(args.get("packages") or ()),
-                requires_sudo=item.get("requires_sudo", True),
-                cache_dir=cache_dir,
-                reason=f"upgrade {item['label']} via apt --only-upgrade",
-            )
-        ]
-    if method == "apt_keyring":
-        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode="upgrade")]
-    if method == "curl_installer":
-        # Re-running self-updating installers (claude.ai/install.sh) refreshes the install.
-        return [_curl_op(entry_id, item, args, cache_dir, mode="upgrade")]
-    if method == "npm":
-        return [_npm_op(entry_id, item, args, cache_dir, mode="upgrade")]
+        return [_npm_op(entry_id, item, args, cache_dir, mode=mode)]
     return []
 
 

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+from .baseline import DEV_BASE_GROUPS, DEV_BASE_PACKAGES, TOOL_BASELINE
+from .font_runner import CommandRunner
+
+
+TOOL_CACHE_REL = ".cache/000-dotfiles/tool-installers"
+DEV_BASE_ENTRY_ID = "tools.dev_base"
+
+
+__all__ = (
+    "build_tool_install_plan",
+    "execute_tool_install_operation",
+    "TOOL_CACHE_REL",
+    "DEV_BASE_ENTRY_ID",
+)
+
+
+def build_tool_install_plan(
+    home: Path | str,
+    *,
+    env: Mapping[str, str] | None = None,
+    path: str | None = None,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    home_path = Path(home).expanduser().resolve()
+    effective_env = dict(os.environ if env is None else env)
+    effective_path = path if path is not None else effective_env.get("PATH", "")
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_path)
+    cache_dir = home_path / TOOL_CACHE_REL
+
+    if not _is_linux(effective_env):
+        return _unsupported_plan(effective_runner)
+
+    entries: list[dict[str, Any]] = []
+    operations: list[dict[str, Any]] = []
+    tools: list[dict[str, Any]] = []
+
+    _extend_dev_base_plan(effective_runner, cache_dir, entries, operations, tools)
+    _extend_tool_baseline_plan(effective_runner, cache_dir, entries, operations, tools)
+
+    return {"entries": entries, "operations": operations, "tools": tools}
+
+
+def execute_tool_install_operation(
+    op: dict[str, Any],
+    *,
+    runner: CommandRunner | None = None,
+    cache_dir: Path | str | None = None,
+) -> int:
+    effective_runner = runner or CommandRunner()
+    op_cache = Path(cache_dir or op.get("cache_dir") or Path.home() / TOOL_CACHE_REL)
+    op_type = op["type"]
+    handlers = _operation_handlers(effective_runner, op_cache)
+    handler = handlers.get(op_type)
+    if handler is None:
+        raise RuntimeError(f"unknown tool install operation: {op_type}")
+    return handler(op)
+
+
+def _operation_handlers(runner: CommandRunner, cache_dir: Path) -> dict[str, Any]:
+    return {
+        "tool_install_apt": lambda op: _execute_apt(op, runner, mode="install"),
+        "tool_install_apt_upgrade": lambda op: _execute_apt(op, runner, mode="upgrade"),
+        "tool_install_apt_keyring": lambda op: _execute_apt_keyring(op, runner, cache_dir),
+        "tool_install_curl": lambda op: _execute_curl(op, runner, cache_dir),
+        "tool_install_npm": lambda op: _execute_npm(op, runner, mode="install"),
+        "tool_install_npm_upgrade": lambda op: _execute_npm(op, runner, mode="upgrade"),
+        "tool_install_skip": lambda op: 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Platform gating
+# ---------------------------------------------------------------------------
+
+
+def _is_linux(env: Mapping[str, str]) -> bool:
+    forced = env.get("DOTFILES_TOOL_PLATFORM")
+    if forced:
+        return forced.lower() == "linux"
+    return sys.platform.startswith("linux")
+
+
+def _unsupported_plan(runner: CommandRunner) -> dict[str, Any]:
+    entries = [
+        {
+            "entry_id": DEV_BASE_ENTRY_ID,
+            "recipe": "tool_installs",
+            "label": "Developer base packages",
+            "command": None,
+            "state": "unsupported",
+            "install_method": "apt",
+            "action": "manual",
+            "reason": "tool installs are Linux/Ubuntu-only in v1",
+        }
+    ]
+    for item in TOOL_BASELINE:
+        if not item.get("bootstrap") or item["install_method"] == "manual":
+            continue
+        entries.append(
+            {
+                "entry_id": f"tools.{item['id']}",
+                "recipe": "tool_installs",
+                "label": item["label"],
+                "command": item["command"],
+                "state": "unsupported",
+                "install_method": item["install_method"],
+                "action": "manual",
+                "reason": "tool installs are Linux/Ubuntu-only in v1",
+            }
+        )
+    return {"entries": entries, "operations": [], "tools": []}
+
+
+# ---------------------------------------------------------------------------
+# Dev-base apt bundle
+# ---------------------------------------------------------------------------
+
+
+def _extend_dev_base_plan(
+    runner: CommandRunner,
+    cache_dir: Path,
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+) -> None:
+    package_states = {pkg: _dpkg_installed(runner, pkg) for pkg in DEV_BASE_PACKAGES}
+    missing = tuple(pkg for pkg in DEV_BASE_PACKAGES if not package_states[pkg])
+    installed = tuple(pkg for pkg in DEV_BASE_PACKAGES if package_states[pkg])
+    groups_summary = []
+    for name, group_pkgs in DEV_BASE_GROUPS:
+        groups_summary.append(
+            {
+                "name": name,
+                "packages": list(group_pkgs),
+                "installed": [pkg for pkg in group_pkgs if package_states[pkg]],
+                "missing": [pkg for pkg in group_pkgs if not package_states[pkg]],
+            }
+        )
+
+    if missing and installed:
+        state = "needs_update"
+        action = "install_and_upgrade"
+    elif missing:
+        state = "missing"
+        action = "install"
+    else:
+        state = "installed"
+        action = "upgrade"
+
+    entry = {
+        "entry_id": DEV_BASE_ENTRY_ID,
+        "recipe": "tool_installs",
+        "label": "Developer base packages",
+        "command": None,
+        "state": state,
+        "install_method": "apt",
+        "action": action,
+        "missing_packages": list(missing),
+        "installed_packages": list(installed),
+        "groups": groups_summary,
+        "total_packages": len(DEV_BASE_PACKAGES),
+    }
+    entries.append(entry)
+    tools.append(entry)
+
+    if missing:
+        operations.append(
+            _apt_op(
+                entry_id=DEV_BASE_ENTRY_ID,
+                op_type="tool_install_apt",
+                packages=list(missing),
+                requires_sudo=True,
+                cache_dir=cache_dir,
+                reason=f"install {len(missing)} missing dev-base packages",
+            )
+        )
+    if installed:
+        operations.append(
+            _apt_op(
+                entry_id=DEV_BASE_ENTRY_ID,
+                op_type="tool_install_apt_upgrade",
+                packages=list(installed),
+                requires_sudo=True,
+                cache_dir=cache_dir,
+                reason=f"upgrade {len(installed)} installed dev-base packages",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool baseline (per-tool)
+# ---------------------------------------------------------------------------
+
+
+def _extend_tool_baseline_plan(
+    runner: CommandRunner,
+    cache_dir: Path,
+    entries: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+) -> None:
+    for item in TOOL_BASELINE:
+        if not item.get("bootstrap") or item["install_method"] == "manual":
+            continue
+        entry, ops = _plan_tool_entry(item, runner, cache_dir)
+        entries.append(entry)
+        tools.append(entry)
+        operations.extend(ops)
+
+
+def _plan_tool_entry(
+    item: Mapping[str, Any],
+    runner: CommandRunner,
+    cache_dir: Path,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    method = item["install_method"]
+    found_path = runner.which(item["command"])
+    base_entry: dict[str, Any] = {
+        "entry_id": f"tools.{item['id']}",
+        "recipe": "tool_installs",
+        "label": item["label"],
+        "command": item["command"],
+        "install_method": method,
+        "requires_sudo": item.get("requires_sudo", False),
+    }
+    if found_path:
+        base_entry.update(
+            {
+                "state": "installed",
+                "current_path": found_path,
+                "current_version": _detect_version(item["command"], found_path, runner),
+                "action": "upgrade",
+            }
+        )
+        ops = _upgrade_operations(item, cache_dir)
+    else:
+        base_entry.update({"state": "missing", "action": "install"})
+        ops = _install_operations(item, cache_dir)
+    return base_entry, ops
+
+
+def _install_operations(item: Mapping[str, Any], cache_dir: Path) -> list[dict[str, Any]]:
+    method = item["install_method"]
+    args = dict(item.get("install_args") or {})
+    entry_id = f"tools.{item['id']}"
+    if method == "apt":
+        return [
+            _apt_op(
+                entry_id=entry_id,
+                op_type="tool_install_apt",
+                packages=list(args.get("packages") or ()),
+                requires_sudo=item.get("requires_sudo", True),
+                cache_dir=cache_dir,
+                reason=f"install {item['label']} via apt",
+            )
+        ]
+    if method == "apt_keyring":
+        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode="install")]
+    if method == "curl_installer":
+        return [_curl_op(entry_id, item, args, cache_dir, mode="install")]
+    if method == "npm":
+        return [_npm_op(entry_id, item, args, cache_dir, mode="install")]
+    return []
+
+
+def _upgrade_operations(item: Mapping[str, Any], cache_dir: Path) -> list[dict[str, Any]]:
+    method = item["install_method"]
+    args = dict(item.get("install_args") or {})
+    entry_id = f"tools.{item['id']}"
+    if method == "apt":
+        return [
+            _apt_op(
+                entry_id=entry_id,
+                op_type="tool_install_apt_upgrade",
+                packages=list(args.get("packages") or ()),
+                requires_sudo=item.get("requires_sudo", True),
+                cache_dir=cache_dir,
+                reason=f"upgrade {item['label']} via apt --only-upgrade",
+            )
+        ]
+    if method == "apt_keyring":
+        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode="upgrade")]
+    if method == "curl_installer":
+        # Re-running self-updating installers (claude.ai/install.sh) refreshes the install.
+        return [_curl_op(entry_id, item, args, cache_dir, mode="upgrade")]
+    if method == "npm":
+        return [_npm_op(entry_id, item, args, cache_dir, mode="upgrade")]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Operation factories
+# ---------------------------------------------------------------------------
+
+
+def _apt_op(
+    *,
+    entry_id: str,
+    op_type: str,
+    packages: list[str],
+    requires_sudo: bool,
+    cache_dir: Path,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "recipe": "tool_installs",
+        "type": op_type,
+        "packages": packages,
+        "requires_sudo": requires_sudo,
+        "requires_network": True,
+        "requires_approval": True,
+        "cache_dir": str(cache_dir),
+        "reason": reason,
+    }
+
+
+def _apt_keyring_op(
+    entry_id: str,
+    item: Mapping[str, Any],
+    args: Mapping[str, Any],
+    cache_dir: Path,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "recipe": "tool_installs",
+        "type": "tool_install_apt_keyring",
+        "mode": mode,
+        "packages": list(args.get("packages") or ()),
+        "keyring_url": args["keyring_url"],
+        "keyring_path": args["keyring_path"],
+        "source_line": args["source_line"],
+        "source_path": args["source_path"],
+        "requires_sudo": True,
+        "requires_network": True,
+        "requires_approval": True,
+        "cache_dir": str(cache_dir),
+        "reason": f"{mode} {item['label']} via GitHub keyring repo",
+    }
+
+
+def _curl_op(
+    entry_id: str,
+    item: Mapping[str, Any],
+    args: Mapping[str, Any],
+    cache_dir: Path,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    return {
+        "entry_id": entry_id,
+        "recipe": "tool_installs",
+        "type": "tool_install_curl",
+        "mode": mode,
+        "url": args["url"],
+        "script_name": args.get("script_name", "installer.sh"),
+        "requires_sudo": item.get("requires_sudo", False),
+        "requires_network": True,
+        "requires_approval": True,
+        "cache_dir": str(cache_dir),
+        "reason": f"{mode} {item['label']} via {args['url']}",
+    }
+
+
+def _npm_op(
+    entry_id: str,
+    item: Mapping[str, Any],
+    args: Mapping[str, Any],
+    cache_dir: Path,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    op_type = "tool_install_npm" if mode == "install" else "tool_install_npm_upgrade"
+    return {
+        "entry_id": entry_id,
+        "recipe": "tool_installs",
+        "type": op_type,
+        "mode": mode,
+        "package": args["package"],
+        "requires_sudo": item.get("requires_sudo", True),
+        "requires_network": True,
+        "requires_approval": True,
+        "cache_dir": str(cache_dir),
+        "reason": f"{mode} {item['label']} via npm",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def _dpkg_installed(runner: CommandRunner, package: str) -> bool:
+    dpkg = runner.which("dpkg-query")
+    if not dpkg:
+        return False
+    try:
+        result = runner.run(
+            [dpkg, "-W", "-f=${Status}", package],
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, RuntimeError):
+        return False
+    return result.returncode == 0 and "install ok installed" in (result.stdout or "")
+
+
+def _detect_version(command: str, found_path: str, runner: CommandRunner) -> str:
+    try:
+        result = runner.run([found_path, "--version"], capture_output=True, check=False)
+    except (OSError, RuntimeError):
+        return ""
+    output = (result.stdout or "").strip().splitlines()
+    return output[0] if output else ""
+
+
+# ---------------------------------------------------------------------------
+# Executors
+# ---------------------------------------------------------------------------
+
+
+def _sudo_prefix() -> list[str]:
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return []
+    return ["sudo"]
+
+
+def _execute_apt(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int:
+    packages = [str(pkg) for pkg in op.get("packages", []) if pkg]
+    if not packages:
+        return 0
+    apt_get = runner.which("apt-get")
+    if not apt_get:
+        op["result"] = "apt-get not found; install packages manually"
+        return 0
+    prefix = _sudo_prefix()
+    runner.run([*prefix, apt_get, "update"])
+    if mode == "upgrade":
+        runner.run([*prefix, apt_get, "install", "--only-upgrade", "-y", *packages])
+    else:
+        runner.run([*prefix, apt_get, "install", "-y", *packages])
+    return 1
+
+
+def _execute_apt_keyring(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) -> int:
+    packages = [str(pkg) for pkg in op.get("packages", []) if pkg]
+    if not packages:
+        return 0
+    apt_get = runner.which("apt-get")
+    if not apt_get:
+        op["result"] = "apt-get not found; install manually"
+        return 0
+    prefix = _sudo_prefix()
+    keyring_path = Path(op["keyring_path"])
+    source_path = Path(op["source_path"])
+
+    if not keyring_path.exists():
+        cached_keyring = Path(cache_dir) / keyring_path.name
+        runner.download(op["keyring_url"], cached_keyring)
+        runner.run([*prefix, "install", "-D", "-m", "0644", str(cached_keyring), str(keyring_path)])
+
+    arch = _detect_dpkg_arch(runner)
+    rendered_source = op["source_line"].replace("{ARCH}", arch)
+    cached_source = Path(cache_dir) / source_path.name
+    cached_source.parent.mkdir(parents=True, exist_ok=True)
+    cached_source.write_text(rendered_source + "\n")
+    runner.run([*prefix, "install", "-D", "-m", "0644", str(cached_source), str(source_path)])
+
+    runner.run([*prefix, apt_get, "update"])
+    if op.get("mode") == "upgrade":
+        runner.run([*prefix, apt_get, "install", "--only-upgrade", "-y", *packages])
+    else:
+        runner.run([*prefix, apt_get, "install", "-y", *packages])
+    return 1
+
+
+def _execute_curl(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) -> int:
+    sh = runner.which("sh") or "/bin/sh"
+    script = Path(cache_dir) / op["script_name"]
+    runner.download(op["url"], script)
+    if script.exists():
+        script.chmod(0o755)
+    prefix = _sudo_prefix() if op.get("requires_sudo") else []
+    runner.run([*prefix, sh, str(script)])
+    return 1
+
+
+def _execute_npm(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int:
+    package = op.get("package")
+    if not package:
+        return 0
+    npm = runner.which("npm")
+    if not npm:
+        op["result"] = "npm not found; install Node first or re-run option 5 after dev-base completes"
+        return 0
+    prefix = _sudo_prefix() if op.get("requires_sudo", True) else []
+    if mode == "upgrade":
+        runner.run([*prefix, npm, "update", "-g", package])
+    else:
+        runner.run([*prefix, npm, "install", "-g", package])
+    return 1
+
+
+def _detect_dpkg_arch(runner: CommandRunner) -> str:
+    dpkg = runner.which("dpkg")
+    if not dpkg:
+        return "amd64"
+    try:
+        result = runner.run([dpkg, "--print-architecture"], capture_output=True, check=False)
+    except (OSError, RuntimeError):
+        return "amd64"
+    return (result.stdout or "amd64").strip() or "amd64"

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -12,6 +12,9 @@ from .font_runner import CommandRunner
 TOOL_CACHE_REL = ".cache/000-dotfiles/tool-installers"
 DEV_BASE_ENTRY_ID = "tools.dev_base"
 
+_APT_OP_TYPE = {"install": "tool_install_apt", "upgrade": "tool_install_apt_upgrade"}
+_APT_REASON_SUFFIX = {"install": "apt", "upgrade": "apt --only-upgrade"}
+
 
 __all__ = (
     "build_tool_install_plan",
@@ -264,27 +267,25 @@ def _plan_tool_entry(
 
 def _tool_operations(item: Mapping[str, Any], cache_dir: Path, *, mode: str) -> list[dict[str, Any]]:
     method = item["install_method"]
-    args = dict(item.get("install_args") or {})
+    iargs = dict(item.get("install_args", {}))
     entry_id = f"tools.{item['id']}"
     if method == "apt":
-        op_type = "tool_install_apt_upgrade" if mode == "upgrade" else "tool_install_apt"
-        action_label = "apt --only-upgrade" if mode == "upgrade" else "apt"
         return [
             _apt_op(
                 entry_id=entry_id,
-                op_type=op_type,
-                packages=list(args.get("packages") or ()),
+                op_type=_APT_OP_TYPE[mode],
+                packages=list(iargs.get("packages", [])),
                 requires_sudo=item.get("requires_sudo", True),
                 cache_dir=cache_dir,
-                reason=f"{mode} {item['label']} via {action_label}",
+                reason=f"{mode} {item['label']} via {_APT_REASON_SUFFIX[mode]}",
             )
         ]
     if method == "apt_keyring":
-        return [_apt_keyring_op(entry_id, item, args, cache_dir, mode=mode)]
+        return [_apt_keyring_op(entry_id, item, iargs, cache_dir, mode=mode)]
     if method == "curl_installer":
-        return [_curl_op(entry_id, item, args, cache_dir, mode=mode)]
+        return [_curl_op(entry_id, item, iargs, cache_dir, mode=mode)]
     if method == "npm":
-        return [_npm_op(entry_id, item, args, cache_dir, mode=mode)]
+        return [_npm_op(entry_id, item, iargs, cache_dir, mode=mode)]
     return []
 
 

--- a/setup
+++ b/setup
@@ -490,6 +490,20 @@ run_machine_apply() {
     --yes)
 }
 
+run_machine_install_tools_preview() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools-plan \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME")
+}
+
+run_machine_install_tools_apply() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --backup-dir "$HOME/.dotfiles-backups" \
+    --yes)
+}
+
 run_machine_summary() {
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
     --repo "$DOTFILES_REPO" \
@@ -527,8 +541,9 @@ Next steps:
   2. Show full technical details.
   3. Show tool and sign-in guidance.
   4. Exit without writing.
+  5. Install / update developer tools (preview, then apply).
 EOF
-    printf 'Choose [1-4]: '
+    printf 'Choose [1-5]: '
     local choice
     if ! read -r choice; then
       echo
@@ -553,6 +568,19 @@ EOF
       4|"")
         echo "No changes applied."
         return 0
+        ;;
+      5)
+        echo
+        run_machine_install_tools_preview
+        echo
+        printf 'Apply tool install/update actions? [y/N]: '
+        local confirm
+        if read -r confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
+          echo
+          run_machine_install_tools_apply
+        else
+          echo "No tool changes applied."
+        fi
         ;;
       *)
         echo "Unknown choice: $choice" >&2

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -44,15 +44,18 @@ class FakeRunner:
             raise self.run_failures[Path(args[0]).name]
         command = Path(args[0]).name if args else ""
         if command == "dpkg-query":
-            package = args[-1]
-            if package in self.installed_dpkg:
-                return subprocess.CompletedProcess(args, 0, stdout="install ok installed", stderr="")
-            return subprocess.CompletedProcess(args, 1, stdout="", stderr="not installed")
+            return self._run_dpkg_query(args)
         if command == "dpkg" and "--print-architecture" in args:
             return subprocess.CompletedProcess(args, 0, stdout=f"{self.dpkg_arch}\n", stderr="")
         if "--version" in args:
             return subprocess.CompletedProcess(args, 0, stdout="dummy 1.2.3\n", stderr="")
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def _run_dpkg_query(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        package = args[-1]
+        if package in self.installed_dpkg:
+            return subprocess.CompletedProcess(args, 0, stdout="install ok installed", stderr="")
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="not installed")
 
     def download(self, url: str, target: Path) -> None:
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess  # nosec B404
+from unittest import mock
+
+from dotfiles_tools.baseline import DEV_BASE_PACKAGES
+from dotfiles_tools.tool_installer import (
+    DEV_BASE_ENTRY_ID,
+    build_tool_install_plan,
+    execute_tool_install_operation,
+)
+from tests.helpers import DotfilesTestCase
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        which: dict[str, str] | None = None,
+        installed_dpkg: tuple[str, ...] = (),
+        dpkg_arch: str = "amd64",
+        run_failures: dict[str, OSError] | None = None,
+    ) -> None:
+        self.which_map = which or {}
+        self.installed_dpkg = set(installed_dpkg)
+        self.dpkg_arch = dpkg_arch
+        self.run_failures = run_failures or {}
+        self.commands: list[list[str]] = []
+        self.downloads: list[tuple[str, Path]] = []
+
+    def which(self, command: str) -> str | None:
+        return self.which_map.get(command)
+
+    def run(
+        self,
+        args: list[str],
+        *,
+        capture_output: bool = False,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        self.commands.append(list(args))
+        if args and Path(args[0]).name in self.run_failures:
+            raise self.run_failures[Path(args[0]).name]
+        command = Path(args[0]).name if args else ""
+        if command == "dpkg-query":
+            package = args[-1]
+            if package in self.installed_dpkg:
+                return subprocess.CompletedProcess(args, 0, stdout="install ok installed", stderr="")
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="not installed")
+        if command == "dpkg" and "--print-architecture" in args:
+            return subprocess.CompletedProcess(args, 0, stdout=f"{self.dpkg_arch}\n", stderr="")
+        if "--version" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="dummy 1.2.3\n", stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def download(self, url: str, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("#!/bin/sh\necho fake\n")
+        self.downloads.append((url, target))
+
+
+class ToolInstallPlanTests(DotfilesTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.geteuid_patch = mock.patch("dotfiles_tools.tool_installer.os.geteuid", return_value=1000, create=True)
+        self.geteuid_patch.start()
+        self.addCleanup(self.geteuid_patch.stop)
+        self.platform_patch = mock.patch("dotfiles_tools.tool_installer.sys.platform", "linux")
+        self.platform_patch.start()
+        self.addCleanup(self.platform_patch.stop)
+
+    def _make_runner(self, **kwargs) -> FakeRunner:
+        defaults = dict(which={"dpkg-query": "/usr/bin/dpkg-query", "apt-get": "/usr/bin/apt-get"})
+        defaults.update(kwargs.pop("which", {}) and {"which": {**defaults["which"], **kwargs.pop("which")}} or {})
+        defaults.update(kwargs)
+        # remerge which if user passed it
+        return FakeRunner(**defaults)
+
+    def test_dev_base_apt_batched_install_fresh(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        dev_base_ops = [op for op in plan["operations"] if op.get("entry_id") == DEV_BASE_ENTRY_ID]
+        self.assertEqual(len(dev_base_ops), 1)
+        op = dev_base_ops[0]
+        self.assertEqual(op["type"], "tool_install_apt")
+        self.assertEqual(set(op["packages"]), set(DEV_BASE_PACKAGES))
+
+    def test_dev_base_partial_install(self) -> None:
+        home = self.make_home()
+        installed = DEV_BASE_PACKAGES[:5]
+        missing = DEV_BASE_PACKAGES[5:]
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query"},
+            installed_dpkg=installed,
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        dev_base_ops = [op for op in plan["operations"] if op.get("entry_id") == DEV_BASE_ENTRY_ID]
+        types = {op["type"]: set(op["packages"]) for op in dev_base_ops}
+        self.assertEqual(types["tool_install_apt"], set(missing))
+        self.assertEqual(types["tool_install_apt_upgrade"], set(installed))
+
+    def test_dev_base_all_installed_emits_upgrade_only(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query"},
+            installed_dpkg=DEV_BASE_PACKAGES,
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        dev_base_ops = [op for op in plan["operations"] if op.get("entry_id") == DEV_BASE_ENTRY_ID]
+        self.assertEqual(len(dev_base_ops), 1)
+        self.assertEqual(dev_base_ops[0]["type"], "tool_install_apt_upgrade")
+
+    def test_apt_keyring_for_gh_missing(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        gh_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.gh"]
+        self.assertEqual(len(gh_ops), 1)
+        self.assertEqual(gh_ops[0]["type"], "tool_install_apt_keyring")
+        self.assertEqual(gh_ops[0]["mode"], "install")
+        self.assertEqual(gh_ops[0]["packages"], ["gh"])
+
+    def test_apt_keyring_for_gh_installed_upgrade_path(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query", "gh": "/usr/bin/gh"})
+        plan = build_tool_install_plan(home, runner=runner)
+        gh_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.gh"]
+        self.assertEqual(len(gh_ops), 1)
+        self.assertEqual(gh_ops[0]["mode"], "upgrade")
+
+    def test_curl_installer_for_claude_install(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        claude_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.claude"]
+        self.assertEqual(len(claude_ops), 1)
+        self.assertEqual(claude_ops[0]["type"], "tool_install_curl")
+        self.assertEqual(claude_ops[0]["mode"], "install")
+        self.assertIn("install.sh", claude_ops[0]["url"])
+
+    def test_curl_installer_for_claude_upgrade_reruns_installer(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query", "claude": "/home/x/.local/bin/claude"},
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        claude_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.claude"]
+        self.assertEqual(claude_ops[0]["type"], "tool_install_curl")
+        self.assertEqual(claude_ops[0]["mode"], "upgrade")
+
+    def test_npm_install_for_codex_and_gemini(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        codex_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.codex"]
+        gemini_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.gemini"]
+        self.assertEqual(codex_ops[0]["type"], "tool_install_npm")
+        self.assertEqual(codex_ops[0]["package"], "@openai/codex")
+        self.assertEqual(gemini_ops[0]["package"], "@google/gemini-cli")
+
+    def test_npm_upgrade_when_present(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={
+                "dpkg-query": "/usr/bin/dpkg-query",
+                "codex": "/usr/local/bin/codex",
+                "gemini": "/usr/local/bin/gemini",
+            },
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        codex_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.codex"]
+        self.assertEqual(codex_ops[0]["type"], "tool_install_npm_upgrade")
+
+    def test_entries_include_installed_for_preview(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query", "git": "/usr/bin/git"},
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        git_entry = next(e for e in plan["entries"] if e.get("entry_id") == "tools.git")
+        self.assertEqual(git_entry["state"], "installed")
+        self.assertEqual(git_entry["current_path"], "/usr/bin/git")
+        self.assertEqual(git_entry["action"], "upgrade")
+
+    def test_unsupported_on_non_linux(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner()
+        with mock.patch("dotfiles_tools.tool_installer.sys.platform", "darwin"):
+            plan = build_tool_install_plan(home, runner=runner, env={})
+        self.assertEqual(plan["operations"], [])
+        self.assertTrue(all(entry["state"] == "unsupported" for entry in plan["entries"]))
+
+
+class ToolInstallExecuteTests(DotfilesTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.geteuid_patch = mock.patch(
+            "dotfiles_tools.tool_installer.os.geteuid", return_value=1000, create=True
+        )
+        self.geteuid_patch.start()
+        self.addCleanup(self.geteuid_patch.stop)
+
+    def test_apt_executes_with_sudo_prefix(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"apt-get": "/usr/bin/apt-get"})
+        op = {
+            "entry_id": DEV_BASE_ENTRY_ID,
+            "recipe": "tool_installs",
+            "type": "tool_install_apt",
+            "packages": ["curl", "wget"],
+            "cache_dir": str(home / ".cache"),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertEqual(runner.commands[0], ["sudo", "/usr/bin/apt-get", "update"])
+        self.assertEqual(
+            runner.commands[1],
+            ["sudo", "/usr/bin/apt-get", "install", "-y", "curl", "wget"],
+        )
+
+    def test_apt_upgrade_uses_only_upgrade_flag(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"apt-get": "/usr/bin/apt-get"})
+        op = {
+            "entry_id": DEV_BASE_ENTRY_ID,
+            "recipe": "tool_installs",
+            "type": "tool_install_apt_upgrade",
+            "packages": ["git"],
+            "cache_dir": str(home / ".cache"),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertIn("--only-upgrade", runner.commands[1])
+
+    def test_apt_missing_apt_get_soft_skips(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={})
+        op = {
+            "entry_id": DEV_BASE_ENTRY_ID,
+            "recipe": "tool_installs",
+            "type": "tool_install_apt",
+            "packages": ["git"],
+            "cache_dir": str(home / ".cache"),
+        }
+        result = execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertEqual(result, 0)
+        self.assertIn("apt-get not found", op["result"])
+        self.assertEqual(runner.commands, [])
+
+    def test_curl_installer_downloads_and_runs(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"sh": "/bin/sh"})
+        cache_dir = home / ".cache" / "tool-installers"
+        op = {
+            "entry_id": "tools.claude",
+            "recipe": "tool_installs",
+            "type": "tool_install_curl",
+            "url": "https://claude.ai/install.sh",
+            "script_name": "claude-install.sh",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(len(runner.downloads), 1)
+        self.assertEqual(runner.downloads[0][0], "https://claude.ai/install.sh")
+        self.assertTrue(runner.commands)
+        self.assertEqual(runner.commands[-1][0], "/bin/sh")
+        # No sudo for the curl installer.
+        self.assertNotIn("sudo", runner.commands[-1])
+
+    def test_npm_missing_skips(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={})
+        op = {
+            "entry_id": "tools.codex",
+            "recipe": "tool_installs",
+            "type": "tool_install_npm",
+            "package": "@openai/codex",
+            "cache_dir": str(home / ".cache"),
+            "requires_sudo": True,
+        }
+        result = execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertEqual(result, 0)
+        self.assertIn("npm not found", op["result"])
+
+    def test_npm_present_runs_global_install(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"npm": "/usr/bin/npm"})
+        op = {
+            "entry_id": "tools.codex",
+            "recipe": "tool_installs",
+            "type": "tool_install_npm",
+            "package": "@openai/codex",
+            "cache_dir": str(home / ".cache"),
+            "requires_sudo": True,
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertEqual(
+            runner.commands[0],
+            ["sudo", "/usr/bin/npm", "install", "-g", "@openai/codex"],
+        )
+
+    def test_apt_keyring_downloads_keyring_and_writes_source(self) -> None:
+        home = self.make_home()
+        cache_dir = home / ".cache" / "tool-installers"
+        runner = FakeRunner(
+            which={
+                "apt-get": "/usr/bin/apt-get",
+                "dpkg": "/usr/bin/dpkg",
+            },
+            dpkg_arch="amd64",
+        )
+        op = {
+            "entry_id": "tools.gh",
+            "recipe": "tool_installs",
+            "type": "tool_install_apt_keyring",
+            "mode": "install",
+            "packages": ["gh"],
+            "keyring_url": "https://example.test/keyring.gpg",
+            "keyring_path": str(home / "keyrings" / "gh.gpg"),
+            "source_line": "deb [arch={ARCH} signed-by=...] https://example.test stable main",
+            "source_path": str(home / "sources.list.d" / "gh.list"),
+            "cache_dir": str(cache_dir),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(len(runner.downloads), 1)
+        # First install command should be the keyring file.
+        install_cmds = [cmd for cmd in runner.commands if cmd[:1] == ["sudo"] and "install" in cmd]
+        self.assertGreaterEqual(len(install_cmds), 2)
+        # Source line was rendered with the architecture.
+        rendered_source_path = cache_dir / "gh.list"
+        self.assertIn("arch=amd64", rendered_source_path.read_text())
+
+    def test_sudo_gating_as_root(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"apt-get": "/usr/bin/apt-get"})
+        op = {
+            "entry_id": DEV_BASE_ENTRY_ID,
+            "recipe": "tool_installs",
+            "type": "tool_install_apt",
+            "packages": ["git"],
+            "cache_dir": str(home / ".cache"),
+        }
+        with mock.patch("dotfiles_tools.tool_installer.os.geteuid", return_value=0, create=True):
+            execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
+        self.assertNotIn("sudo", runner.commands[0])


### PR DESCRIPTION
## Summary

- Adds a new menu option 5 to `./setup` that previews and applies developer-tool installs/updates.
- On a fresh Ubuntu box, installs a 32-package dev-base apt bundle (`curl`, `wget`, `unzip`, `build-essential`, `nodejs`, `npm`, `jq`, `ripgrep`, ssh client, etc.) plus the seven tracked CLIs: `git`, `gh` (official GitHub keyring repo), `fish`, `direnv`, `claude` (curl installer), `codex` and `gemini` (npm).
- On re-runs, detects what's already installed and routes those entries through the appropriate upgrade path (`apt --only-upgrade`, `npm update -g`, or re-run the self-updating curl installer for `claude`).

## How option 5 looks

```
Tool install/update preview:
  Already installed (will be updated where possible):
    - Git: /usr/bin/git git version 2.43.0 -> apt --only-upgrade
    - Claude Code: /opt/node22/bin/claude 2.1.126 (Claude Code) -> re-run installer (self-update)
  Missing (will be installed):
    - GitHub CLI: apt + keyring repo (sudo)
    - fish: apt (sudo)
    - direnv: apt (sudo)
    - Codex CLI: npm install -g (sudo)
    - Gemini CLI: npm install -g (sudo)
  Dev base packages (32 total, grouped):
    tls_keys   3/3 installed -> apt --only-upgrade
    transfer   2/2 installed -> apt --only-upgrade
    archives   4/4 installed -> apt --only-upgrade
    build      3/3 installed -> apt --only-upgrade
    python     2/3 installed (missing: python3-venv)
    node       0/2 installed (missing: nodejs, npm)
    json_text  2/3 installed (missing: fd-find)
    editors    2/2 installed -> apt --only-upgrade
    shell      2/3 installed (missing: man-db)
    system     1/3 installed (missing: htop, tree)
    network    0/4 installed (missing: openssh-client, dnsutils, iputils-ping, net-tools)
  -> One batched apt install for 11 missing packages, one batched apt upgrade for 21 present packages.
```

After confirming `y`, the apply runs: one batched `sudo apt-get install -y …` for missing dev-base packages, one batched `--only-upgrade` for the rest, the `gh` keyring repo setup + install, the curl installer for `claude`, and `npm install -g` for `codex`/`gemini`.

## Architecture

Mirrors the existing font-install pattern: catalog → plan → operations → execute, all in stdlib Python reusing the existing `CommandRunner`. Option 1 keeps its current scope (files + fonts only); tool installs are surfaced only by the new `bootstrap-install-tools-plan` / `bootstrap-install-tools` subcommands so the user sees a per-tool preview before any sudo prompt.

| Path | Change |
|---|---|
| `dotfiles_tools/baseline.py` | Extended `TOOL_BASELINE` with `install_method` / `install_args` / `requires_sudo`. Added `DEV_BASE_GROUPS` (11 groups, 32 packages). |
| `dotfiles_tools/tool_installer.py` | **New.** `build_tool_install_plan` + `execute_tool_install_operation` with handlers for `apt`, `apt_keyring`, `curl_installer`, `npm`, plus their upgrade variants. |
| `dotfiles_tools/bootstrap.py` | Added `build_tool_install_subplan` + `apply_tool_installs`. New `recipe == "tool_installs"` branch in `_execute_operation`. |
| `dotfiles_tools/cli.py` | New `bootstrap-install-tools-plan` and `bootstrap-install-tools` subcommands. |
| `dotfiles_tools/reports.py` | Added preview rendering for `extra["tools"]`. |
| `setup` | Added menu option 5 with preview-then-confirm flow. |
| `tests/test_tool_installer.py` | **New.** 18 test cases mirroring the `test_fonts.py` `FakeRunner` pattern. |

## Test plan

- [x] `uv run python -m unittest discover -s tests` — all 88 tests pass (including the 18 new ones in `test_tool_installer.py`).
- [x] `uv run python -m dotfiles_tools bootstrap-install-tools-plan --repo . --home "$HOME"` — preview renders with installed/missing breakdown and per-group dev-base counts.
- [ ] Manual run of `./setup` on a fresh Ubuntu container, selecting option 5, to validate the end-to-end install path (apt, keyring, curl, npm).
- [ ] Re-run `./setup` on the same machine and confirm option 5 routes installed tools through the upgrade path.

https://claude.ai/code/session_011JzgecDik64Wk4PNAmUwsD

---
_Generated by [Claude Code](https://claude.ai/code/session_011JzgecDik64Wk4PNAmUwsD)_