### PR TITLE
fix: bash interpreter for curl installs, state-aware menu, post-install verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ ls -la CLAUDE.md GEMINI.md
 - Adding a new tool config: create a `<tool>/` directory with `<file>.template` files; update `README.md` table and the bootstrap commands.
 - Updating an existing template: edit the `.template` file directly; note in the commit message if any placeholder names changed.
 - Never commit files containing real credentials. Run `git diff --staged` before every commit and check for tokens, keys, or personal paths.
+- Adding a curl-based installer to `TOOL_BASELINE`: declare `"interpreter": "..."` in `install_args` if the script is anything other than bash. `_execute_curl` runs the script under that interpreter (Ubuntu's default `/bin/sh` is dash and rejects bash extensions).
+- Adding a new bootstrap tool to `TOOL_BASELINE`: declare a `post_install` tuple (may be empty) listing follow-up actions. `kind="auto"` runs when the user passes `--yes`; `kind="guidance"` only prints the command. Templates may use `{which:<name>}` and `{user}` placeholders; unresolved placeholders downgrade to guidance automatically.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,38 @@ git clone https://github.com/kairin/000-dotfiles.git ~/000-dotfiles
 ~/000-dotfiles/setup ~/Apps/my-project
 ```
 
-`./setup` with no args audits the current machine and offers four choices:
-apply safe dotfiles + fonts, show full diagnostics, show sign-in guidance, or
-exit. Nothing is written without explicit confirmation.
+`./setup` with no args audits the current machine and presents a **state-aware
+menu**. When developer tools are missing (fresh-Ubuntu box), option 1 is
+"Install / update developer tools" and the apply-configs option moves to 2.
+When tools are already installed, option 1 applies safe dotfile + font drift,
+and option 5 re-runs the tool installer to upgrade existing tools. Nothing is
+written without explicit confirmation. After tool install, the run prints a
+verification panel and a list of post-install actions (login commands, etc.)
+to complete on your terms.
+
+### First-time setup on a fresh Ubuntu box
+
+```bash
+git clone https://github.com/kairin/000-dotfiles.git ~/000-dotfiles
+~/000-dotfiles/setup
+# 1. Install / update developer tools (preview, then apply)  → choose 1, then y
+#    Installs the dev-base apt bundle, git, gh, fish, direnv, claude, codex,
+#    gemini. Auto-runs fish chsh + fisher bootstrap + plugin apply.
+#    Prints sign-in commands for gh/claude/codex/gemini.
+# 2. Apply safe changes  → choose 2, then y
+#    Copies all non-protected config templates and installs Nerd Fonts.
+# Run the printed sign-in commands when ready (gh auth login, claude /login,
+# codex auth login, gemini).
+```
+
+### Re-running on a configured machine
+
+```bash
+~/000-dotfiles/setup
+# Option 1 applies any config drift (safe, backups files it overwrites).
+# Option 5 upgrades installed tools (apt --only-upgrade, npm update -g,
+# re-run self-updating curl installers).
+```
 
 ## What you can do with this
 

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -15,6 +15,7 @@ TOOL_BASELINE = (
         "install_args": {},
         "requires_sudo": False,
         "install_hint": "Installed automatically by ./setup when missing.",
+        "post_install": (),
     },
     {
         "id": "git",
@@ -24,7 +25,14 @@ TOOL_BASELINE = (
         "install_method": "apt",
         "install_args": {"packages": ("git",)},
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (apt).",
+        "install_hint": "Installed by the setup tool-install menu option (apt).",
+        "post_install": (
+            {
+                "kind": "guidance",
+                "label": "Configure git identity (skip if git/config already sets it)",
+                "command_template": ("git", "config", "--global", "user.email", "<your-email>"),
+            },
+        ),
     },
     {
         "id": "gh",
@@ -43,7 +51,14 @@ TOOL_BASELINE = (
             "source_path": "/etc/apt/sources.list.d/github-cli.list",
         },
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (GitHub keyring repo).",
+        "install_hint": "Installed by the setup tool-install menu option (GitHub keyring repo).",
+        "post_install": (
+            {
+                "kind": "guidance",
+                "label": "Sign in to GitHub CLI",
+                "command_template": ("gh", "auth", "login"),
+            },
+        ),
     },
     {
         "id": "fish",
@@ -53,7 +68,29 @@ TOOL_BASELINE = (
         "install_method": "apt",
         "install_args": {"packages": ("fish",)},
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (apt).",
+        "install_hint": "Installed by the setup tool-install menu option (apt).",
+        "post_install": (
+            {
+                "kind": "auto",
+                "label": "Set fish as default shell",
+                "command_template": ("sudo", "chsh", "-s", "{which:fish}", "{user}"),
+            },
+            {
+                "kind": "auto",
+                "label": "Bootstrap fisher (one-time)",
+                "command_template": (
+                    "fish",
+                    "-c",
+                    "curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher",
+                ),
+            },
+            {
+                "kind": "auto",
+                "label": "Apply fish_plugins via fisher update",
+                "command_template": ("fish", "-c", "fisher update"),
+                "requires_protected_apply": ("fish/fish_plugins",),
+            },
+        ),
     },
     {
         "id": "direnv",
@@ -63,7 +100,8 @@ TOOL_BASELINE = (
         "install_method": "apt",
         "install_args": {"packages": ("direnv",)},
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (apt).",
+        "install_hint": "Installed by the setup tool-install menu option (apt).",
+        "post_install": (),  # hook is in fish/direnv.fish.template; no manual step needed
     },
     {
         "id": "codex",
@@ -73,7 +111,14 @@ TOOL_BASELINE = (
         "install_method": "npm",
         "install_args": {"package": "@openai/codex"},
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (npm install -g @openai/codex).",
+        "install_hint": "Installed by the setup tool-install menu option (npm install -g @openai/codex).",
+        "post_install": (
+            {
+                "kind": "guidance",
+                "label": "Sign in to Codex CLI",
+                "command_template": ("codex", "auth", "login"),
+            },
+        ),
     },
     {
         "id": "claude",
@@ -84,9 +129,17 @@ TOOL_BASELINE = (
         "install_args": {
             "url": "https://claude.ai/install.sh",
             "script_name": "claude-install.sh",
+            "interpreter": "bash",
         },
         "requires_sudo": False,
-        "install_hint": "Installed by setup option 5 (claude.ai/install.sh).",
+        "install_hint": "Installed by the setup tool-install menu option (claude.ai/install.sh).",
+        "post_install": (
+            {
+                "kind": "guidance",
+                "label": "Sign in to Claude Code",
+                "command_template": ("claude", "/login"),
+            },
+        ),
     },
     {
         "id": "gemini",
@@ -96,7 +149,14 @@ TOOL_BASELINE = (
         "install_method": "npm",
         "install_args": {"package": "@google/gemini-cli"},
         "requires_sudo": True,
-        "install_hint": "Installed by setup option 5 (npm install -g @google/gemini-cli).",
+        "install_hint": "Installed by the setup tool-install menu option (npm install -g @google/gemini-cli).",
+        "post_install": (
+            {
+                "kind": "guidance",
+                "label": "Sign in to Gemini CLI",
+                "command_template": ("gemini",),
+            },
+        ),
     },
 )
 
@@ -175,7 +235,7 @@ def _extend_missing_tools(lines: list[str], missing_tools: list[dict[str, Any]])
     lines.append("  Missing tools:")
     for item in missing_tools:
         if item.get("bootstrap"):
-            hint = "Install via setup option 5 (Install / update developer tools)."
+            hint = "Install via the setup tool-install menu option."
         else:
             hint = item["install_hint"]
         lines.append(f"    - {item['command']}: {hint}")

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -11,6 +11,8 @@ from .tool_installer import (
     TOOL_CACHE_REL,
     build_tool_install_plan,
     execute_tool_install_operation,
+    run_post_install_actions,
+    verify_installed_tools,
 )
 
 
@@ -151,7 +153,31 @@ def apply_tool_installs(
     if plan.errors or any(entry.get("state") in FAILED_STATES for entry in plan.entries):
         plan.status = "failed"
         return plan
-    return _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
+    report = _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
+    _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner)
+    return report
+
+
+def _attach_verification_and_post_install(
+    report: Report,
+    repo_path: Path,
+    home_path: Path,
+    yes: bool,
+    env: Mapping[str, str] | None,
+    runner: CommandRunner | None,
+) -> None:
+    if report.status == "failed":
+        return
+    verification = verify_installed_tools(home_path, runner=runner, env=env)
+    actions = run_post_install_actions(
+        home_path, yes=yes, runner=runner, env=env, repo_path=repo_path
+    )
+    report.extra["verification"] = verification
+    report.extra["post_install_actions"] = actions
+    if any(not item["verified"] for item in verification):
+        report.status = "warning"
+    if any(item.get("status") == "failed" for item in actions):
+        report.status = "warning"
 
 
 def _execute_bootstrap_operations(

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -186,8 +186,6 @@ def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[st
     for action in actions:
         collected.extend(action.get("backups") or [])
     return collected
-    if any(item.get("status") == "failed" for item in actions):
-        report.status = "warning"
 
 
 def _execute_bootstrap_operations(

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -154,7 +154,7 @@ def apply_tool_installs(
         plan.status = "failed"
         return plan
     report = _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
-    _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner)
+    _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner, backup_path)
     return report
 
 
@@ -165,17 +165,27 @@ def _attach_verification_and_post_install(
     yes: bool,
     env: Mapping[str, str] | None,
     runner: CommandRunner | None,
+    backup_dir: Path,
 ) -> None:
     if report.status == "failed":
         return
     verification = verify_installed_tools(home_path, runner=runner, env=env)
     actions = run_post_install_actions(
-        home_path, yes=yes, runner=runner, env=env, repo_path=repo_path
+        home_path, yes=yes, runner=runner, env=env,
+        repo_path=repo_path, backup_dir=backup_dir,
     )
     report.extra["verification"] = verification
     report.extra["post_install_actions"] = actions
+    report.backups.extend(_collect_post_install_backups(actions))
     if any(not item["verified"] for item in verification):
         report.status = "warning"
+
+
+def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    collected: list[dict[str, Any]] = []
+    for action in actions:
+        collected.extend(action.get("backups") or [])
+    return collected
     if any(item.get("status") == "failed" for item in actions):
         report.status = "warning"
 

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -4,10 +4,11 @@ import argparse
 from pathlib import Path
 from typing import Any, Sequence
 
-from .bootstrap import build_bootstrap_plan
+from .bootstrap import build_bootstrap_plan, build_tool_install_subplan
 from .doctor import run_doctor
 from .manifest import ManifestEntry, ManifestError, load_manifest
 from .reports import Report
+from .tool_installer import DEV_BASE_ENTRY_ID
 
 
 def render_machine_summary(repo: Path | str, home: Path | str, *, profile: str = "machine") -> str:
@@ -24,6 +25,28 @@ def render_menu_label(repo: Path | str, home: Path | str, *, profile: str = "mac
     plan = build_bootstrap_plan(repo_path, home_path, profile=profile)
     groups = _group_entries(plan.entries)
     return _option_one_label(plan, groups)
+
+
+def render_menu_mode(repo: Path | str, home: Path | str) -> str:
+    """Return 'tools_missing' if any non-dev-base bootstrap tool is absent;
+    otherwise 'tools_present'. The bash menu reads this token to choose the
+    fresh-box vs. configured-machine option ordering."""
+    plan = build_tool_install_subplan(Path(repo).resolve(), Path(home).resolve())
+    has_missing = any(
+        entry.get("state") == "missing"
+        for entry in plan.entries
+        if entry.get("entry_id") != DEV_BASE_ENTRY_ID
+    )
+    return "tools_missing" if has_missing else "tools_present"
+
+
+def render_missing_tool_count(repo: Path | str, home: Path | str) -> int:
+    plan = build_tool_install_subplan(Path(repo).resolve(), Path(home).resolve())
+    return sum(
+        1
+        for entry in plan.entries
+        if entry.get("state") == "missing" and entry.get("entry_id") != DEV_BASE_ENTRY_ID
+    )
 
 
 def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, profile: str = "machine") -> str:
@@ -521,9 +544,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--home", required=True)
     parser.add_argument("--profile", default="machine")
     parser.add_argument("--menu-label", action="store_true")
+    parser.add_argument("--menu-mode", action="store_true")
+    parser.add_argument("--missing-tool-count", action="store_true")
     args = parser.parse_args(argv)
     if args.menu_label:
         print(render_menu_label(args.repo, args.home, profile=args.profile))
+    elif args.menu_mode:
+        print(render_menu_mode(args.repo, args.home))
+    elif args.missing_tool_count:
+        print(render_missing_tool_count(args.repo, args.home))
     else:
         print(render_machine_summary(args.repo, args.home, profile=args.profile), end="")
     return 0

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -152,6 +152,8 @@ def _extend_extra(lines: list[str], extra: dict[str, Any]) -> None:
     _extend_extra_tool_checks(lines, extra.get("tool_checks") or [])
     _extend_extra_auth_guidance(lines, extra.get("auth_guidance") or [])
     _extend_extra_tools(lines, extra.get("tools") or [])
+    _extend_extra_verification(lines, extra.get("verification") or [])
+    _extend_extra_post_install(lines, extra.get("post_install_actions") or [])
 
 
 def _extend_extra_fonts(lines: list[str], fonts: list[dict[str, Any]]) -> None:
@@ -297,3 +299,72 @@ def _dev_base_summary_line(missing: list[str], installed: list[str]) -> str:
     if installed:
         return f"  -> One batched apt upgrade for {len(installed)} present packages."
     return ""
+
+
+def _extend_extra_verification(lines: list[str], verification: list[dict[str, Any]]) -> None:
+    if not verification:
+        return
+    lines.append("verification:")
+    for item in verification:
+        glyph = "OK" if item.get("verified") else "MISSING"
+        path = item.get("path") or "not found on PATH"
+        version = f"  ({item['version']})" if item.get("version") else ""
+        lines.append(f"  {glyph}  {item.get('command', ''):<10s} {path}{version}")
+
+
+def _extend_extra_post_install(lines: list[str], actions: list[dict[str, Any]]) -> None:
+    if not actions:
+        return
+    by_status = _post_install_group_by_status(actions)
+    _extend_post_install_auto(lines, by_status["ran"], by_status["failed"])
+    _extend_post_install_skipped(lines, by_status["skipped"])
+    _extend_post_install_guidance(lines, by_status["guidance"])
+
+
+def _post_install_group_by_status(actions: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {
+        "ran": [], "failed": [], "skipped": [], "guidance": [],
+    }
+    for action in actions:
+        bucket = groups.get(action.get("status"))
+        if bucket is not None:
+            bucket.append(action)
+    return groups
+
+
+def _extend_post_install_auto(
+    lines: list[str],
+    auto_run: list[dict[str, Any]],
+    auto_failed: list[dict[str, Any]],
+) -> None:
+    if not (auto_run or auto_failed):
+        return
+    lines.append("post-install actions (auto-run, --yes):")
+    for item in auto_run:
+        lines.append(_post_install_line(item, glyph="OK"))
+    for item in auto_failed:
+        lines.append(_post_install_line(item, glyph="FAIL"))
+        if item.get("result"):
+            lines.append(f"      reason: {item['result']}")
+
+
+def _extend_post_install_skipped(lines: list[str], skipped: list[dict[str, Any]]) -> None:
+    if not skipped:
+        return
+    lines.append("post-install actions (skipped, unresolved placeholder):")
+    for item in skipped:
+        lines.append(f"  - {item.get('tool')}  {item.get('label')}: {item.get('reason')}")
+
+
+def _extend_post_install_guidance(lines: list[str], guidance: list[dict[str, Any]]) -> None:
+    if not guidance:
+        return
+    lines.append("post-install actions (manual, run when ready):")
+    for item in guidance:
+        cmd = " ".join(item.get("command") or item.get("raw_template") or [])
+        lines.append(f"  - {item.get('tool'):<8s} {item.get('label')}:  {cmd}")
+
+
+def _post_install_line(item: dict[str, Any], *, glyph: str) -> str:
+    cmd = " ".join(item.get("command") or [])
+    return f"  {glyph}  {item.get('tool'):<8s} {item.get('label')}:  {cmd}"

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -19,6 +19,8 @@ _APT_REASON_SUFFIX = {"install": "apt", "upgrade": "apt --only-upgrade"}
 __all__ = (
     "build_tool_install_plan",
     "execute_tool_install_operation",
+    "verify_installed_tools",
+    "run_post_install_actions",
     "TOOL_CACHE_REL",
     "DEV_BASE_ENTRY_ID",
 )
@@ -357,6 +359,7 @@ def _curl_op(
         "mode": mode,
         "url": args["url"],
         "script_name": args.get("script_name", "installer.sh"),
+        "interpreter": args.get("interpreter", "bash"),
         "requires_sudo": item.get("requires_sudo", False),
         "requires_network": True,
         "requires_approval": True,
@@ -468,7 +471,8 @@ def _execute_apt_keyring(op: dict[str, Any], runner: CommandRunner, cache_dir: P
 
 
 def _execute_curl(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) -> int:
-    sh = runner.which("sh") or "/bin/sh"
+    interpreter_name = op.get("interpreter", "bash")
+    interpreter = runner.which(interpreter_name) or f"/bin/{interpreter_name}"
     cache_dir.mkdir(parents=True, exist_ok=True)
     script = cache_dir / op["script_name"]
     runner.download(op["url"], script)
@@ -477,7 +481,7 @@ def _execute_curl(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) ->
         return 0
     script.chmod(0o755)
     prefix = _sudo_prefix() if op.get("requires_sudo") else []
-    runner.run([*prefix, sh, str(script)])
+    runner.run([*prefix, interpreter, str(script)])
     return 1
 
 
@@ -521,3 +525,157 @@ def _detect_dpkg_arch(runner: CommandRunner) -> str:
     except (OSError, RuntimeError):
         return "amd64"
     return (result.stdout or "amd64").strip() or "amd64"
+
+
+# ---------------------------------------------------------------------------
+# Verification + post-install actions
+# ---------------------------------------------------------------------------
+
+
+def verify_installed_tools(
+    home: Path | str,
+    *,
+    runner: CommandRunner | None = None,
+    env: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Re-probe each bootstrap tool. Returns one result per tool with
+    keys: entry_id, label, command, path, verified (bool), version."""
+    effective_env = dict(os.environ if env is None else env)
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
+    results: list[dict[str, Any]] = []
+    for item in TOOL_BASELINE:
+        if not item.get("bootstrap"):
+            continue
+        path = effective_runner.which(item["command"])
+        version = _detect_version(item["command"], path, effective_runner) if path else ""
+        results.append({
+            "entry_id": f"tools.{item['id']}",
+            "label": item["label"],
+            "command": item["command"],
+            "path": path,
+            "verified": bool(path),
+            "version": version,
+        })
+    return results
+
+
+def run_post_install_actions(
+    home: Path | str,
+    *,
+    yes: bool = False,
+    runner: CommandRunner | None = None,
+    env: Mapping[str, str] | None = None,
+    repo_path: Path | str | None = None,
+) -> list[dict[str, Any]]:
+    """For each verified tool, walk its `post_install` list:
+      - kind='auto' AND yes=True → execute via runner.run; record outcome.
+      - kind='auto' AND yes=False → downgrade to guidance, record command.
+      - kind='guidance' → record command for printing.
+    Templates with `{which:<name>}` or `{user}` placeholders are substituted
+    before execution; an unresolved placeholder downgrades the action to
+    guidance. `requires_protected_apply` copies the listed protected files
+    from the repo before exec (only when yes=True and repo_path is set)."""
+    effective_env = dict(os.environ if env is None else env)
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
+    repo = Path(repo_path).resolve() if repo_path else None
+    home_path = Path(home).expanduser().resolve()
+    results: list[dict[str, Any]] = []
+    for item in TOOL_BASELINE:
+        if not item.get("bootstrap"):
+            continue
+        if not effective_runner.which(item["command"]):
+            continue  # only run post-install for tools we can actually verify
+        for action in item.get("post_install", ()):
+            results.append(_run_one_post_install(
+                item, action, effective_runner, effective_env, yes=yes,
+                repo=repo, home=home_path,
+            ))
+    return results
+
+
+def _run_one_post_install(
+    item: Mapping[str, Any],
+    action: Mapping[str, Any],
+    runner: CommandRunner,
+    env: Mapping[str, str],
+    *,
+    yes: bool,
+    repo: Path | None,
+    home: Path,
+) -> dict[str, Any]:
+    label = action.get("label", "")
+    kind = action.get("kind", "guidance")
+    template = list(action.get("command_template", ()))
+    rendered, unresolved = _render_post_install_template(template, runner, env)
+    base = {
+        "tool": item["id"],
+        "label": label,
+        "kind": kind,
+        "command": rendered,
+        "raw_template": template,
+    }
+    if unresolved:
+        return {**base, "kind": "guidance", "status": "skipped",
+                "reason": f"unresolved placeholder: {unresolved}"}
+    if kind != "auto" or not yes:
+        return {**base, "status": "guidance"}
+    protected = list(action.get("requires_protected_apply", ()))
+    overrides = _apply_protected_files(protected, repo, home) if protected else []
+    try:
+        runner.run(rendered)
+    except (OSError, RuntimeError) as exc:
+        return {**base, "status": "failed", "result": str(exc), "protected_overrides": overrides}
+    return {**base, "status": "ran", "protected_overrides": overrides}
+
+
+def _render_post_install_template(
+    template: list[str],
+    runner: CommandRunner,
+    env: Mapping[str, str],
+) -> tuple[list[str], str | None]:
+    rendered: list[str] = []
+    for token in template:
+        substituted, missing = _substitute_token(token, runner, env)
+        if missing:
+            return rendered, missing
+        rendered.append(substituted)
+    return rendered, None
+
+
+def _substitute_token(
+    token: str,
+    runner: CommandRunner,
+    env: Mapping[str, str],
+) -> tuple[str, str | None]:
+    if not (token.startswith("{") and token.endswith("}")):
+        return token, None
+    expr = token[1:-1]
+    if expr == "user":
+        user = env.get("USER") or env.get("LOGNAME")
+        return (user, None) if user else (token, "user")
+    if expr.startswith("which:"):
+        name = expr[len("which:"):]
+        path = runner.which(name)
+        return (path, None) if path else (token, expr)
+    return token, expr
+
+
+def _apply_protected_files(
+    protected: list[str],
+    repo: Path | None,
+    home: Path,
+) -> list[dict[str, str]]:
+    if not repo:
+        return []
+    overrides: list[dict[str, str]] = []
+    for rel in protected:
+        # rel is repo-relative like "fish/fish_plugins" → target is
+        # ~/.config/fish/fish_plugins (mirror the manifest mapping).
+        source = repo / rel
+        target = home / ".config" / rel
+        if not source.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source.read_text())
+        overrides.append({"source": str(source), "target": str(target)})
+    return overrides

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import sys
 from typing import Any, Mapping
 
+from .backups import BackupError, create_backup
 from .baseline import DEV_BASE_GROUPS, DEV_BASE_PACKAGES, TOOL_BASELINE
 from .font_runner import CommandRunner
+from .manifest import ManifestError, load_manifest
 
 
 TOOL_CACHE_REL = ".cache/000-dotfiles/tool-installers"
@@ -566,6 +568,7 @@ def run_post_install_actions(
     runner: CommandRunner | None = None,
     env: Mapping[str, str] | None = None,
     repo_path: Path | str | None = None,
+    backup_dir: Path | str | None = None,
 ) -> list[dict[str, Any]]:
     """For each verified tool, walk its `post_install` list:
       - kind='auto' AND yes=True → execute via runner.run; record outcome.
@@ -574,21 +577,36 @@ def run_post_install_actions(
     Templates with `{which:<name>}` or `{user}` placeholders are substituted
     before execution; an unresolved placeholder downgrades the action to
     guidance. `requires_protected_apply` copies the listed protected files
-    from the repo before exec (only when yes=True and repo_path is set)."""
+    from the repo before exec (only when yes=True and repo_path is set);
+    existing targets are backed up to `backup_dir` first."""
     effective_env = dict(os.environ if env is None else env)
     effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
     repo = Path(repo_path).resolve() if repo_path else None
     home_path = Path(home).expanduser().resolve()
+    backup = Path(backup_dir).expanduser().resolve() if backup_dir else None
+    return _walk_post_install(
+        effective_runner, effective_env, yes=yes,
+        repo=repo, home=home_path, backup_dir=backup,
+    )
+
+
+def _walk_post_install(
+    runner: CommandRunner,
+    env: Mapping[str, str],
+    *,
+    yes: bool,
+    repo: Path | None,
+    home: Path,
+    backup_dir: Path | None,
+) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for item in TOOL_BASELINE:
-        if not item.get("bootstrap"):
+        if not item.get("bootstrap") or not runner.which(item["command"]):
             continue
-        if not effective_runner.which(item["command"]):
-            continue  # only run post-install for tools we can actually verify
         for action in item.get("post_install", ()):
             results.append(_run_one_post_install(
-                item, action, effective_runner, effective_env, yes=yes,
-                repo=repo, home=home_path,
+                item, action, runner, env, yes=yes,
+                repo=repo, home=home, backup_dir=backup_dir,
             ))
     return results
 
@@ -602,30 +620,47 @@ def _run_one_post_install(
     yes: bool,
     repo: Path | None,
     home: Path,
+    backup_dir: Path | None,
 ) -> dict[str, Any]:
     label = action.get("label", "")
     kind = action.get("kind", "guidance")
     template = list(action.get("command_template", ()))
     rendered, unresolved = _render_post_install_template(template, runner, env)
     base = {
-        "tool": item["id"],
-        "label": label,
-        "kind": kind,
-        "command": rendered,
-        "raw_template": template,
+        "tool": item["id"], "label": label, "kind": kind,
+        "command": rendered, "raw_template": template,
     }
     if unresolved:
         return {**base, "kind": "guidance", "status": "skipped",
                 "reason": f"unresolved placeholder: {unresolved}"}
     if kind != "auto" or not yes:
         return {**base, "status": "guidance"}
+    if not rendered:
+        return {**base, "status": "skipped", "reason": "empty command after substitution"}
+    return _execute_post_install_action(action, rendered, runner, base, repo=repo, home=home, backup_dir=backup_dir)
+
+
+def _execute_post_install_action(
+    action: Mapping[str, Any],
+    rendered: list[str],
+    runner: CommandRunner,
+    base: dict[str, Any],
+    *,
+    repo: Path | None,
+    home: Path,
+    backup_dir: Path | None,
+) -> dict[str, Any]:
     protected = list(action.get("requires_protected_apply", ()))
-    overrides = _apply_protected_files(protected, repo, home) if protected else []
+    overrides: list[dict[str, str]] = []
+    backups: list[dict[str, str]] = []
     try:
+        if protected:
+            overrides, backups = _apply_protected_files(protected, repo, home, backup_dir)
         runner.run(rendered)
-    except (OSError, RuntimeError) as exc:
-        return {**base, "status": "failed", "result": str(exc), "protected_overrides": overrides}
-    return {**base, "status": "ran", "protected_overrides": overrides}
+    except (OSError, RuntimeError, BackupError) as exc:
+        return {**base, "status": "failed", "result": str(exc),
+                "protected_overrides": overrides, "backups": backups}
+    return {**base, "status": "ran", "protected_overrides": overrides, "backups": backups}
 
 
 def _render_post_install_template(
@@ -664,18 +699,48 @@ def _apply_protected_files(
     protected: list[str],
     repo: Path | None,
     home: Path,
-) -> list[dict[str, str]]:
+    backup_dir: Path | None,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Look up each `protected` source path in the manifest, back up the
+    existing target (when a `backup_dir` is set), and copy the repo file
+    into place. Returns (overrides_applied, backups_created)."""
     if not repo:
-        return []
+        return [], []
+    try:
+        manifest = load_manifest(repo)
+    except ManifestError:
+        return [], []
+    by_source = {entry.source: entry for entry in manifest.entries}
     overrides: list[dict[str, str]] = []
+    backups: list[dict[str, str]] = []
     for rel in protected:
-        # rel is repo-relative like "fish/fish_plugins" → target is
-        # ~/.config/fish/fish_plugins (mirror the manifest mapping).
-        source = repo / rel
-        target = home / ".config" / rel
-        if not source.exists():
+        entry = by_source.get(rel)
+        if entry is None:
             continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(source.read_text())
-        overrides.append({"source": str(source), "target": str(target)})
-    return overrides
+        result = _copy_protected_file(entry, repo, home, backup_dir)
+        if result is None:
+            continue
+        override, backup = result
+        overrides.append(override)
+        if backup is not None:
+            backups.append(backup)
+    return overrides, backups
+
+
+def _copy_protected_file(
+    entry: Any,  # ManifestEntry
+    repo: Path,
+    home: Path,
+    backup_dir: Path | None,
+) -> tuple[dict[str, str], dict[str, str] | None] | None:
+    source = repo / entry.source
+    target = home / entry.target
+    if not source.exists():
+        return None
+    backup: dict[str, str] | None = None
+    if (target.exists() or target.is_symlink()) and backup_dir is not None:
+        backup = create_backup(target, backup_dir, entry_id=f"post_install:{entry.id}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source.read_text())
+    override = {"source": str(source), "target": str(target), "entry_id": entry.id}
+    return override, backup

--- a/setup
+++ b/setup
@@ -504,6 +504,26 @@ run_machine_install_tools_apply() {
     --yes)
 }
 
+run_machine_install_tools_with_confirm() {
+  echo
+  run_machine_install_tools_preview
+  echo
+  printf 'Apply tool install/update actions? [y/N]: '
+  local confirm
+  if read -r confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
+    echo
+    run_machine_install_tools_apply
+  else
+    echo "No tool changes applied."
+  fi
+}
+
+run_machine_apply_with_message() {
+  echo
+  echo "Applying safe non-protected machine dotfiles and approved install/update recipes..."
+  run_machine_apply
+}
+
 run_machine_summary() {
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
     --repo "$DOTFILES_REPO" \
@@ -519,6 +539,20 @@ run_machine_menu_label() {
     --menu-label)
 }
 
+run_machine_menu_mode() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --menu-mode)
+}
+
+run_machine_missing_tool_count() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --missing-tool-count)
+}
+
 run_machine_details() {
   echo "Full machine doctor:"
   run_machine_doctor
@@ -531,8 +565,8 @@ show_tool_auth_commands() {
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.baseline)
 }
 
-machine_menu() {
-  local option_one="${1:-Apply safe non-protected dotfiles and approved install/update recipes.}"
+machine_menu_tools_present() {
+  local option_one="$1"
   while true; do
     cat <<EOF
 
@@ -551,42 +585,59 @@ EOF
       return 0
     fi
     case "$choice" in
-      1)
-        echo
-        echo "Applying safe non-protected machine dotfiles and approved install/update recipes..."
-        run_machine_apply
-        return $?
-        ;;
-      2)
-        echo
-        run_machine_details
-        ;;
-      3)
-        echo
-        show_tool_auth_commands
-        ;;
-      4|"")
-        echo "No changes applied."
-        return 0
-        ;;
-      5)
-        echo
-        run_machine_install_tools_preview
-        echo
-        printf 'Apply tool install/update actions? [y/N]: '
-        local confirm
-        if read -r confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
-          echo
-          run_machine_install_tools_apply
-        else
-          echo "No tool changes applied."
-        fi
-        ;;
-      *)
-        echo "Unknown choice: $choice" >&2
-        ;;
+      1) run_machine_apply_with_message; return $? ;;
+      2) echo; run_machine_details ;;
+      3) echo; show_tool_auth_commands ;;
+      4|"") echo "No changes applied."; return 0 ;;
+      5) run_machine_install_tools_with_confirm ;;
+      *) echo "Unknown choice: $choice" >&2 ;;
     esac
   done
+}
+
+machine_menu_tools_missing() {
+  local missing_count="$1"
+  while true; do
+    cat <<EOF
+
+Recommended next: option 1 — ${missing_count} developer tools missing.
+
+Next steps:
+  1. Install / update developer tools (preview, then apply).
+  2. Apply safe changes (note: some configs target tools not yet installed).
+  3. Show full technical details.
+  4. Show tool and sign-in guidance.
+  5. Exit without writing.
+EOF
+    printf 'Choose [1-5]: '
+    local choice
+    if ! read -r choice; then
+      echo
+      echo "No interactive selection received; no changes applied."
+      return 0
+    fi
+    case "$choice" in
+      1) run_machine_install_tools_with_confirm ;;
+      2) run_machine_apply_with_message; return $? ;;
+      3) echo; run_machine_details ;;
+      4) echo; show_tool_auth_commands ;;
+      5|"") echo "No changes applied."; return 0 ;;
+      *) echo "Unknown choice: $choice" >&2 ;;
+    esac
+  done
+}
+
+machine_menu() {
+  local mode="${1:-tools_present}"
+  local option_one="${2:-Apply safe non-protected dotfiles and approved install/update recipes.}"
+  if [[ "$mode" == "tools_missing" ]]; then
+    local missing_count
+    missing_count="$(run_machine_missing_tool_count 2>/dev/null)" || missing_count="?"
+    [[ -z "$missing_count" ]] && missing_count="?"
+    machine_menu_tools_missing "$missing_count"
+  else
+    machine_menu_tools_present "$option_one"
+  fi
 }
 
 cmd_machine_setup() {
@@ -598,7 +649,11 @@ cmd_machine_setup() {
   if ! option_one="$(run_machine_menu_label)" || [[ -z "$option_one" ]]; then
     option_one="Apply safe non-protected dotfiles and approved install/update recipes."
   fi
-  machine_menu "$option_one"
+  local mode
+  if ! mode="$(run_machine_menu_mode)" || [[ -z "$mode" ]]; then
+    mode="tools_present"
+  fi
+  machine_menu "$mode" "$option_one"
 }
 
 project_is_empty() {

--- a/tests/test_machine_summary.py
+++ b/tests/test_machine_summary.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from dotfiles_tools.machine_summary import render_menu_label, render_reports
+from unittest import mock
+
+from dotfiles_tools.machine_summary import (
+    render_menu_label,
+    render_menu_mode,
+    render_missing_tool_count,
+    render_reports,
+)
 from dotfiles_tools.reports import Report
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
@@ -223,3 +230,24 @@ class MachineSummaryTests(DotfilesTestCase):
 
         self.assertRegex(label, r"^Apply [0-9]+ file changes?( \+ [0-9]+ font actions?)?")
         self.assertIn("backs up 1 file", label)
+
+    def test_menu_mode_returns_tools_missing_when_any_bootstrap_tool_absent(self) -> None:
+        home = self.make_home()
+        # Empty PATH means no bootstrap tool is detected on the user's machine
+        # (linux platform forced so the plan emits real entries, not "unsupported").
+        with mock.patch.dict("os.environ", {"PATH": "", "DOTFILES_TOOL_PLATFORM": "linux"}, clear=False):
+            mode = render_menu_mode(REPO_ROOT, home)
+            count = render_missing_tool_count(REPO_ROOT, home)
+        self.assertEqual(mode, "tools_missing")
+        self.assertGreater(count, 0)
+
+    def test_menu_mode_returns_tools_present_when_platform_unsupported(self) -> None:
+        home = self.make_home()
+        # Forcing darwin makes every tool entry "unsupported", so nothing is
+        # "missing" — this is also the behaviour every test exercises through
+        # env_for in test_setup_script.py.
+        with mock.patch.dict("os.environ", {"DOTFILES_TOOL_PLATFORM": "darwin"}, clear=False):
+            mode = render_menu_mode(REPO_ROOT, home)
+            count = render_missing_tool_count(REPO_ROOT, home)
+        self.assertEqual(mode, "tools_present")
+        self.assertEqual(count, 0)

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -74,6 +74,10 @@ class SetupScriptTests(DotfilesTestCase):
         env["PATH"] = str(bin_dir)
         env["HOME"] = str(home)
         env["PYTHONPATH"] = str(REPO_ROOT)
+        # Default tests to the configured-machine ("tools_present") menu mode
+        # so option numbers stay stable. Tests that need the fresh-box flow
+        # explicitly override this.
+        env["DOTFILES_TOOL_PLATFORM"] = "darwin"
         return env
 
     def write_executable(self, path: Path, text: str) -> None:

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -9,6 +9,8 @@ from dotfiles_tools.tool_installer import (
     DEV_BASE_ENTRY_ID,
     build_tool_install_plan,
     execute_tool_install_operation,
+    run_post_install_actions,
+    verify_installed_tools,
 )
 from tests.helpers import DotfilesTestCase
 
@@ -142,6 +144,9 @@ class ToolInstallPlanTests(DotfilesTestCase):
         self.assertEqual(claude_ops[0]["type"], "tool_install_curl")
         self.assertEqual(claude_ops[0]["mode"], "install")
         self.assertIn("install.sh", claude_ops[0]["url"])
+        # Phase 1: curl ops carry an explicit interpreter so dash-only systems
+        # don't run bash scripts under /bin/sh.
+        self.assertEqual(claude_ops[0]["interpreter"], "bash")
 
     def test_curl_installer_for_claude_upgrade_reruns_installer(self) -> None:
         home = self.make_home()
@@ -252,7 +257,7 @@ class ToolInstallExecuteTests(DotfilesTestCase):
 
     def test_curl_installer_downloads_and_runs(self) -> None:
         home = self.make_home()
-        runner = FakeRunner(which={"sh": "/bin/sh"})
+        runner = FakeRunner(which={"bash": "/bin/bash"})
         cache_dir = home / ".cache" / "tool-installers"
         op = {
             "entry_id": "tools.claude",
@@ -260,6 +265,7 @@ class ToolInstallExecuteTests(DotfilesTestCase):
             "type": "tool_install_curl",
             "url": "https://claude.ai/install.sh",
             "script_name": "claude-install.sh",
+            "interpreter": "bash",
             "requires_sudo": False,
             "cache_dir": str(cache_dir),
         }
@@ -267,9 +273,42 @@ class ToolInstallExecuteTests(DotfilesTestCase):
         self.assertEqual(len(runner.downloads), 1)
         self.assertEqual(runner.downloads[0][0], "https://claude.ai/install.sh")
         self.assertTrue(runner.commands)
-        self.assertEqual(runner.commands[-1][0], "/bin/sh")
+        self.assertEqual(runner.commands[-1][0], "/bin/bash")
         # No sudo for the curl installer.
         self.assertNotIn("sudo", runner.commands[-1])
+
+    def test_curl_installer_uses_bash_by_default_when_no_interpreter_set(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"bash": "/usr/bin/bash"})
+        cache_dir = home / ".cache" / "tool-installers"
+        op = {
+            "entry_id": "tools.claude",
+            "recipe": "tool_installs",
+            "type": "tool_install_curl",
+            "url": "https://example.test/install.sh",
+            "script_name": "x.sh",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(runner.commands[-1][0], "/usr/bin/bash")
+
+    def test_curl_installer_honors_interpreter_override(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"python3": "/usr/bin/python3"})
+        cache_dir = home / ".cache" / "tool-installers"
+        op = {
+            "entry_id": "tools.thing",
+            "recipe": "tool_installs",
+            "type": "tool_install_curl",
+            "url": "https://example.test/install.py",
+            "script_name": "x.py",
+            "interpreter": "python3",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+        execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(runner.commands[-1][0], "/usr/bin/python3")
 
     def test_npm_missing_skips(self) -> None:
         home = self.make_home()
@@ -347,3 +386,84 @@ class ToolInstallExecuteTests(DotfilesTestCase):
         with mock.patch("dotfiles_tools.tool_installer.os.geteuid", return_value=0, create=True):
             execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
         self.assertNotIn("sudo", runner.commands[0])
+
+
+class VerifyAndPostInstallTests(DotfilesTestCase):
+    def test_verify_marks_each_bootstrap_tool_with_path_and_version(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"git": "/usr/bin/git", "fish": "/usr/bin/fish"})
+        results = verify_installed_tools(home, runner=runner, env={"PATH": ""})
+        by_command = {item["command"]: item for item in results}
+        self.assertTrue(by_command["git"]["verified"])
+        self.assertEqual(by_command["git"]["path"], "/usr/bin/git")
+        self.assertTrue(by_command["fish"]["verified"])
+        self.assertFalse(by_command["claude"]["verified"])
+        self.assertEqual(by_command["claude"]["path"], None)
+
+    def test_post_install_auto_executes_when_yes_true_and_template_resolves(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"fish": "/usr/bin/fish"})
+        env = {"PATH": "/usr/bin", "USER": "alice"}
+        results = run_post_install_actions(home, yes=True, runner=runner, env=env)
+        ran = [r for r in results if r["status"] == "ran"]
+        labels = [r["label"] for r in ran]
+        self.assertIn("Set fish as default shell", labels)
+        # The chsh template uses {which:fish} and {user} — both substituted.
+        chsh = next(r for r in ran if r["label"] == "Set fish as default shell")
+        self.assertEqual(chsh["command"], ["sudo", "chsh", "-s", "/usr/bin/fish", "alice"])
+
+    def test_post_install_auto_downgrades_to_guidance_when_yes_false(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"fish": "/usr/bin/fish"})
+        env = {"PATH": "/usr/bin", "USER": "alice"}
+        results = run_post_install_actions(home, yes=False, runner=runner, env=env)
+        statuses = {r["status"] for r in results}
+        self.assertEqual(statuses, {"guidance"})
+        self.assertFalse(runner.commands)  # no exec attempted
+
+    def test_post_install_login_actions_never_auto_run_even_with_yes(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"gh": "/usr/bin/gh", "claude": "/usr/local/bin/claude"})
+        results = run_post_install_actions(home, yes=True, runner=runner, env={"PATH": ""})
+        gh_actions = [r for r in results if r["tool"] == "gh"]
+        self.assertTrue(gh_actions)
+        for r in gh_actions:
+            self.assertEqual(r["status"], "guidance")
+            self.assertEqual(r["kind"], "guidance")
+
+    def test_post_install_unresolved_placeholder_downgrades_to_skipped(self) -> None:
+        home = self.make_home()
+        # fish on PATH so post_install runs, but no `which:fish` resolution
+        # because the runner doesn't return a path. Wait — fish IS in `which`
+        # below but the chsh template asks for which:fish; let's test by
+        # making USER absent so {user} can't resolve.
+        runner = FakeRunner(which={"fish": "/usr/bin/fish"})
+        env = {"PATH": ""}  # no USER
+        results = run_post_install_actions(home, yes=True, runner=runner, env=env)
+        chsh = next(r for r in results if r["label"] == "Set fish as default shell")
+        self.assertEqual(chsh["status"], "skipped")
+        self.assertIn("user", chsh["reason"])
+
+    def test_post_install_protected_apply_copies_fish_plugins(self) -> None:
+        home = self.make_home()
+        repo = self.make_home() / "repo"
+        (repo / "fish").mkdir(parents=True)
+        (repo / "fish" / "fish_plugins").write_text("jorgebucaran/fisher\n")
+        runner = FakeRunner(which={"fish": "/usr/bin/fish"})
+        env = {"PATH": "/usr/bin", "USER": "alice"}
+        results = run_post_install_actions(
+            home, yes=True, runner=runner, env=env, repo_path=repo,
+        )
+        plugin_action = next(r for r in results if "fisher update" in " ".join(r["command"]))
+        self.assertEqual(plugin_action["status"], "ran")
+        target = home / ".config" / "fish" / "fish_plugins"
+        self.assertTrue(target.exists())
+        self.assertEqual(target.read_text(), "jorgebucaran/fisher\n")
+        self.assertTrue(plugin_action["protected_overrides"])
+
+    def test_every_bootstrap_tool_declares_post_install(self) -> None:
+        from dotfiles_tools.baseline import TOOL_BASELINE
+        for item in TOOL_BASELINE:
+            if not item.get("bootstrap"):
+                continue
+            self.assertIn("post_install", item, f"{item['id']} missing post_install")

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -444,22 +444,47 @@ class VerifyAndPostInstallTests(DotfilesTestCase):
         self.assertEqual(chsh["status"], "skipped")
         self.assertIn("user", chsh["reason"])
 
-    def test_post_install_protected_apply_copies_fish_plugins(self) -> None:
+    def test_post_install_protected_apply_uses_real_manifest_target(self) -> None:
+        # The real repo manifest maps fish/fish_plugins → ~/.config/fish/fish_plugins,
+        # which validates that protected-apply uses manifest target resolution
+        # (not the previously-hardcoded ~/.config prefix).
+        from tests.helpers import REPO_ROOT
         home = self.make_home()
-        repo = self.make_home() / "repo"
-        (repo / "fish").mkdir(parents=True)
-        (repo / "fish" / "fish_plugins").write_text("jorgebucaran/fisher\n")
         runner = FakeRunner(which={"fish": "/usr/bin/fish"})
         env = {"PATH": "/usr/bin", "USER": "alice"}
+        backup_dir = home / ".dotfiles-backups"
         results = run_post_install_actions(
-            home, yes=True, runner=runner, env=env, repo_path=repo,
+            home, yes=True, runner=runner, env=env,
+            repo_path=REPO_ROOT, backup_dir=backup_dir,
         )
         plugin_action = next(r for r in results if "fisher update" in " ".join(r["command"]))
         self.assertEqual(plugin_action["status"], "ran")
         target = home / ".config" / "fish" / "fish_plugins"
         self.assertTrue(target.exists())
-        self.assertEqual(target.read_text(), "jorgebucaran/fisher\n")
         self.assertTrue(plugin_action["protected_overrides"])
+        # No backup needed because target didn't exist beforehand.
+        self.assertEqual(plugin_action.get("backups"), [])
+
+    def test_post_install_protected_apply_backs_up_existing_target(self) -> None:
+        from tests.helpers import REPO_ROOT
+        home = self.make_home()
+        target = home / ".config" / "fish" / "fish_plugins"
+        target.parent.mkdir(parents=True)
+        target.write_text("user-customized\n")
+        runner = FakeRunner(which={"fish": "/usr/bin/fish"})
+        env = {"PATH": "/usr/bin", "USER": "alice"}
+        backup_dir = home / ".dotfiles-backups"
+        results = run_post_install_actions(
+            home, yes=True, runner=runner, env=env,
+            repo_path=REPO_ROOT, backup_dir=backup_dir,
+        )
+        plugin_action = next(r for r in results if "fisher update" in " ".join(r["command"]))
+        self.assertEqual(plugin_action["status"], "ran")
+        # The existing user-customized file was preserved as a backup.
+        self.assertTrue(plugin_action["backups"])
+        backup_target = Path(plugin_action["backups"][0]["backup_target"])
+        self.assertTrue(backup_target.exists())
+        self.assertEqual(backup_target.read_text(), "user-customized\n")
 
     def test_every_bootstrap_tool_declares_post_install(self) -> None:
         from dotfiles_tools.baseline import TOOL_BASELINE


### PR DESCRIPTION
## Summary

Three improvements driven by a fresh-Ubuntu test of option 5 in PR #79:

### 1. Fix the Claude installer crash

`claude.ai/install.sh` is a **bash** script. `_execute_curl` was running it under `/bin/sh` (dash on Ubuntu), which rejected bash extensions and aborted mid-apply (with `git`/`gh`/`fish`/`direnv` already installed but `codex`/`gemini` never reached). Add an `interpreter` field to curl `install_args` (default `bash`); `_execute_curl` resolves it via `runner.which()`.

### 2. Dynamic menu reorder by machine state

`./setup` no longer assumes option 1 = apply configs. The menu reorders based on detected state:

- **`tools_missing`** (fresh box):
  ```
  Recommended next: option 1 — N developer tools missing.

  Next steps:
    1. Install / update developer tools (preview, then apply).
    2. Apply safe changes (note: some configs target tools not yet installed).
    3. Show full technical details.
    4. Show tool and sign-in guidance.
    5. Exit without writing.
  ```
- **`tools_present`** (configured machine — current behaviour):
  ```
  Next steps:
    1. <dynamic apply-configs label>
    2-4. ...
    5. Install / update developer tools (preview, then apply).
  ```

Detection via new `render_menu_mode()` (queries `build_tool_install_subplan` for any non-dev-base entry with `state="missing"`).

### 3. Post-install verification + follow-up actions

After `bootstrap-install-tools` apply succeeds, the report now includes:

- A **verification panel** re-probing each bootstrap tool (path + version).
- A **post-install actions panel** that processes each tool's `post_install` list:
  - `kind="auto"` + `--yes` → executed (`sudo chsh -s /usr/bin/fish $USER`, fisher bootstrap, `fish -c "fisher update"`)
  - `kind="auto"` + no `--yes` → downgraded to guidance
  - `kind="guidance"` → printed only (`gh auth login`, `claude /login`, `codex auth login`, `gemini`)
  - `requires_protected_apply` → copies listed protected files before exec (only path that bypasses the protected-file rule, gated by `--yes` plus an explicit per-action token; currently only `fish/fish_plugins`)

Templates support `{which:<name>}` and `{user}` placeholders; unresolved placeholders are recorded as skipped instead of crashing.

## Files changed

| Path | Change |
|---|---|
| `dotfiles_tools/baseline.py` | `interpreter: "bash"` on Claude; `post_install` tuples on every bootstrap tool; tool-install hint text is now order-agnostic. |
| `dotfiles_tools/tool_installer.py` | `_curl_op` propagates interpreter; `_execute_curl` resolves it; new `verify_installed_tools` + `run_post_install_actions`. |
| `dotfiles_tools/bootstrap.py` | `apply_tool_installs` now attaches verification + post-install results to `report.extra`. |
| `dotfiles_tools/machine_summary.py` | New `render_menu_mode()` + `render_missing_tool_count()` + `--menu-mode`/`--missing-tool-count` flags. |
| `dotfiles_tools/reports.py` | New `_extend_extra_verification` + `_extend_extra_post_install`. |
| `setup` | New `run_machine_menu_mode()`; `machine_menu` branches by mode. |
| `README.md` | Document state-aware menu, fresh-box vs. re-run flows. |
| `AGENTS.md` | Note interpreter contract + `post_install` requirement for new tools. |
| `tests/test_tool_installer.py` | 9 new tests (interpreter, verification, post-install, baseline catalog). |
| `tests/test_machine_summary.py` | 2 new tests for menu mode. |
| `tests/test_setup_script.py` | Default test env to `DOTFILES_TOOL_PLATFORM=darwin` so existing bash-driven tests keep their option-1 = apply expectation. |

## Test plan

- [x] `uv run python -m unittest discover -s tests` — 99 tests pass (88 prior + 11 new).
- [x] `bash -n setup` — bash syntax valid.
- [x] All functions at CC ≤ 8 (verified via `radon cc`).
- [ ] Manual end-to-end on the fresh Ubuntu container that hit the original Claude crash:
  - [ ] `./setup` shows recommendation banner + tools_missing menu.
  - [ ] Choose 1 → preview → y → all 7 tools install (Claude now via `/bin/bash`, no syntax error).
  - [ ] Verification panel shows OK for all 7.
  - [ ] Post-install (auto): fish chsh + fisher bootstrap + fisher update all run.
  - [ ] Post-install (manual): four sign-in commands listed for gh/claude/codex/gemini.
- [ ] Re-run `./setup` on the same machine: menu now in `tools_present` mode.

https://claude.ai/code/session_011JzgecDik64Wk4PNAmUwsD

---
_Generated by [Claude Code](https://claude.ai/code/session_011JzgecDik64Wk4PNAmUwsD)_