### PR TITLE
Split docs into topic files and tighten coverage workflow

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,6 +4,12 @@ exclude_paths:
   - ".specify/**"
   - "specs/**"
   - "AGENTS.md"
+  - "README.md"
+  - "CHANGELOG.md"
+  - "docs/**"
+  - "tests/**"
+  - "setup"
+  - "graph-obsidian-agent-docs/**"
 engines:
   metric:
     exclude_paths:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+source =
+    dotfiles_tools
+
+[report]
+omit =
+    tests/*
+    docs/*
+    specs/*
+    .agents/*
+    .specify/*
+    graph-obsidian-agent-docs/*
+    setup
+    README.md
+    CHANGELOG.md

--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: dotfiles-validation-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -17,10 +21,10 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
 
       - name: Run unit tests with coverage
-        run: uv run --with coverage coverage run -m unittest discover -s tests
+        run: uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
 
       - name: Generate coverage XML
-        run: uv run --with coverage coverage xml
+        run: uv run --with coverage==7.5.4 coverage xml
 
       - name: Upload coverage to Codacy
         if: ${{ github.event_name == 'push' && env.CODACY_PROJECT_TOKEN != '' }}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-dotfiles-bootstrap-validation"
+  "feature_directory": "specs/002-setup-menu-recommendation"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,5 +92,6 @@ validation/setup code and must generate `coverage.xml` before Codacy upload.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/002-setup-menu-recommendation/plan.md`
 <!-- SPECKIT END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ uv run python -m dotfiles_tools plan --repo . --home "$HOME" --profile machine
 uv run python -m dotfiles_tools apply --repo . --home "$HOME" --profile machine --backup-dir "$HOME/.dotfiles-backups" --yes
 uv run python -m dotfiles_tools init-project --repo . --project /path/to/project --vars project-vars.json --yes
 uv run python -m unittest discover -s tests
-uv run --with coverage coverage run -m unittest discover -s tests
-uv run --with coverage coverage xml
+uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
+uv run --with coverage==7.5.4 coverage xml
 ```
 
 Do not add lock files unless runtime dependencies are introduced and the Spec

--- a/README.md
+++ b/README.md
@@ -1,315 +1,58 @@
 # dotfiles
 
-Config templates and tools to bootstrap a developer machine and scaffold AI agent docs in any
-project. Status: **0.1.x beta** — feature-complete, single-maintainer, suitable for personal
-and team use.
+Config templates and helper tools for bootstrapping a machine and scaffolding AI agent docs.
+One repo manages Claude Code, Codex, Gemini, Copilot, shell, git, gh, fonts, and project agent docs.
+Status: **0.1.x beta**. The repo is intended for repeatable personal and team use.
 
-## What is this?
-
-You've just bought a new laptop (or your hard drive died, or you're setting up CI). On a
-fresh machine, you normally spend hours manually installing tools, copying config files, and
-signing in to each one. This repo automates that: **one command installs your full tool stack
-and applies your configs.** Repeated runs apply any config drift—changes you've made that
-differ from the repo's templates.
-
-This particular repo manages configs for AI coding tools (Claude Code, Codex, Gemini,
-Copilot), shell customization (fish, direnv), version control (git, gh), and terminal fonts
-(Nerd Fonts). It also scaffolds AI agent guidelines for your projects so Claude Code and
-other tools know your codebase conventions.
-
-## What gets installed
-
-| Category | Tools | Notes |
-|---|---|---|
-| **Shell & environment** | fish, direnv | Shell and per-project env vars |
-| **Version control** | git, GitHub CLI | Git + GitHub; auth is manual |
-| **Python toolchain** | uv | Fast Python installer & package manager |
-| **AI coding assistants** | Claude Code, Codex, Gemini, Copilot, SpecKit | Latest versions; sign-in on first run |
-| **Fonts** | JetBrainsMono, FiraCode, Hack, MesloLGS Nerd Fonts | Auto-downloaded and installed |
-| **Project scaffolding** | AI agent docs | `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` per project |
-
-## Quick start
-
-### Clone and run setup on a fresh machine
+## Quick Start
 
 ```bash
 git clone https://github.com/kairin/000-dotfiles.git ~/000-dotfiles
-~/000-dotfiles/setup
-# → Menu appears. Choose 1 (install tools), then 2 (apply configs). Done in ~5 min.
+cd ~/000-dotfiles
+./setup
 ```
 
-### Scaffold AI agent docs in a project
+Fresh machine: choose option 1, confirm the tool install preview, then choose option 2 after the menu refreshes.
+Existing machine: rerun `./setup` and pick the recommended option shown in the menu.
+Project docs: run `./setup init --yes --project ~/Apps/my-project`.
+Read the deeper guides in `docs/` when you need command details or setup architecture.
 
-```bash
-cd ~/Apps/my-project
-~/000-dotfiles/setup init --yes
-# → Creates AGENTS.md, CLAUDE.md, GEMINI.md. Your AI tools now know your codebase.
+## Mental Model
+
+```mermaid
+flowchart LR
+  A[Template files<br>*.template] --> B[./setup]
+  B --> C[Home directory configs]
+  B --> D[Project agent docs]
+  C --> E[fish / git / gh / Claude / Codex / Gemini]
+  D --> F[AGENTS.md<br>CLAUDE.md<br>GEMINI.md]
 ```
 
-### Update a machine you already set up
-
-```bash
-~/000-dotfiles/setup
-# → Menu shows state. Choose 2 to apply any drift. Tools update automatically.
+```mermaid
+flowchart TD
+  A[Run ./setup] --> B{Machine state}
+  B -->|Missing tools| C[Install / update tools]
+  B -->|Config drift| D[Apply safe dotfiles]
+  B -->|Project mode| E[Generate agent docs]
+  C --> F[Sign in to CLIs]
+  D --> G[Backups created]
+  E --> H[Render project templates]
 ```
 
----
+## Docs Map
 
-## How it works — setup flow
-
-When you run `./setup`, the script audits your machine and shows a **5-option menu**. The
-option numbers **never change**, but the `[recommended]` tag highlights which action fits
-your current state.
-
-### Fresh machine (tools missing)
-
-```
-$ ~/000-dotfiles/setup
-                         ↓
-        ╔═══════════════════════════════════════╗
-        ║ Machine setup summary                 ║
-        ║ Home: /home/user                      ║
-        ║ Tools: 7/10 missing                   ║
-        ║ Configs: N/A (tools not installed)    ║
-        ╚═══════════════════════════════════════╝
-                         ↓
-   1. Install / update developer tools   [recommended] ← CHOOSE THIS
-   2. Apply safe non-protected dotfiles
-   3. Show full technical details
-   4. Show tool and sign-in guidance
-   5. Exit without writing
-                         ↓
-        Choose [1-5]: 1
-                         ↓
-   [Preview shows: uv, git, gh, fish, direnv, claude,
-    codex, gemini, copilot, specify to be installed]
-                         ↓
-   Apply tool install/update actions? [y/N]: y
-                         ↓
-   [Tools installed; 5 min...]
-   [Prints sign-in commands: gh auth login, claude /login, etc.]
-                         ↓
-   Menu reappears. Now tool count shows 10/10.
-                         ↓
-   1. Install / update developer tools
-   2. Apply safe non-protected dotfiles   [recommended] ← NOW CHOOSE THIS
-   3. Show full technical details
-   4. Show tool and sign-in guidance
-   5. Exit without writing
-                         ↓
-        Choose [1-5]: 2
-                         ↓
-   [Configs + fonts installed; backups created]
-                         ↓
-        DONE. Run these sign-in commands:
-        $ gh auth login
-        $ claude /login
-        $ codex auth
-        $ gemini
-        $ copilot /login
-```
-
-### Configured machine (tools present, configs drifted)
-
-```
-$ ~/000-dotfiles/setup
-                         ↓
-        ╔═══════════════════════════════════════╗
-        ║ Machine setup summary                 ║
-        ║ Home: /home/user                      ║
-        ║ Tools: 10/10 found                    ║
-        ║ Configs: 2 drifted, 8 current         ║
-        ╚═══════════════════════════════════════╝
-                         ↓
-   1. Install / update developer tools
-   2. Apply safe non-protected dotfiles   [recommended] ← CHOOSE THIS
-   3. Show full technical details
-   4. Show tool and sign-in guidance
-   5. Exit without writing
-                         ↓
-        Choose [1-5]: 2
-                         ↓
-   [2 files written with backups]
-   [Fonts already installed, no changes]
-                         ↓
-        DONE.
-```
-
-Nothing is written without your explicit confirmation (`[y/N]`). Files are backed up before overwrite (default: `~/.dotfiles-backups/`). The script is idempotent—safe to run repeatedly.
-
----
-
-## What you can do with this
-
-| Scenario | Command |
+| Doc | Purpose |
 |---|---|
-| Fresh-machine setup (tools + configs + fonts) | `./setup` |
-| Check current state (read-only) | `./setup doctor` |
-| Scaffold `AGENTS.md` + `CLAUDE.md`/`GEMINI.md` in a project | `./setup init --yes` |
-| Verify agent docs in CI / pre-commit (no uv required) | `./setup verify` |
-| Upgrade installed tools | `./setup` → choose option 1 |
-| Apply config drift | `./setup` → choose option 2 |
-| Show full technical details (cache, versions, operations) | `./setup` → choose option 3 |
+| [docs/README.md](docs/README.md) | Docs hub and table of contents |
+| [docs/getting-started.md](docs/getting-started.md) | First-time setup and ongoing maintenance |
+| [docs/setup-reference.md](docs/setup-reference.md) | `./setup` menu, wrapper commands, and direct CLI reference |
+| [docs/repo-layout.md](docs/repo-layout.md) | Repository structure and template conventions |
+| [docs/protected-files.md](docs/protected-files.md) | Files that are reported but never auto-overwritten |
+| [docs/validation.md](docs/validation.md) | Tests, coverage, and CI/Codacy flow |
+| [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
+| [docs/architecture/setup-flow.md](docs/architecture/setup-flow.md) | Interactive setup recommendation flow |
+| [docs/architecture/scaffold-flow.md](docs/architecture/scaffold-flow.md) | Project agent-doc scaffolding flow |
+| [docs/codacy-coverage-rollout.md](docs/codacy-coverage-rollout.md) | Codacy coverage rollout notes |
+| [CHANGELOG.md](CHANGELOG.md) | Version history |
 
-Supported platforms: Ubuntu-style Linux, WSL (with Windows host font install), Raspberry Pi, Pixel Terminal, Pixel AVF.
-
----
-
-## Going deeper
-
-- **[Getting Started](docs/getting-started.md)** — Step-by-step first-time setup, ongoing maintenance, AI agent doc scaffolding, troubleshooting
-- **[Setup script reference](#setup-script-reference)** (below) — All commands and options
-- **[Direct CLI reference](#direct-cli-advanced)** (below) — Stable commands for automation
-- **[Protected files](#protected-files)** — Which files are never auto-overwritten
-- **[Project bootstrap example](#project-bootstrap-example)** (below) — Detailed walkthrough
-- **[Validation and coverage](#validation-and-coverage)** (below) — Running tests
-- **[Changelog](CHANGELOG.md)** — Version history and what was built
-
-## Is this a good dotfiles repo? ✓
-
-A good dotfiles repo should:
-
-| Requirement | Status |
-|---|---|
-| Version-controlled config templates | ✓ All `.template` files tracked |
-| One-command bootstrap on a fresh machine | ✓ `./setup` handles it |
-| Idempotent — safe to run repeatedly | ✓ No errors from running twice |
-| Backup before overwrite | ✓ Default: `~/.dotfiles-backups/` |
-| Never writes without confirmation | ✓ Requires explicit `[y/N]` |
-| Protected files never auto-overwritten | ✓ git config, fish plugins, etc. |
-| No secrets or tokens committed | ✓ Auth files `.gitignore`d |
-| Multi-platform support | ✓ Linux, WSL, Pi, Pixel Terminal |
-| Validation & test coverage | ✓ 103 unit tests; CI/CD integration |
-| AI tool config management | ✓ Claude, Codex, Gemini, Copilot |
-| Per-project AI agent scaffolding | ✓ `AGENTS.md` + symlinks |
-
----
-
-## Repo layout
-
-| Directory | Target on disk | Contents |
-|---|---|---|
-| `agents/` | a project root | `AGENTS.md` + `CLAUDE.md`/`GEMINI.md`/`copilot-instructions.md` templates |
-| `claude/` | `~/.claude/` | `settings.json`, `keybindings.json`, global `CLAUDE.md` |
-| `codex/` | `~/.codex/` | `config.toml`, `rules/default.rules` |
-| `gemini/` | `~/.gemini/` | `settings.json`, global `GEMINI.md` |
-| `gh/` | `~/.config/gh/` | `config.yml`, Codacy branch-protection checklist |
-| `fish/` | `~/.config/fish/` | `fish_plugins`, `functions/direnv.fish`, `env.fish` |
-| `git/` | `~/.config/git/` | `config` |
-| `dotfiles_tools/` | — | Python validation/setup CLI (`python -m dotfiles_tools …`) |
-| `setup` | `~/.local/bin/dotfiles-setup` (optional) | Self-locating bash entrypoint |
-| `dotfiles-manifest.json` | — | Source of truth for what installs where |
-| `specs/` | — | Design specification, task tracking, contracts |
-| `docs/` | — | Getting started guide, operations docs, issue tracking |
-
-Files ending in `.template` are copy-and-customize sources. Placeholders use `{{UPPER_SNAKE_CASE}}` and must all be replaced before use.
-
----
-
-## Setup script reference
-
-| Command | What it does |
-|---|---|
-| `./setup` | Audit machine, present a menu, optionally apply non-protected dotfiles + font recipes |
-| `./setup /path/to/project` | Inspect project folder, offer agent-doc actions |
-| `./setup init [--project PATH] [--vars FILE] [--copilot] --yes` | Render `AGENTS.md` + `CLAUDE.md`/`GEMINI.md` symlinks; auto-discovers `project-vars.json` or `.dotfiles/project-vars.json` and infers defaults from `package.json`/`pyproject.toml`/`Cargo.toml`/`go.mod`/Makefile when missing |
-| `./setup verify [--project PATH] [--copilot]` | Read-only check: requires no `uv`, suitable for CI |
-| `./setup doctor [--home PATH] [--profile NAME]` | Read-only machine audit (wraps `dotfiles_tools doctor`) |
-
-Install on `PATH`:
-
-```bash
-ln -s /path/to/000-dotfiles/setup ~/.local/bin/dotfiles-setup
-dotfiles-setup verify --project ~/code/my-app
-```
-
----
-
-## Direct CLI (advanced)
-
-`./setup` is a wrapper. The underlying commands are stable and useful for automation:
-
-```bash
-uv run python -m dotfiles_tools doctor          --repo . --home "$HOME"
-uv run python -m dotfiles_tools plan            --repo . --home "$HOME" --profile machine
-uv run python -m dotfiles_tools apply           --repo . --home "$HOME" --profile machine --backup-dir "$HOME/.dotfiles-backups" --yes
-uv run python -m dotfiles_tools bootstrap-plan  --repo . --home "$HOME" --json
-uv run python -m dotfiles_tools bootstrap-apply --repo . --home "$HOME" --yes
-uv run python -m dotfiles_tools init-project    --repo . --project /path/to/project --vars project-vars.json --yes
-```
-
-`doctor` audits without writing. `plan` prints exact operations. `apply` writes only after `--yes`. Existing differing files are backed up before replacement. `bootstrap-plan`/`bootstrap-apply` add font recipes to the same manifest operations. Every command supports `--json` for stable machine output.
-
-### Protected files
-
-Five manifest entries are protected by default (reported but never written):
-
-- `git.config` → `~/.config/git/config` (committer identity)
-- `fish.plugins` → `~/.config/fish/fish_plugins` (manually curated; needs `fisher update`)
-- `repo.gitignore` → repo `.gitignore`
-- `agents.claude-template`, `agents.gemini-template` → symlinks to `agents/AGENTS.md.template`
-
-To include one explicitly, name its exact manifest ID:
-
-```bash
-uv run python -m dotfiles_tools apply --repo . --home "$HOME" \
-  --profile machine --backup-dir "$HOME/.dotfiles-backups" \
-  --include-protected git.config --yes
-```
-
-### Fonts
-
-The font stage is catalog-driven. On Linux it manages Nerd Fonts archives (`JetBrainsMono`, `FiraCode`, `Hack`, `Meslo`) cached in `~/.cache/000-dotfiles/fonts/` and installs to `~/.local/share/fonts/`. It also installs apt fallbacks (`fonts-noto-color-emoji`, `fonts-symbola`, `fonts-freefont-ttf`, `fonts-dejavu-core`). Terminal checks always use `* Nerd Font Mono` faces, never Propo. WSL additionally installs JetBrainsMono on the Windows host and updates Windows Terminal defaults when discoverable.
-
----
-
-## Project bootstrap example
-
-```bash
-cd ~/Apps/my-project
-cat > project-vars.json <<'JSON'
-{
-  "PROJECT_NAME": "Example",
-  "PROJECT_DESCRIPTION": "a concise description",
-  "LANGUAGE": "Python",
-  "PACKAGE_MANAGER": "uv",
-  "RUNTIME_DESCRIPTION": "local CLI",
-  "INSTALL_CMD": "uv sync",
-  "RUN_CMD": "uv run python main.py",
-  "TEST_CMD": "uv run pytest"
-}
-JSON
-
-~/000-dotfiles/setup init --yes              # bootstrap + auto-verify
-~/000-dotfiles/setup init --copilot --yes    # also write copilot file
-~/000-dotfiles/setup verify                  # re-check
-```
-
-When `project-vars.json` is missing and `--yes` is supplied, defaults are inferred from `package.json`/`pyproject.toml`/`Cargo.toml`/`go.mod`/Makefile and persisted to `<project>/.dotfiles/project-vars.json`.
-
----
-
-## Validation and coverage
-
-```bash
-uv run python -m unittest discover -s tests
-uv run --with coverage coverage run -m unittest discover -s tests
-uv run --with coverage coverage xml
-```
-
-CI runs the same validation suite on pushes and pull requests and generates `coverage.xml`. Codacy upload is attempted on push events only when the `CODACY_PROJECT_TOKEN` GitHub secret is configured. See `docs/codacy-coverage-rollout.md` for replicating this pattern in other repos.
-
----
-
-## Conventions and safety
-
-- **No secrets.** No tokens, passwords, or API keys live in this repo. Auth files (`hosts.yml`, `auth.json`, `oauth_creds.json`, `token`) are `.gitignore`d. Sign in via `gh auth login`, `codex auth`, `claude /login`, etc.
-- **Symlinks for AI-agent docs.** Root `CLAUDE.md`/`GEMINI.md` symlink to `AGENTS.md`; `agents/CLAUDE.md.template` and `agents/GEMINI.md.template` symlink to `agents/AGENTS.md.template`. One source of truth per scope.
-- **Backups before replace.** Drifted targets are copied to the backup dir (default `~/.dotfiles-backups`) before being overwritten.
-- **Stop on first failure.** `apply` halts on the first failed write and reports `partial` status with completed operations and backups intact.
-
----
-
-## Design and contributing
-
-The implementation plan, contracts, and task list live in `specs/001-dotfiles-bootstrap-validation/`. AI-agent guidelines are in `AGENTS.md` (which `CLAUDE.md` and `GEMINI.md` symlink to). When changing templates, edit the `.template` file directly and run `git diff --staged` before every commit to catch tokens or personal paths. See `AGENTS.md` for detailed agent guidelines.
+For implementation details, use the docs above instead of the root page.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Docs
+
+This directory is split by topic so the root `README.md` can stay short.
+
+## Navigation
+
+| Doc | Purpose |
+|---|---|
+| [Getting Started](getting-started.md) | First-time setup and routine maintenance |
+| [Setup Reference](setup-reference.md) | `./setup` menu, wrapper commands, and direct CLI reference |
+| [Repo Layout](repo-layout.md) | Repository structure and template conventions |
+| [Protected Files](protected-files.md) | Files that are reported but never auto-overwritten |
+| [Validation](validation.md) | Tests, coverage, CI, and Codacy behavior |
+| [Troubleshooting](troubleshooting.md) | Common issues and fixes |
+| [Architecture: Setup Flow](architecture/setup-flow.md) | Interactive recommendation flow and menu behavior |
+| [Architecture: Scaffold Flow](architecture/scaffold-flow.md) | Project agent-doc scaffolding flow |
+| [Codacy Rollout](codacy-coverage-rollout.md) | Coverage upload rollout notes |
+| [Issues](issues/) | Topic-specific notes and follow-ups |
+
+## Reading Order
+
+Start with `getting-started.md`, then `setup-reference.md` if you need command details.
+Use `validation.md` for CI and coverage questions, and the architecture docs when you want the flow diagrams.

--- a/docs/architecture/scaffold-flow.md
+++ b/docs/architecture/scaffold-flow.md
@@ -1,0 +1,30 @@
+# Scaffold Flow
+
+`./setup init` renders project agent docs from a project metadata file and then verifies the result.
+
+## Flow
+
+```mermaid
+flowchart TD
+  A[Run ./setup init] --> B{project-vars.json present?}
+  B -->|Yes| C[Use the discovered vars file]
+  B -->|No| D[Infer defaults from project files]
+  D --> E[Persist or use inferred vars]
+  C --> F[Run dotfiles_tools init-project]
+  E --> F
+  F --> G[Write AGENTS.md]
+  F --> H[Write CLAUDE.md symlink]
+  F --> I[Write GEMINI.md symlink]
+  F --> J[Optional Copilot instructions]
+  F --> K[Verify the rendered project docs]
+```
+
+## What Gets Generated
+
+- `AGENTS.md` for shared project guidance
+- `CLAUDE.md` and `GEMINI.md` as symlinks to `AGENTS.md`
+- optional Copilot instructions when requested
+
+## Default Inference
+
+When no vars file is supplied, the wrapper infers defaults from common project files such as `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, and `Makefile`.

--- a/docs/architecture/setup-flow.md
+++ b/docs/architecture/setup-flow.md
@@ -1,0 +1,37 @@
+# Setup Flow
+
+`./setup` inspects the machine, prints a recommendation-aware summary, and then shows the stable 5-option menu.
+The recommended option changes with the audited state, but the option numbers stay fixed so the menu remains learnable.
+
+## Core Flow
+
+```mermaid
+flowchart TD
+  A[Run ./setup] --> B[Audit machine state]
+  B --> C[Print summary with recommended option]
+  C --> D[Show 5-option menu]
+  D --> E{User choice}
+  E -->|1| F[Preview and apply tool updates]
+  E -->|2| G[Apply safe dotfiles and font recipes]
+  E -->|3| H[Show full technical details]
+  E -->|4| I[Show tool and sign-in guidance]
+  E -->|5| J[Exit without writing]
+  F --> K[Refresh summary and menu]
+  G --> J
+  H --> D
+  I --> D
+  K --> C
+```
+
+## Recommendation States
+
+- `1` - missing or unverified developer tools
+- `2` - safe non-protected dotfiles or font work is pending
+- `3` - audit failure, blockers, or manual-only work needs inspection
+- `4` - tool and sign-in guidance is the useful next step
+- `5` - the machine is already current
+
+## Why The Refresh Matters
+
+Option 1 can change the machine state before the user returns to the menu.
+The wrapper refreshes the summary after cancel or completion so the recommended option does not stay stale.

--- a/docs/codacy-coverage-rollout.md
+++ b/docs/codacy-coverage-rollout.md
@@ -47,10 +47,11 @@ Use this document as the checklist for applying the same pattern to other repos.
      ```
 2. Generate a Codacy-supported coverage report.
    - For Python, `coverage.py` can generate `coverage.xml`.
+   - Scope coverage to production Python code with `.coveragerc` so docs, tests, and shell scripts do not inflate the report.
    - Example:
      ```bash
-     uv run --with coverage coverage run -m unittest discover -s tests
-     uv run --with coverage coverage xml
+     uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
+     uv run --with coverage==7.5.4 coverage xml
      test -f coverage.xml
      ```
 3. Add a GitHub Actions workflow that runs tests and generates coverage.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,322 +1,39 @@
 # Getting Started
 
-A complete guide to using this dotfiles repo, from first-time setup to ongoing maintenance
-and AI agent doc scaffolding.
+Use this repo to set up a machine once, then keep it in sync with repeatable audits and menu-driven updates.
+If you want command details, jump to [Setup Reference](setup-reference.md). For the flow diagrams, use [Architecture: Setup Flow](architecture/setup-flow.md).
 
-## What are dotfiles?
+## First-Time Setup
 
-Dotfiles are the hidden configuration files (names starting with `.`) that configure your
-shell, editor, git, and other tools. Most developers manually copy these across machines,
-losing customizations and consistency. A **dotfiles repo** version-controls these files and
-provides an automated way to deploy them on a fresh machine.
-
-This repo does that—and adds two unique features: it manages AI coding tool configs (Claude
-Code, Codex, Gemini, Copilot) and scaffolds AI agent guidelines for your projects.
-
-## What does this repo manage?
-
-| Tool | Purpose | Config file |
-|---|---|---|
-| **fish** | Shell | `~/.config/fish/env.fish`, `direnv.fish` |
-| **direnv** | Environment isolation | `~/.config/direnv/direnvrc` |
-| **git** | Version control (manual) | `~/.config/git/config` |
-| **gh** | GitHub CLI | `~/.config/gh/config.yml` |
-| **Claude Code** | AI coding assistant | `~/.claude/settings.json`, `keybindings.json` |
-| **Codex** | Codex CLI | `~/.codex/config.toml`, `rules/default.rules` |
-| **Gemini** | Gemini CLI | `~/.gemini/settings.json`, `GEMINI.md` |
-| **Copilot** | GitHub Copilot CLI | (no config; auth via sign-in) |
-| **SpecKit** | SpecKit agent framework | (per-project scaffold) |
-| **Fonts** | Terminal UI | JetBrainsMono, FiraCode, Hack, MesloLGS Nerd Fonts + apt fallbacks |
-| **AI agent docs** | Your project | `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` |
-
----
-
-## Part 1: First-time setup (fresh machine)
-
-### Prerequisites
-
-- Ubuntu 20.04+ or similar Linux (WSL works; Raspberry Pi supported)
-- ~15 min of interactive time
-- Internet access to download tools and fonts
-
-### Step 1: Clone the repo
+1. Clone the repo.
+2. Run `./setup`.
+3. Choose option 1 on a fresh machine.
+4. Confirm the install preview.
+5. When the menu returns, choose option 2 to apply safe config and font changes.
+6. Run the sign-in commands the menu prints for your installed tools.
 
 ```bash
 git clone https://github.com/kairin/000-dotfiles.git ~/000-dotfiles
 cd ~/000-dotfiles
-```
-
-### Step 2: Run the interactive setup
-
-```bash
 ./setup
 ```
 
-You'll see a summary of your machine state and a 5-option menu:
+Option 1 installs or updates developer tools. Option 2 applies non-protected dotfiles and approved font recipes.
+The menu refreshes after tool install so the recommended option can change as the machine state changes.
 
-```
-1. Install / update developer tools        [recommended]
-2. Apply safe non-protected dotfiles
-3. Show full technical details
-4. Show tool and sign-in guidance
-5. Exit without writing
-```
+## Ongoing Maintenance
 
-Since tools are missing on a fresh machine, **option 1 is highlighted**. Choose it.
+Run `./setup` again whenever you want to check drift or pick up new templates.
 
-```
-Choose [1-5]: 1
-```
+- Option 1 upgrades tools.
+- Option 2 applies safe config drift.
+- Option 3 prints full technical details.
+- Option 4 shows tool and sign-in guidance.
+- Option 5 exits without writing.
 
-### Step 3: Preview and confirm
+## Project Scaffolding
 
-You'll see a preview of all tools that will be installed:
+Use `./setup init --yes --project /path/to/project` to render `AGENTS.md` and the `CLAUDE.md` / `GEMINI.md` symlinks for a project.
+If `project-vars.json` is missing, the wrapper infers sensible defaults from common project files before running `dotfiles_tools init-project`.
 
-```
-Already installed (will be updated where possible):
-  - Git: git version 2.x → apt --only-upgrade
-  - GitHub CLI: gh version 2.x → apt --only-upgrade
-  ... etc ...
-```
-
-Review the list and confirm:
-
-```
-Apply tool install/update actions? [y/N]: y
-```
-
-The installer will run for 2–5 minutes. Once done, you'll see a summary with sign-in commands to run:
-
-```
-Auth/setup guidance:
-  - gh auth status: If it reports no authenticated host, run gh auth login.
-  - codex auth: Run when Codex CLI is installed and needs user authentication.
-  - claude login: Run when Claude Code CLI is installed and needs user authentication.
-  - gemini: Start Gemini CLI and complete its login/setup prompt if needed.
-  - copilot /login: Run when GitHub Copilot CLI is installed and needs user authentication.
-```
-
-### Step 4: Sign in to each tool
-
-Run the sign-in commands one by one at your leisure:
-
-```bash
-gh auth login      # GitHub CLI
-claude /login      # Claude Code (or just: claude)
-codex auth         # Codex CLI
-gemini             # Gemini CLI (prompts for auth)
-copilot /login     # GitHub Copilot CLI
-```
-
-For `specify` (SpecKit), sign-in happens per-project (see Part 3).
-
-### Step 5: Apply configs and fonts
-
-The menu is now back. Option 2 is now highlighted:
-
-```
-1. Install / update developer tools
-2. Apply safe non-protected dotfiles        [recommended]
-3. Show full technical details
-4. Show tool and sign-in guidance
-5. Exit without writing
-Choose [1-5]: 2
-```
-
-Choose option 2:
-
-```
-Choose [1-5]: 2
-```
-
-You'll see a preview of config files and fonts to install:
-
-```
-Update existing files with backups:
-  - ~/.claude/settings.json
-  - ~/.codex/config.toml
-  - (other config templates)
-
-Fonts:
-  - JetBrainsMono Nerd Font
-  - FiraCode Nerd Font
-  - ... etc ...
-```
-
-Confirm to apply:
-
-```
-Apply these changes? [y/N]: y
-```
-
-Configs and fonts are now installed. Done!
-
-### Step 6: Restart your shell
-
-For fish shell changes to take effect:
-
-```bash
-exec fish
-```
-
----
-
-## Part 2: Ongoing maintenance
-
-Your machine is now set up. The tools and configs will stay current by following a simple pattern:
-
-### Check for drift
-
-Drift occurs when you've manually edited a config file or when the repo's template has been updated. To audit your machine:
-
-```bash
-~/000-dotfiles/setup
-```
-
-The menu shows your current state:
-
-```
-Machine setup summary
-  - All 10 baseline tools are visible on PATH.
-  - Configs: 2 drifted, 8 current
-
-1. Install / update developer tools
-2. Apply safe non-protected dotfiles        [recommended]
-3. Show full technical details
-4. Show tool and sign-in guidance
-5. Exit without writing
-```
-
-Option 2 is highlighted because configs have drifted. Choose it to review and apply the changes.
-
-### Update tools
-
-To upgrade installed tools:
-
-```bash
-~/000-dotfiles/setup
-Choose [1-5]: 1
-```
-
-This runs:
-- `apt --only-upgrade` for OS packages (git, gh, fish, direnv)
-- `npm update -g` for globally-installed npm tools (codex, gemini, copilot)
-- Self-update for curl installers (claude)
-- `uv tool upgrade` for uv-managed tools (specify)
-
-### Show details (option 3)
-
-If you want to inspect cache paths, font versions, or the full operation plan without applying:
-
-```bash
-Choose [1-5]: 3
-```
-
-Shows raw cache state, package versions, and all pending operations.
-
----
-
-## Part 3: Scaffold AI agent docs in your project
-
-Once you have this repo cloned, you can scaffold AI agent guidelines in any of your projects. This creates a consistent interface for Claude Code, Codex, and Gemini CLIs to work with your codebase.
-
-### In your project directory:
-
-```bash
-cd ~/Apps/my-project
-~/000-dotfiles/setup
-
-# Or with explicit variables:
-~/000-dotfiles/setup init --yes \
-  --project ~/Apps/my-project \
-  --vars <(cat <<'EOF'
-{
-  "PROJECT_NAME": "My Project",
-  "PROJECT_DESCRIPTION": "A concise description",
-  "LANGUAGE": "Python",
-  "PACKAGE_MANAGER": "uv",
-  "RUNTIME_DESCRIPTION": "CLI tool",
-  "INSTALL_CMD": "uv sync",
-  "RUN_CMD": "uv run main.py",
-  "TEST_CMD": "uv run pytest"
-}
-EOF
-)
-```
-
-This creates:
-
-- `AGENTS.md` — shared guidelines for all AI agents
-- `CLAUDE.md` → symlink to `AGENTS.md`
-- `GEMINI.md` → symlink to `AGENTS.md`
-- `copilot-instructions.md` (optional) — Copilot-specific instructions
-
-### For SpecKit users:
-
-Once `specify` is installed, initialize SpecKit in your project:
-
-```bash
-cd ~/Apps/my-project
-specify init --here
-```
-
-This creates per-project scaffolding (`.specify/`, `.agents/skills/`, etc.) that lets you define feature specs and code-generation integrations specific to your project.
-
----
-
-## Troubleshooting
-
-### `uv: command not found`
-
-The setup script installs uv if missing. If you see this:
-
-1. Check if the install completed: `which uv`
-2. If not found, manually install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
-3. Reload your shell: `exec fish` (or `bash`, `zsh`)
-4. Re-run `./setup`
-
-### `Tool install failed: X not found`
-
-Most tools install via `apt`, `npm`, or `uv`. If one fails:
-
-1. Check the error message (scroll back in your terminal)
-2. Run the tool doctor to see state: `./setup doctor`
-3. Try the install command manually, e.g. `apt install git` or `npm install -g @github/copilot`
-4. Re-run `./setup`
-
-### `Config drift: file X differs`
-
-If the setup script reports config drift:
-
-1. Review the difference: `./setup` then choose option 3 (full details)
-2. If you want to keep your changes, skip this file: just don't confirm the apply
-3. If you want the repo's version: choose option 2 and confirm
-4. Backups are created before overwrite (default: `~/.dotfiles-backups/`)
-
-### Font icons look broken in my terminal
-
-Nerd Fonts provide glyphs for code icons. If they're not displaying:
-
-1. Confirm fonts installed: `fc-list | grep JetBrainsMono` (should find them)
-2. In your terminal preferences, set the font to **JetBrainsMono Nerd Font Mono** (or another `* Nerd Font Mono`)
-3. If terminal doesn't show that option, try `FiraCode Nerd Font Mono` or `Hack Nerd Font Mono`
-
-### I accidentally overwrote a file I wanted to keep
-
-Your old file is in `~/.dotfiles-backups/`. Restore it:
-
-```bash
-# List backups
-ls ~/.dotfiles-backups/
-
-# Restore one
-cp ~/.dotfiles-backups/settings.json ~/.claude/settings.json
-```
-
----
-
-## Next steps
-
-- Customize the AI agent docs for your projects: edit `AGENTS.md` to reflect your team's coding standards
-- Set up SpecKit for feature-driven development: `specify init --here` in any project
-- Contribute improvements: the repo is open source and welcomes issues and PRs
+For the full project-doc flow, see [Architecture: Scaffold Flow](architecture/scaffold-flow.md).

--- a/docs/protected-files.md
+++ b/docs/protected-files.md
@@ -1,0 +1,24 @@
+# Protected Files
+
+Some files in this repo are reported by validation, but the setup flow does not overwrite them automatically.
+They either contain local identity, are manually curated, or are symlink anchors that must stay consistent.
+
+## Protected Targets In This Repo
+
+- `git/config` - git identity and credential helper behavior
+- `fish/fish_plugins` - manually curated plugin list
+- `.gitignore` - ignore rules that should be edited intentionally
+- `agents/CLAUDE.md.template` - symlink anchor for project-level agent docs
+- `agents/GEMINI.md.template` - symlink anchor for project-level agent docs
+
+## Why They Stay Protected
+
+- `git/config` affects all git operations for the user.
+- `fish/fish_plugins` may require a manual `fisher update`.
+- `.gitignore` changes can expose secrets or noisy files.
+- The agent template symlinks keep one source of truth for project docs.
+
+## How To Override
+
+Protected items stay visible in the plan, but they are not auto-written unless you explicitly include them in the apply command by manifest ID.
+Use the direct CLI only when you intend to replace one of these files and are prepared to review the backup behavior first.

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -1,0 +1,31 @@
+# Repo Layout
+
+This repo stores templates, validation code, docs, and the interactive setup wrapper.
+
+## Top-Level Layout
+
+| Directory or file | Purpose |
+|---|---|
+| `agents/` | Project-level agent doc templates |
+| `claude/` | `~/.claude/` templates |
+| `codex/` | `~/.codex/` templates |
+| `gemini/` | `~/.gemini/` templates |
+| `gh/` | `~/.config/gh/` templates |
+| `fish/` | `~/.config/fish/` live files and templates |
+| `git/` | `~/.config/git/` live files |
+| `dotfiles_tools/` | Python validation and setup CLI |
+| `setup` | Bash entrypoint that wraps `dotfiles_tools` |
+| `tests/` | Unit tests for the CLI, docs, and workflow contract |
+| `docs/` | User docs, architecture notes, and rollout guidance |
+| `specs/` | Spec Kit feature specs and task artifacts |
+| `dotfiles-manifest.json` | Source of truth for install targets |
+
+## Template Convention
+
+Files ending in `.template` are copy-and-customize sources. They are not executed or sourced directly from the repo.
+Placeholders use `{{UPPER_SNAKE_CASE}}` and should be fully replaced before use.
+
+## Symlink Convention
+
+The root `CLAUDE.md` and `GEMINI.md` files are symlinks to `AGENTS.md`.
+At the project level, the agent templates in `agents/` use the same single-source pattern.

--- a/docs/setup-reference.md
+++ b/docs/setup-reference.md
@@ -1,0 +1,50 @@
+# Setup Reference
+
+This page documents the `./setup` wrapper and the stable `dotfiles_tools` commands it exposes.
+
+## `./setup` Commands
+
+| Command | What it does |
+|---|---|
+| `./setup` | Audit the machine, present the recommendation-aware menu, and optionally apply tool or config changes |
+| `./setup /path/to/project` | Inspect a project folder and offer agent-doc actions |
+| `./setup init [--project PATH] [--vars FILE] [--copilot] --yes` | Render project agent docs and symlinks |
+| `./setup verify [--project PATH] [--copilot]` | Read-only project doc validation |
+| `./setup doctor [--home PATH] [--profile NAME]` | Read-only machine audit |
+
+## Direct CLI
+
+These are the stable commands that `./setup` wraps:
+
+```bash
+uv run python -m dotfiles_tools doctor --repo . --home "$HOME"
+uv run python -m dotfiles_tools plan --repo . --home "$HOME" --profile machine
+uv run python -m dotfiles_tools apply --repo . --home "$HOME" --profile machine --backup-dir "$HOME/.dotfiles-backups" --yes
+uv run python -m dotfiles_tools bootstrap-plan --repo . --home "$HOME" --json
+uv run python -m dotfiles_tools bootstrap-apply --repo . --home "$HOME" --yes
+uv run python -m dotfiles_tools init-project --repo . --project /path/to/project --vars project-vars.json --yes
+```
+
+`doctor` audits without writing. `plan` prints exact operations. `apply` writes only after `--yes` and creates backups first.
+`bootstrap-plan` and `bootstrap-apply` include the font recipes used by the interactive machine menu.
+
+## PATH Installation
+
+Install the wrapper on your `PATH` with a symlink:
+
+```bash
+ln -s /path/to/000-dotfiles/setup ~/.local/bin/dotfiles-setup
+dotfiles-setup verify --project ~/code/my-app
+```
+
+## Recommendation Menu
+
+The interactive menu always keeps the option numbers stable:
+
+1. Install / update developer tools
+2. Apply safe non-protected dotfiles
+3. Show full technical details
+4. Show tool and sign-in guidance
+5. Exit without writing
+
+The summary line marks one option as recommended based on the audited state.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,36 @@
+# Troubleshooting
+
+Common failures are usually one of four things: a missing `uv`, a tool install problem, config drift, or a font issue.
+
+## `uv: command not found`
+
+`./setup` installs `uv` if it is missing. If the bootstrap step fails, verify the install path and reload your shell.
+
+```bash
+which uv
+exec fish
+```
+
+## Tool Install Failed
+
+Most tool installs come from `apt`, `npm`, or `uv`.
+Use option 3 in `./setup` or `./setup doctor` to inspect the current state, then retry the installer once the missing prerequisite is present.
+
+## Config Drift
+
+If the menu reports drift, choose option 2 to review the pending changes.
+Backups are created before overwrite and are stored in `~/.dotfiles-backups/` by default.
+
+## Font Icons Look Broken
+
+Set your terminal font to a `* Nerd Font Mono` face such as `JetBrainsMono Nerd Font Mono`.
+If the terminal does not show that font, choose a different installed Nerd Font Mono variant.
+
+## Restore A File
+
+If you overwrite a file you wanted to keep, restore it from the backup directory.
+
+```bash
+ls ~/.dotfiles-backups/
+cp ~/.dotfiles-backups/settings.json ~/.claude/settings.json
+```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,32 @@
+# Validation
+
+This repo uses unit tests, coverage, and a GitHub Actions workflow to validate the setup code and docs contract.
+
+## Local Commands
+
+```bash
+uv run python -m unittest discover -s tests
+uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
+uv run --with coverage==7.5.4 coverage xml
+```
+
+## Coverage Scope
+
+Coverage is source-scoped to `dotfiles_tools/` through `.coveragerc`.
+That keeps the report focused on production Python code instead of tests, docs, or spec artifacts.
+
+## CI Workflow
+
+`.github/workflows/dotfiles-validation.yml` runs tests on push and pull request events.
+It uploads `coverage.xml` to Codacy on push events when `CODACY_PROJECT_TOKEN` is configured.
+The workflow uses concurrency cancellation so stale runs do not pile up.
+
+## Codacy Checks
+
+The repo expects the following Codacy contexts when coverage is enabled:
+
+- `Codacy Static Code Analysis`
+- `Codacy Coverage Variation`
+- `Codacy Diff Coverage`
+
+The docs in `docs/codacy-coverage-rollout.md` describe the rollout pattern in more detail.

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -9,6 +10,14 @@ from .doctor import run_doctor
 from .manifest import ManifestEntry, ManifestError, load_manifest
 from .reports import Report
 from .tool_installer import DEV_BASE_ENTRY_ID
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    option_number: int
+    label: str
+    reason: str
+    state_category: str
 
 
 def render_machine_summary(repo: Path | str, home: Path | str, *, profile: str = "machine") -> str:
@@ -45,8 +54,9 @@ def render_reports(doctor: Report, plan: Report, repo: Path, home: Path, *, prof
     groups = _group_entries(plan.entries)
     action_summary = _action_summary(doctor, plan, groups)
     manifest_entries = _manifest_entry_map(repo)
-    lines = _summary_header(repo, home, profile)
-    _extend_option_decision(lines, action_summary, groups)
+    recommendation = _recommendation(doctor, plan, action_summary, groups)
+    lines = _summary_header(repo, home, profile, recommendation)
+    _extend_recommendation_context(lines, recommendation, action_summary, groups, doctor, plan)
     _extend_report_sections(lines, doctor, plan, groups, manifest_entries)
     lines.extend([
         "",
@@ -62,68 +72,132 @@ def _manifest_entry_map(repo: Path) -> dict[str, ManifestEntry]:
         return {}
 
 
-def _summary_header(repo: Path, home: Path, profile: str) -> list[str]:
+def _recommendation(
+    doctor: Report,
+    plan: Report,
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> Recommendation:
+    tool_checks = doctor.extra.get("tool_checks") or []
+    missing_tools = _missing_tool_checks(tool_checks)
+    auth_guidance = doctor.extra.get("auth_guidance") or []
+
+    if doctor.errors or plan.errors:
+        return Recommendation(
+            3,
+            "Show full technical details",
+            "The audit is incomplete.",
+            "incomplete_audit",
+        )
+    if action_summary["blockers"]:
+        return Recommendation(
+            3,
+            "Show full technical details",
+            "Inspect the full details before applying changes.",
+            "blocked",
+        )
+    if missing_tools:
+        return Recommendation(
+            1,
+            "Install / update developer tools",
+            "Developer tools should be installed or updated first.",
+            "tools_missing",
+        )
+    if action_summary["file_changes"] or action_summary["font_actions"]:
+        return Recommendation(
+            2,
+            "Apply safe non-protected dotfiles",
+            "Safe non-protected setup changes are pending.",
+            "safe_changes",
+        )
+    if any(item.get("state") == "available" for item in auth_guidance):
+        return Recommendation(
+            4,
+            "Show tool and sign-in guidance",
+            "Sign-in guidance is the useful next step.",
+            "auth_guidance",
+        )
+    if groups["protected"] or action_summary["manual_fonts"]:
+        return Recommendation(
+            3,
+            "Show full technical details",
+            "Manual items need inspection and are not applied automatically.",
+            "manual_only",
+        )
+    return Recommendation(
+        5,
+        "Exit without writing",
+        "Setup is current and no write action is needed.",
+        "current",
+    )
+
+
+def _missing_tool_checks(tool_checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [item for item in tool_checks if item.get("state") == "missing"]
+
+
+def _summary_header(repo: Path, home: Path, profile: str, recommendation: Recommendation) -> list[str]:
     return [
         "Machine setup summary",
         f"Repo: {repo}",
         f"Home: {home}",
         f"Profile: {profile}",
         "",
-        "Option 2 will:",
+        f"Recommended next step: {recommendation.option_number}. {recommendation.label} - {recommendation.reason}",
     ]
 
 
-def _extend_option_decision(
+def _extend_recommendation_context(
     lines: list[str],
+    recommendation: Recommendation,
     action_summary: dict[str, int | bool],
     groups: dict[str, list[dict[str, Any]]],
+    doctor: Report,
+    plan: Report,
 ) -> None:
-    _extend_file_decision(lines, action_summary, groups)
-    _extend_font_decision(lines, action_summary)
-    _extend_requirement_decisions(lines, action_summary)
-    _extend_skip_decisions(lines, action_summary, groups)
-    lines.append("  - Nothing changes until you choose option 2.")
-
-
-def _extend_file_decision(
-    lines: list[str],
-    action_summary: dict[str, int | bool],
-    groups: dict[str, list[dict[str, Any]]],
-) -> None:
-    if not action_summary["file_changes"]:
-        lines.append("  - Apply no file changes; all non-protected targets are current.")
+    if recommendation.state_category == "tools_missing":
+        missing = _missing_tool_checks(doctor.extra.get("tool_checks") or [])
+        lines.append(f"  - {len(missing)} developer tools are missing or unverified.")
+        for item in missing:
+            lines.append(f"    - {item.get('command')}: {item.get('install_hint')}")
         return
-    sentence = _file_change_sentence(len(groups["updates"]), len(groups["creates"]), action_summary["backups"])
-    lines.append("  - " + sentence)
-
-
-def _extend_font_decision(lines: list[str], action_summary: dict[str, int | bool]) -> None:
-    if action_summary["font_actions"]:
-        lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
-    else:
-        lines.append("  - Run no font install/update actions.")
-
-
-def _extend_requirement_decisions(lines: list[str], action_summary: dict[str, int | bool]) -> None:
-    if action_summary["requires_network"]:
-        lines.append("  - Network may be used for Nerd Font downloads unless cached.")
-    if action_summary["requires_apt_sudo"]:
-        lines.append("  - sudo is needed for apt fallback font packages.")
-    elif action_summary["requires_sudo"]:
-        lines.append("  - sudo is needed for host/system font actions.")
-
-
-def _extend_skip_decisions(
-    lines: list[str],
-    action_summary: dict[str, int | bool],
-    groups: dict[str, list[dict[str, Any]]],
-) -> None:
-    if groups["protected"]:
-        lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
-    if action_summary["manual_fonts"]:
-        lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
-    if action_summary["blockers"]:
+    if recommendation.state_category == "safe_changes":
+        lines.append("  - Safe non-protected setup changes are pending.")
+        if action_summary["file_changes"]:
+            sentence = _file_change_sentence(len(groups["updates"]), len(groups["creates"]), action_summary["backups"])
+            lines.append("  - " + sentence)
+        if action_summary["font_actions"]:
+            lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
+        if action_summary["requires_network"]:
+            lines.append("  - Network may be used for Nerd Font downloads unless cached.")
+        if action_summary["requires_apt_sudo"]:
+            lines.append("  - sudo is needed for apt fallback font packages.")
+        elif action_summary["requires_sudo"]:
+            lines.append("  - sudo is needed for host/system font actions.")
+        return
+    if recommendation.state_category == "incomplete_audit":
+        lines.append("  - The audit is incomplete; inspect the full technical details.")
+        if doctor.errors:
+            lines.append(f"  - Doctor errors: {_plural(len(doctor.errors), 'issue')}.")
+        if plan.errors:
+            lines.append(f"  - Plan errors: {_plural(len(plan.errors), 'issue')}.")
+        return
+    if recommendation.state_category == "blocked":
         lines.append(f"  - Stop on {_plural(action_summary['blockers'], 'blocking issue')}; fix before applying.")
+        return
+    if recommendation.state_category == "auth_guidance":
+        auth_guidance = doctor.extra.get("auth_guidance") or []
+        commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
+        if commands:
+            lines.append(f"  - Tool and sign-in guidance: {commands}.")
+        return
+    if recommendation.state_category == "manual_only":
+        if groups["protected"]:
+            lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
+        if action_summary["manual_fonts"]:
+            lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
+        return
+    lines.append("  - Setup is current and no write action is needed.")
 
 
 def _extend_report_sections(
@@ -494,11 +568,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--profile", default="machine")
     parser.add_argument("--menu-mode", action="store_true")
     parser.add_argument("--missing-tool-count", action="store_true")
+    parser.add_argument("--recommendation", action="store_true")
     args = parser.parse_args(argv)
     if args.menu_mode:
         print(render_menu_mode(args.repo, args.home))
     elif args.missing_tool_count:
         print(render_missing_tool_count(args.repo, args.home))
+    elif args.recommendation:
+        repo_path = Path(args.repo).resolve()
+        home_path = Path(args.home).resolve()
+        doctor = run_doctor(repo_path, home_path, profile=args.profile)
+        plan = build_bootstrap_plan(repo_path, home_path, profile=args.profile)
+        groups = _group_entries(plan.entries)
+        action_summary = _action_summary(doctor, plan, groups)
+        recommendation = _recommendation(doctor, plan, action_summary, groups)
+        print(
+            f"{recommendation.option_number}\t{recommendation.label}\t{recommendation.reason}\t{recommendation.state_category}"
+        )
     else:
         print(render_machine_summary(args.repo, args.home, profile=args.profile), end="")
     return 0

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -78,17 +78,27 @@ def _recommendation(
     action_summary: dict[str, int | bool],
     groups: dict[str, list[dict[str, Any]]],
 ) -> Recommendation:
-    tool_checks = doctor.extra.get("tool_checks") or []
-    missing_tools = _missing_tool_checks(tool_checks)
-    auth_guidance = doctor.extra.get("auth_guidance") or []
+    for candidate in (
+        _recommendation_for_audit_failure(doctor, plan),
+        _recommendation_for_blockers(action_summary),
+        _recommendation_for_missing_tools(doctor),
+        _recommendation_for_safe_changes(action_summary),
+        _recommendation_for_auth_guidance(doctor),
+        _recommendation_for_manual_only(action_summary, groups),
+        _recommendation_for_current(),
+    ):
+        if candidate is not None:
+            return candidate
+    raise AssertionError("unreachable recommendation state")
 
+
+def _recommendation_for_audit_failure(doctor: Report, plan: Report) -> Recommendation | None:
     if doctor.errors or plan.errors:
-        return Recommendation(
-            3,
-            "Show full technical details",
-            "The audit is incomplete.",
-            "incomplete_audit",
-        )
+        return Recommendation(3, "Show full technical details", "The audit is incomplete.", "incomplete_audit")
+    return None
+
+
+def _recommendation_for_blockers(action_summary: dict[str, int | bool]) -> Recommendation | None:
     if action_summary["blockers"]:
         return Recommendation(
             3,
@@ -96,13 +106,21 @@ def _recommendation(
             "Inspect the full details before applying changes.",
             "blocked",
         )
-    if missing_tools:
+    return None
+
+
+def _recommendation_for_missing_tools(doctor: Report) -> Recommendation | None:
+    if _missing_tool_checks(doctor.extra.get("tool_checks") or []):
         return Recommendation(
             1,
             "Install / update developer tools",
             "Developer tools should be installed or updated first.",
             "tools_missing",
         )
+    return None
+
+
+def _recommendation_for_safe_changes(action_summary: dict[str, int | bool]) -> Recommendation | None:
     if action_summary["file_changes"] or action_summary["font_actions"]:
         return Recommendation(
             2,
@@ -110,6 +128,11 @@ def _recommendation(
             "Safe non-protected setup changes are pending.",
             "safe_changes",
         )
+    return None
+
+
+def _recommendation_for_auth_guidance(doctor: Report) -> Recommendation | None:
+    auth_guidance = doctor.extra.get("auth_guidance") or []
     if any(item.get("state") == "available" for item in auth_guidance):
         return Recommendation(
             4,
@@ -117,6 +140,13 @@ def _recommendation(
             "Sign-in guidance is the useful next step.",
             "auth_guidance",
         )
+    return None
+
+
+def _recommendation_for_manual_only(
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> Recommendation | None:
     if groups["protected"] or action_summary["manual_fonts"]:
         return Recommendation(
             3,
@@ -124,12 +154,11 @@ def _recommendation(
             "Manual items need inspection and are not applied automatically.",
             "manual_only",
         )
-    return Recommendation(
-        5,
-        "Exit without writing",
-        "Setup is current and no write action is needed.",
-        "current",
-    )
+    return None
+
+
+def _recommendation_for_current() -> Recommendation:
+    return Recommendation(5, "Exit without writing", "Setup is current and no write action is needed.", "current")
 
 
 def _missing_tool_checks(tool_checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -155,49 +184,74 @@ def _extend_recommendation_context(
     doctor: Report,
     plan: Report,
 ) -> None:
-    if recommendation.state_category == "tools_missing":
-        missing = _missing_tool_checks(doctor.extra.get("tool_checks") or [])
-        lines.append(f"  - {len(missing)} developer tools are missing or unverified.")
-        for item in missing:
-            lines.append(f"    - {item.get('command')}: {item.get('install_hint')}")
-        return
-    if recommendation.state_category == "safe_changes":
-        lines.append("  - Safe non-protected setup changes are pending.")
-        if action_summary["file_changes"]:
-            sentence = _file_change_sentence(len(groups["updates"]), len(groups["creates"]), action_summary["backups"])
-            lines.append("  - " + sentence)
-        if action_summary["font_actions"]:
-            lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
-        if action_summary["requires_network"]:
-            lines.append("  - Network may be used for Nerd Font downloads unless cached.")
-        if action_summary["requires_apt_sudo"]:
-            lines.append("  - sudo is needed for apt fallback font packages.")
-        elif action_summary["requires_sudo"]:
-            lines.append("  - sudo is needed for host/system font actions.")
-        return
-    if recommendation.state_category == "incomplete_audit":
-        lines.append("  - The audit is incomplete; inspect the full technical details.")
-        if doctor.errors:
-            lines.append(f"  - Doctor errors: {_plural(len(doctor.errors), 'issue')}.")
-        if plan.errors:
-            lines.append(f"  - Plan errors: {_plural(len(plan.errors), 'issue')}.")
-        return
-    if recommendation.state_category == "blocked":
-        lines.append(f"  - Stop on {_plural(action_summary['blockers'], 'blocking issue')}; fix before applying.")
-        return
-    if recommendation.state_category == "auth_guidance":
-        auth_guidance = doctor.extra.get("auth_guidance") or []
-        commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
-        if commands:
-            lines.append(f"  - Tool and sign-in guidance: {commands}.")
-        return
-    if recommendation.state_category == "manual_only":
-        if groups["protected"]:
-            lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
-        if action_summary["manual_fonts"]:
-            lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
-        return
-    lines.append("  - Setup is current and no write action is needed.")
+    handlers = {
+        "tools_missing": lambda: _extend_tools_missing_context(lines, doctor),
+        "safe_changes": lambda: _extend_safe_changes_context(lines, action_summary, groups),
+        "incomplete_audit": lambda: _extend_incomplete_audit_context(lines, doctor, plan),
+        "blocked": lambda: _extend_blocked_context(lines, action_summary),
+        "auth_guidance": lambda: _extend_auth_guidance_context(lines, doctor),
+        "manual_only": lambda: _extend_manual_only_context(lines, action_summary, groups),
+        "current": lambda: lines.append("  - Setup is current and no write action is needed."),
+    }
+    handler = handlers.get(recommendation.state_category)
+    if handler is not None:
+        handler()
+
+
+def _extend_tools_missing_context(lines: list[str], doctor: Report) -> None:
+    missing = _missing_tool_checks(doctor.extra.get("tool_checks") or [])
+    lines.append(f"  - {len(missing)} developer tools are missing or unverified.")
+    for item in missing:
+        lines.append(f"    - {item.get('command')}: {item.get('install_hint')}")
+
+
+def _extend_safe_changes_context(
+    lines: list[str],
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> None:
+    lines.append("  - Safe non-protected setup changes are pending.")
+    if action_summary["file_changes"]:
+        sentence = _file_change_sentence(len(groups["updates"]), len(groups["creates"]), action_summary["backups"])
+        lines.append("  - " + sentence)
+    if action_summary["font_actions"]:
+        lines.append("  - Install/update " + _font_action_sentence(action_summary) + ".")
+    if action_summary["requires_network"]:
+        lines.append("  - Network may be used for Nerd Font downloads unless cached.")
+    if action_summary["requires_apt_sudo"]:
+        lines.append("  - sudo is needed for apt fallback font packages.")
+    elif action_summary["requires_sudo"]:
+        lines.append("  - sudo is needed for host/system font actions.")
+
+
+def _extend_incomplete_audit_context(lines: list[str], doctor: Report, plan: Report) -> None:
+    lines.append("  - The audit is incomplete; inspect the full technical details.")
+    if doctor.errors:
+        lines.append(f"  - Doctor errors: {_plural(len(doctor.errors), 'issue')}.")
+    if plan.errors:
+        lines.append(f"  - Plan errors: {_plural(len(plan.errors), 'issue')}.")
+
+
+def _extend_blocked_context(lines: list[str], action_summary: dict[str, int | bool]) -> None:
+    lines.append(f"  - Stop on {_plural(action_summary['blockers'], 'blocking issue')}; fix before applying.")
+
+
+def _extend_auth_guidance_context(lines: list[str], doctor: Report) -> None:
+    auth_guidance = doctor.extra.get("auth_guidance") or []
+    commands = ", ".join(str(item.get("command")) for item in auth_guidance if item.get("state") == "available")
+    if commands:
+        lines.append(f"  - Tool and sign-in guidance: {commands}.")
+
+
+def _extend_manual_only_context(
+    lines: list[str],
+    action_summary: dict[str, int | bool],
+    groups: dict[str, list[dict[str, Any]]],
+) -> None:
+    if groups["protected"]:
+        lines.append(f"  - Leave {_plural(len(groups['protected']), 'protected/manual file')} untouched.")
+    if action_summary["manual_fonts"]:
+        lines.append(f"  - Skip {_plural(action_summary['manual_fonts'], 'manual/unsupported font item')}; see Fonts below.")
 
 
 def _extend_report_sections(

--- a/setup
+++ b/setup
@@ -513,8 +513,10 @@ run_machine_install_tools_with_confirm() {
   if read -r confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
     echo
     run_machine_install_tools_apply || return $?
+    return 2
   else
     echo "No tool changes applied."
+    return 2
   fi
 }
 
@@ -531,18 +533,14 @@ run_machine_summary() {
     --profile machine)
 }
 
-run_machine_menu_mode() {
-  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
-    --repo "$DOTFILES_REPO" \
-    --home "$HOME" \
-    --menu-mode)
-}
-
-run_machine_missing_tool_count() {
-  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.machine_summary \
-    --repo "$DOTFILES_REPO" \
-    --home "$HOME" \
-    --missing-tool-count)
+extract_machine_recommendation() {
+  local summary_text="$1"
+  local recommendation_body
+  recommendation_body="$(printf '%s\n' "$summary_text" | sed -n 's/^Recommended next step: //p' | head -n1)"
+  if [[ -z "$recommendation_body" ]]; then
+    recommendation_body="5. Exit without writing - Setup is current and no write action is needed."
+  fi
+  printf '%s\n' "$recommendation_body"
 }
 
 run_machine_details() {
@@ -558,21 +556,27 @@ show_tool_auth_commands() {
 }
 
 machine_menu_loop() {
-  local header_line="$1"
+  local recommendation_body="$1"
   local rec_opt="$2"
   while true; do
     local opt1="  1. Install / update developer tools (preview, then apply)."
     local opt2="  2. Apply safe non-protected dotfiles and approved install/update recipes."
+    local opt3="  3. Show full technical details."
+    local opt4="  4. Show tool and sign-in guidance."
+    local opt5="  5. Exit without writing."
     [[ "$rec_opt" == "1" ]] && opt1+=" [recommended]"
     [[ "$rec_opt" == "2" ]] && opt2+=" [recommended]"
+    [[ "$rec_opt" == "3" ]] && opt3+=" [recommended]"
+    [[ "$rec_opt" == "4" ]] && opt4+=" [recommended]"
+    [[ "$rec_opt" == "5" ]] && opt5+=" [recommended]"
     cat <<EOF
 
-${header_line}
+Recommended next step: ${recommendation_body}
 ${opt1}
 ${opt2}
-  3. Show full technical details.
-  4. Show tool and sign-in guidance.
-  5. Exit without writing.
+${opt3}
+${opt4}
+${opt5}
 EOF
     printf 'Choose [1-5]: '
     local choice
@@ -593,27 +597,33 @@ EOF
 }
 
 machine_menu() {
-  local mode="${1:-tools_present}"
-  if [[ "$mode" == "tools_missing" ]]; then
-    local missing_count
-    missing_count="$(run_machine_missing_tool_count 2>/dev/null)" || missing_count="?"
-    [[ -z "$missing_count" ]] && missing_count="?"
-    machine_menu_loop "Next steps (${missing_count} developer tools missing):" "1"
-  else
-    machine_menu_loop "Next steps:" "2"
-  fi
+  local recommendation_body="${1:-5. Exit without writing - Setup is current and no write action is needed.}"
+  local rec_opt="${2:-5}"
+  machine_menu_loop "$recommendation_body" "$rec_opt"
 }
 
 cmd_machine_setup() {
   preflight_common
   echo "Preparing/checking this computer with profile: machine"
   echo
-  run_machine_summary
-  local mode
-  if ! mode="$(run_machine_menu_mode)" || [[ -z "$mode" ]]; then
-    mode="tools_present"
-  fi
-  machine_menu "$mode"
+  while true; do
+    local summary_output recommendation_body rec_opt menu_status
+    summary_output="$(run_machine_summary)"
+    printf '%s\n' "$summary_output"
+    recommendation_body="$(extract_machine_recommendation "$summary_output")"
+    rec_opt="${recommendation_body%%.*}"
+    [[ "$rec_opt" =~ ^[1-5]$ ]] || rec_opt="5"
+    if machine_menu "$recommendation_body" "$rec_opt"; then
+      menu_status=0
+    else
+      menu_status=$?
+    fi
+    if [[ "$menu_status" -eq 2 ]]; then
+      echo
+      continue
+    fi
+    return "$menu_status"
+  done
 }
 
 project_is_empty() {

--- a/specs/002-setup-menu-recommendation/checklists/menu-recommendation.md
+++ b/specs/002-setup-menu-recommendation/checklists/menu-recommendation.md
@@ -1,0 +1,68 @@
+# Menu Recommendation Requirements Checklist: Setup Menu Recommendation Guidance
+
+**Purpose**: Validate requirement quality for the `./setup` machine-menu recommendation flow before task generation
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Recommendation Decision Completeness
+
+- [x] CHK001 Are all machine setup states that can affect the recommended option explicitly enumerated? [Completeness, Spec §FR-001, Contract §State-To-Recommendation]
+- [x] CHK002 Are priority rules defined for cases where blockers, missing tools, safe changes, auth guidance, and manual items overlap? [Completeness, Research §Recommendation Priority Order]
+- [x] CHK003 Is the "exactly one recommended option" requirement tied to every evaluated state, including current and manual-only states? [Clarity, Spec §FR-001, Spec §FR-007]
+- [x] CHK004 Are requirements defined for how unverified tools differ from missing, installed, and unsupported tools? [Gap, Spec §FR-004, Data Model §Machine Setup State]
+- [x] CHK005 Are requirements defined for deciding whether auth guidance is the only useful remaining action? [Gap, Spec §FR-008, Data Model §Machine Setup State]
+
+## Scenario Coverage
+
+- [x] CHK006 Are primary fresh-machine and configured-machine flows both covered with independent scenarios? [Coverage, Spec §User Story 1, Spec §User Story 2]
+- [x] CHK007 Are recovery requirements complete for canceled tool installation and partial or unsuccessful tool installation outcomes? [Coverage, Spec §User Story 2, Edge Cases]
+- [x] CHK008 Are exception requirements defined for audit or plan failures that prevent safe apply? [Coverage, Spec §FR-006, Edge Cases]
+- [x] CHK009 Are protected/manual-only scenarios clearly distinguished from safe-change scenarios? [Clarity, Spec §FR-013, Contract §Safety Contract]
+- [x] CHK010 Are fully-current/no-action scenarios specified with enough detail to prevent recommending a no-op apply path? [Completeness, Spec §FR-007, SC-004]
+- [x] CHK011 Are non-recommended user choices explicitly allowed without weakening the recommended path? [Consistency, Spec §FR-012, Contract §Safety Contract]
+
+## Requirement Clarity
+
+- [x] CHK012 Is "visible in plain text" defined well enough to avoid relying on color, cursor position, or styling? [Clarity, Spec §FR-002, SC-007]
+- [x] CHK013 Is "short reason near the menu" specific enough to guide placement and wording without ambiguity? [Ambiguity, Spec §FR-003, Contract §Recommendation Rendering]
+- [x] CHK014 Are stable menu option labels specific enough to prevent documentation and output from drifting? [Clarity, Spec §FR-011, Contract §Stable Menu Options]
+- [x] CHK015 Is "same audited machine status" defined with clear source data boundaries? [Ambiguity, Spec §FR-014, Data Model §Machine Setup State]
+- [x] CHK016 Are "safe non-protected dotfile or font actions" defined consistently across spec, plan, and contract? [Consistency, Spec §FR-005, Plan §Summary, Contract §State-To-Recommendation]
+
+## Acceptance Criteria Quality
+
+- [x] CHK017 Are success criteria measurable for each recommendation state without depending on terminal styling? [Measurability, SC-001, SC-007]
+- [x] CHK018 Do success criteria cover negative cases where no other option may be marked recommended? [Completeness, SC-001, SC-002]
+- [x] CHK019 Are documentation-alignment success criteria traceable to specific documented examples? [Traceability, SC-008, Spec §Grounding Context]
+- [x] CHK020 Is the refreshed-menu success criterion specific about which actions require a refreshed summary and recommendation? [Clarity, SC-006, Contract §Fresh-Machine Session Contract]
+
+## Consistency And Safety
+
+- [x] CHK021 Are explicit confirmation, backup, and protected-file requirements consistent with the existing constitution gates? [Consistency, Spec §FR-013, Plan §Constitution Check]
+- [x] CHK022 Are requirements clear that protected/manual files remain visible but are not counted as safe writable changes? [Clarity, Data Model §Machine Setup State, Contract §Safety Contract]
+- [x] CHK023 Are scope boundaries consistent across spec and plan, especially excluding project-folder menus? [Consistency, Spec §Assumptions, Plan §Technical Context]
+- [x] CHK024 Are dependency and lock-file assumptions documented clearly enough to avoid unintended tooling changes? [Assumption, Plan §Technical Context, Plan §Constitution Check]
+
+## Documentation And Contract Alignment
+
+- [x] CHK025 Are README and getting-started requirements explicit about the transition from option 1 to option 2 in the fresh-machine flow? [Completeness, Spec §User Story 3, Contract §Fresh-Machine Session Contract]
+- [x] CHK026 Are documentation examples required to use the same option numbers and recommendation wording as the contract? [Consistency, Spec §FR-015, Contract §Stable Menu Options]
+- [x] CHK027 Does the data model define enough fields to support every state listed in the contract? [Coverage, Data Model §Machine Setup State, Contract §State-To-Recommendation]
+- [x] CHK028 Are traceability references available from each user story to functional requirements and success criteria? [Traceability, Spec §User Scenarios, Spec §Functional Requirements, Spec §Success Criteria]
+
+## Incomplete Audit Fallback
+
+- [x] CHK029 Is the incomplete/failed status-audit fallback explicitly treated as a first-class recommendation state across the spec, plan, and contract? [Completeness, Spec §FR-017, Plan §Summary, Contract §State-To-Recommendation]
+- [x] CHK030 Is the fallback reason for incomplete or failed status audits specific enough to distinguish "audit incomplete" from the other option 3 reasons? [Clarity, Spec §FR-017, Spec §SC-009]
+- [x] CHK031 Are all status-command failure modes that can suppress recommendation confidence identified as in-scope or intentionally excluded? [Coverage, Spec §Edge Cases, Data Model §Machine Setup State]
+
+## Recommendation Language And Traceability
+
+- [x] CHK032 Is the phrase "recommended action" used consistently for the highlighted menu item, summary output, and documentation examples? [Consistency, Spec §Grounding Context, Contract §Recommendation Rendering]
+- [x] CHK033 Are the stable option labels and the "Recommended next step" line described with enough precision to avoid alternate wording across docs? [Clarity, Spec §FR-003, Contract §Stable Menu Options]
+- [x] CHK034 Are the machine-state inputs that drive recommendation selection named clearly enough to trace from contract to implementation tasks? [Traceability, Spec §FR-014, Tasks T004-T007]
+
+## Scenario And Acceptance Coverage
+
+- [x] CHK035 Are acceptance scenarios defined for both the stale-state case and the refreshed-state case after tool install/cancel, including the incomplete-audit fallback? [Coverage, Spec §User Story 1, Spec §User Story 2]
+- [x] CHK036 Are success criteria measurable for the incomplete-audit fallback without relying on implementation-specific command names or shell behavior? [Measurability, Spec §SC-009]

--- a/specs/002-setup-menu-recommendation/checklists/requirements.md
+++ b/specs/002-setup-menu-recommendation/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Setup Menu Recommendation Guidance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-05-02.
+- The spec intentionally includes user-facing command and menu option names
+  because they are part of the documented product behavior.

--- a/specs/002-setup-menu-recommendation/contracts/setup-menu.md
+++ b/specs/002-setup-menu-recommendation/contracts/setup-menu.md
@@ -1,0 +1,66 @@
+# Contract: `./setup` Machine Menu Recommendation
+
+This contract defines the user-visible behavior for running `./setup` with no
+arguments.
+
+## Stable Menu Options
+
+The machine setup menu must expose these option numbers:
+
+```text
+1. Install / update developer tools
+2. Apply safe non-protected dotfiles
+3. Show full technical details
+4. Show tool and sign-in guidance
+5. Exit without writing
+```
+
+Labels may include short clarifying suffixes, but the option purpose and number
+must remain stable.
+
+## Recommendation Rendering
+
+Every menu render must include:
+
+```text
+Recommended next step: <N>. <label> - <reason>
+```
+
+Exactly one menu option must include:
+
+```text
+[recommended]
+```
+
+The recommendation must remain visible in plain captured output without color.
+
+## State-To-Recommendation Contract
+
+| Machine state | Recommended option | Required reason |
+| --- | --- | --- |
+| Status command fails or required status data is incomplete | 3 | Explain that details should be inspected because the audit is incomplete |
+| Blocking audit or plan issues exist | 3 | Explain that details should be inspected before applying |
+| One or more developer tools are missing or unverified | 1 | Explain that tools should be installed or updated first |
+| Tools are present and safe dotfile or font actions are pending | 2 | Explain that safe non-protected setup changes are pending |
+| Only manual sign-in guidance is pending | 4 | Explain that sign-in guidance is the useful next step |
+| Only protected/manual items are pending | 3 | Explain that manual items need inspection and are not applied automatically |
+| No useful setup action is pending | 5 | Explain that setup is current and no write action is needed |
+
+## Fresh-Machine Session Contract
+
+When option 1 is selected:
+
+1. The tool install/update preview is shown.
+2. The user is asked for confirmation before writes.
+3. If the user confirms, the action runs and reports the result.
+4. If the user declines, no tool changes are applied.
+5. In both cases, `./setup` re-runs the machine summary and renders a fresh
+   recommendation unless the process cannot continue.
+
+## Safety Contract
+
+- Option 2 still requires explicit apply confirmation before writes.
+- Protected/manual files remain untouched unless separately and explicitly
+  included by protected entry ID outside the safe menu path.
+- Backups remain required before replacing differing files.
+- Choosing a non-recommended option remains allowed.

--- a/specs/002-setup-menu-recommendation/data-model.md
+++ b/specs/002-setup-menu-recommendation/data-model.md
@@ -1,0 +1,117 @@
+# Data Model: Setup Menu Recommendation Guidance
+
+## Machine Setup State
+
+Represents the audited status used to choose the next menu action.
+
+Fields:
+
+- `tool_status`: Summary of missing, installed, unverified, or unsupported
+  developer tools.
+- `safe_file_actions`: Count and labels of non-protected dotfile actions that
+  can be applied with approval and backups.
+- `font_actions`: Count and labels of font install/update actions.
+- `protected_manual_items`: Count and reasons for protected/manual files that
+  will not be applied automatically.
+- `blockers`: Count and reasons for audit or plan failures that require
+  inspection before writes.
+- `auth_guidance_available`: Whether installed tools have manual sign-in
+  guidance to show.
+- `is_current`: Whether no useful setup action remains.
+
+Validation rules:
+
+- State must be derived from the same audit/plan data shown in the machine
+  summary.
+- Blocking issues must remain visible even when another action is recommended.
+- Protected/manual items must not be counted as safe writable changes.
+
+## Recommended Option
+
+Represents the single next option highlighted in the machine menu.
+
+Fields:
+
+- `option_number`: One of `1`, `2`, `3`, `4`, or `5`.
+- `label`: The stable menu label for the option.
+- `reason`: Plain-language explanation for why this option is recommended.
+- `state_category`: One of `blocked`, `tools_missing`, `safe_changes`,
+  `auth_guidance`, `manual_only`, or `current`.
+
+Validation rules:
+
+- Exactly one recommendation must exist for each machine setup state.
+- The option number must correspond to a visible stable menu option.
+- The reason must be visible in plain captured output.
+
+State transitions:
+
+- `blocked` -> remains until blockers are fixed.
+- `tools_missing` -> `safe_changes`, `auth_guidance`, `manual_only`, or
+  `current` after tool install/update is re-audited.
+- `safe_changes` -> `auth_guidance`, `manual_only`, or `current` after approved
+  apply succeeds.
+- `auth_guidance` -> `current` after the user completes manual sign-in outside
+  setup, if no other actions remain.
+- `manual_only` -> `current` only if protected/manual state is intentionally
+  resolved outside the safe apply path.
+
+## Machine Setup Menu
+
+Represents the stable interactive menu shown by `./setup` with no arguments.
+
+Fields:
+
+- `options`: Five stable option labels.
+- `recommended_option`: The single recommended option.
+- `prompt`: The user input prompt.
+- `non_writing_choices`: Choices that inspect or exit without writes.
+- `write_choices`: Choices that still require explicit confirmation before
+  writes.
+
+Validation rules:
+
+- Option numbers must remain stable across all states.
+- Only the recommended option may include `[recommended]`.
+- Non-recommended options remain selectable.
+- Write choices must preserve existing confirmation, backup, and protected-file
+  behavior.
+
+## Guided Setup Session
+
+Represents one interactive run of the machine setup flow.
+
+Fields:
+
+- `initial_state`: State before the first menu render.
+- `selected_option`: User-selected menu option.
+- `action_result`: Completed, canceled, failed, or no-op result.
+- `refreshed_state`: State after a menu action that can change setup status.
+- `next_recommendation`: Recommendation shown after refresh.
+
+Validation rules:
+
+- Tool install/update completion or cancellation must refresh state and return
+  to the menu.
+- Full details and auth guidance may return to the menu after display.
+- Exit must not write files.
+
+## Documentation Example
+
+Represents README or getting-started content that documents expected menu
+behavior.
+
+Fields:
+
+- `document_path`: Documentation file path.
+- `scenario`: Fresh machine, configured machine, current machine, or issue flow.
+- `expected_recommendation`: Option number and reason described by the example.
+- `menu_labels`: Stable option labels shown in the example.
+
+Validation rules:
+
+- Documentation examples must match current option labels.
+- Fresh-machine documentation must show option 1 first, then option 2 after
+  tool installation.
+- Documentation must not imply protected/manual files are applied
+  automatically.

--- a/specs/002-setup-menu-recommendation/plan.md
+++ b/specs/002-setup-menu-recommendation/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Setup Menu Recommendation Guidance
+
+**Branch**: `20260503-setup-menu-recommendation` | **Date**: 2026-05-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-setup-menu-recommendation/spec.md`
+
+**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Make the interactive `./setup` machine menu show one unmistakable recommended
+next step for the user's current system state. The recommendation will be
+derived from the same audited tool, dotfile, font, blocker, auth-guidance, and
+incomplete/failed status-audit states shown in the machine summary, then
+rendered consistently in the summary and stable five-option menu. The guided
+fresh-machine path will return to a refreshed summary and menu after the tool
+install/update step, matching the README and getting-started documentation.
+
+## Technical Context
+
+**Language/Version**: Bash for the `./setup` wrapper; Python 3.11+ standard library for `dotfiles_tools`
+**Primary Dependencies**: Python standard library and existing shell tools only; no new runtime dependencies
+**Storage**: No new persistent storage; reads existing manifest/status data and writes only existing setup artifacts during approved setup actions
+**Testing**: `uv run python -m unittest discover -s tests`; supplemental focused checks in existing `tests/test_machine_summary.py`, `tests/test_setup_script.py`, and `tests/test_docs.py`
+**Target Platform**: Linux-like developer machines supported by the existing setup flow, including Ubuntu, WSL, Raspberry Pi, Pixel Terminal, and Pixel AVF
+**Project Type**: Repository-local CLI and shell wrapper enhancement
+**Performance Goals**: Recommendation decision adds no meaningful delay beyond the existing summary audit; no duplicate expensive probes in the common menu path
+**Constraints**: Keep option numbers stable; recommendation must be plain-text visible; no protected-file edits; no lock file; no new runtime dependency; writes still require explicit confirmation and backups
+**Scale/Scope**: Machine setup menu invoked by `./setup` with no arguments; project-folder menus are out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Template Source of Truth**: PASS. The feature does not edit `.template`
+  files or AGENTS.md symlink conventions.
+- **Secret-Free and Identity-Safe**: PASS. The feature changes menu guidance
+  only and does not add credentials, auth files, tokens, or identity behavior.
+- **Protected Files**: PASS. `git/config`, `fish/fish_plugins`, `.gitignore`,
+  and symlinked agent templates remain untouched.
+- **Reproducible Bootstrap**: PASS. Recommendation is derived from existing
+  manifest-backed audit/plan data, keeps dry-run visibility, and preserves
+  explicit apply approval plus backup behavior.
+- **Validation Before Coverage**: PASS. Planning requires focused tests for the
+  new recommendation states before any coverage signal is relevant.
+- **uv Python Workflow**: PASS. Validation commands use `uv`; runtime code uses
+  only the Python standard library and existing Bash wrapper.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-setup-menu-recommendation/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── setup-menu.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+setup
+
+dotfiles_tools/
+├── machine_summary.py
+├── bootstrap.py
+├── tool_installer.py
+├── baseline.py
+└── reports.py
+
+tests/
+├── test_machine_summary.py
+├── test_setup_script.py
+└── test_docs.py
+
+README.md
+docs/
+└── getting-started.md
+```
+
+**Structure Decision**: Extend the existing setup wrapper and
+`dotfiles_tools.machine_summary` recommendation path. Keep recommendation
+calculation in Python so tests can exercise state combinations without driving
+the whole shell menu, and keep shell changes limited to rendering and looping
+around the existing actions.
+
+## Phase 0: Research
+
+Research decisions are captured in [research.md](./research.md). Key resolved
+decisions:
+
+- Use one structured recommendation decision as the source of truth for summary
+  and menu rendering.
+- Preserve a plain `[recommended]` marker and add a nearby reason line.
+- Use a documented priority order for incomplete/failed status audits,
+  blockers, missing tools, safe writes, auth-only guidance,
+  protected/manual-only states, and fully current state.
+- Return to the machine summary/menu after tool install/update completes or is
+  canceled.
+
+## Phase 1: Design
+
+Design artifacts:
+
+- [data-model.md](./data-model.md): machine setup state, recommendation,
+  menu option, guided session, and documentation example.
+- [contracts/setup-menu.md](./contracts/setup-menu.md): user-visible menu
+  output and state-to-recommendation contract.
+- [quickstart.md](./quickstart.md): validation commands and manual smoke flows.
+
+## Constitution Check - Post-Design
+
+- **Template Source of Truth**: PASS. Design does not alter template execution
+  semantics or symlink source-of-truth rules.
+- **Secret-Free and Identity-Safe**: PASS. Contracts and quickstart contain no
+  secrets and do not change auth storage; auth remains manual guidance.
+- **Protected Files**: PASS. Design keeps protected/manual files visible and
+  excludes them from automatic safe apply behavior.
+- **Reproducible Bootstrap**: PASS. Recommendation states are tied to existing
+  audit/plan data and keep explicit apply confirmation and backup guarantees.
+- **Validation Before Coverage**: PASS. Quickstart and plan call for focused
+  unit tests before coverage.
+- **uv Python Workflow**: PASS. All Python validation commands use `uv` and no
+  runtime dependency or lock-file change is introduced.
+
+## Complexity Tracking
+
+No constitution violations are accepted for this feature.

--- a/specs/002-setup-menu-recommendation/quickstart.md
+++ b/specs/002-setup-menu-recommendation/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Setup Menu Recommendation Guidance
+
+## 1. Run The Focused Tests
+
+```bash
+uv run python -m unittest tests.test_machine_summary tests.test_setup_script tests.test_docs
+```
+
+Expected result: the tests cover missing-tools, safe-changes-pending,
+blockers-present, auth-guidance-only, protected/manual-only, and fully-current
+recommendation states.
+
+## 2. Run The Full Test Suite
+
+```bash
+uv run python -m unittest discover -s tests
+```
+
+Expected result: all existing setup, manifest, project-init, docs, and workflow
+tests still pass.
+
+## 3. Verify Fresh-Machine Recommendation
+
+Run `./setup` in an environment where one or more baseline developer tools are
+missing.
+
+Expected result:
+
+- The summary shows missing tools.
+- The menu includes `Recommended next step: 1. ...`.
+- Only option 1 has `[recommended]`.
+- Declining the tool install prompt returns to a refreshed summary and menu
+  without writing files.
+
+## 4. Verify Configured-Machine Recommendation
+
+Run `./setup` in an environment where developer tools are present and at least
+one safe non-protected dotfile or font action is pending.
+
+Expected result:
+
+- The summary names pending safe changes.
+- The menu includes `Recommended next step: 2. ...`.
+- Only option 2 has `[recommended]`.
+- Safe apply still requires explicit confirmation and backups.
+
+## 5. Verify No-Action Recommendation
+
+Run `./setup` in an environment where tools are present, safe dotfiles and fonts
+are current, no blockers exist, and no auth guidance remains.
+
+Expected result:
+
+- The summary states that setup is current.
+- The menu recommends option 5, exit without writing.
+- Choosing option 5 exits without writes.
+
+## 6. Verify Documentation Alignment
+
+Review these files after implementation:
+
+- `README.md`
+- `docs/getting-started.md`
+- `tests/test_docs.py`
+
+Expected result: documented menu labels and recommendation states match the
+actual setup output, including the fresh-machine transition from option 1 to
+option 2.

--- a/specs/002-setup-menu-recommendation/research.md
+++ b/specs/002-setup-menu-recommendation/research.md
@@ -1,0 +1,92 @@
+# Research: Setup Menu Recommendation Guidance
+
+## Decision: Use One Structured Recommendation Decision
+
+The menu recommendation will be represented as a single structured decision
+containing option number, label, reason, and state category. The machine summary
+and shell menu should render this same decision instead of independently
+recomputing recommendation text.
+
+**Rationale**: The current behavior can tag option 1 or option 2, but the
+summary still frames everything as "Option 2 will". A single decision prevents
+the summary and menu from disagreeing and makes the behavior easier to test.
+
+**Alternatives considered**:
+
+- Keep Bash-only branching. Rejected because it duplicates the state decision
+  outside the audited Python report path.
+- Only change documentation. Rejected because the reported user issue is an
+  interactive guidance gap, not just a documentation wording issue.
+
+## Decision: Recommendation Must Be Plain Text Plus Reason
+
+The menu will keep a visible `[recommended]` marker on exactly one option and
+also print a nearby "Recommended next step" reason line before the prompt.
+Color or styling may be added later, but plain text remains the contract.
+
+**Rationale**: Captured output, low-color terminals, and screen readers need the
+recommendation to be visible without styling. A reason reduces guesswork when
+the recommended option is details, auth guidance, or exit.
+
+**Alternatives considered**:
+
+- Use color-only highlighting. Rejected because some terminals and captured
+  test output would not show it.
+- Use only `[recommended]`. Rejected because it does not explain why an option
+  is recommended.
+
+## Decision: Recommendation Priority Order
+
+Recommendation precedence will be:
+
+1. Blocking audit/plan issues: recommend option 3, full details.
+2. Missing or unverified developer tools: recommend option 1, install/update tools.
+3. Safe non-protected dotfile or font actions: recommend option 2, apply safe changes.
+4. Auth-guidance-only state: recommend option 4, tool/sign-in guidance.
+5. Protected/manual-only state: recommend option 3, full details.
+6. Fully current state: recommend option 5, exit without writing.
+
+**Rationale**: Blocking issues must be inspected before writes. Missing tools
+come before config apply in the documented fresh-machine flow. Safe writes
+remain the main configured-machine action. Auth and protected/manual states need
+guidance but should not imply a safe apply will help. Fully current systems
+should not be nudged into a no-op write path.
+
+**Alternatives considered**:
+
+- Always recommend option 2 when tools are present. Rejected because it
+  misguides users in blocker, auth-only, protected-only, and fully current
+  states.
+- Recommend exit for protected/manual-only states. Rejected because the user
+  may need to inspect why items were not applied.
+
+## Decision: Refresh Menu After Tool Install/Update
+
+After option 1 completes or is canceled, `./setup` will return to a refreshed
+machine summary and menu instead of ending the guided session.
+
+**Rationale**: README and getting-started documentation describe a fresh-machine
+flow where the menu returns and option 2 becomes recommended after tools are
+installed. Re-rendering also handles partial install results and cancellation
+without guessing stale state.
+
+**Alternatives considered**:
+
+- End after tool install and require users to rerun `./setup`. Rejected because
+  it contradicts documented flow and increases guesswork.
+- Blindly show option 2 after tool install. Rejected because partial failures
+  or unverified tools may mean option 1 remains the right recommendation.
+
+## Decision: Keep Project Menus Out Of Scope
+
+This feature covers only the machine setup menu shown by `./setup` with no
+arguments.
+
+**Rationale**: The reported gap and documentation references are specifically
+about the machine setup flow and its five-option menu. Project-folder menus have
+different choices and state checks.
+
+**Alternatives considered**:
+
+- Redesign all interactive menus. Rejected because it expands scope beyond the
+  grounded requirement.

--- a/specs/002-setup-menu-recommendation/spec.md
+++ b/specs/002-setup-menu-recommendation/spec.md
@@ -1,0 +1,233 @@
+# Feature Specification: Setup Menu Recommendation Guidance
+
+**Feature Branch**: `20260503-setup-menu-recommendation`
+**Created**: 2026-05-02
+**Status**: Draft
+**Input**: User description: "Review the current implementation, the ./setup menu is supposed to provide the recommendation highlighting which step should be used depending on the user's existing system status, this is to minimise guess work. However, I don't think I saw this highlight of the menu item to guide me. Identify how it should be done, think through the process and expected flow of using ./setup and identify the areas on how to implement it. Take reference to all documentation so that this is grounded requirement."
+
+## Grounding Context
+
+The README and getting-started guide promise that `./setup` audits the machine,
+shows a stable five-option menu, and marks the option that fits the current
+machine state with `[recommended]`. They describe a fresh-machine flow where
+option 1 is recommended while developer tools are missing, then the menu
+returns and option 2 is recommended after tools are installed. They also
+describe an existing-machine flow where option 2 is recommended when safe
+dotfile or font changes are pending.
+
+The current behavior already has a recommendation concept, but the user-visible
+experience needs to make the recommendation unmistakable, keep the summary and
+menu consistent, and cover every common machine state so users do not have to
+infer the next step from raw status details.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See The Recommended Next Step (Priority: P1)
+
+A maintainer runs `./setup` on a machine and wants the menu to clearly identify
+which action to choose next, so setup can proceed without guessing from the
+status summary.
+
+**Why this priority**: The recommendation is the primary navigation aid for the
+interactive setup flow and is explicitly promised in user-facing documentation.
+
+**Independent Test**: Can be tested by running the setup flow against simulated
+machine states and verifying that exactly one visible recommendation appears,
+with a reason that matches the audited state.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more developer tools are missing, **When** the maintainer
+   reaches the machine setup menu, **Then** option 1 is visibly marked as the
+   recommended option and the menu explains that tool installation or update is
+   the next step.
+2. **Given** developer tools are present and safe non-protected dotfile or font
+   changes are pending, **When** the maintainer reaches the machine setup menu,
+   **Then** option 2 is visibly marked as the recommended option and the menu
+   explains that safe setup changes are pending.
+3. **Given** blocking setup issues are present, **When** the maintainer reaches
+   the machine setup menu, **Then** the recommendation guides the maintainer to
+   inspect details before applying changes and the blocking reason remains
+   visible.
+4. **Given** the machine state cannot be fully evaluated because a status
+   command fails, **When** the maintainer reaches the machine setup menu,
+   **Then** option 3 is recommended and the menu explains that the audit is
+   incomplete.
+5. **Given** no tool, safe dotfile, font, blocker, or auth-guidance action is
+   pending, **When** the maintainer reaches the machine setup menu, **Then** the
+   menu clearly states that setup is current and recommends exiting without
+   writing.
+
+---
+
+### User Story 2 - Follow The Fresh-Machine Flow (Priority: P1)
+
+A maintainer sets up a new machine and wants the menu to move from installing
+tools to applying configs in the same guided session, so they can complete setup
+without restarting the command or rereading documentation.
+
+**Why this priority**: The fresh-machine flow is the main quick-start path and
+the README describes a two-step sequence: install tools first, then return to
+apply safe dotfiles and fonts.
+
+**Independent Test**: Can be tested with a simulated fresh machine where tools
+are initially missing, then become present after the install action, and the
+menu is shown again with an updated recommendation. It can also be tested when
+tool installation is canceled or partial, and when a failed status audit falls
+back to option 3.
+
+**Acceptance Scenarios**:
+
+1. **Given** tools are missing, **When** the maintainer chooses the recommended
+   tool install action and confirms it, **Then** setup returns to an updated
+   machine summary and menu after the action completes.
+2. **Given** tool installation completed successfully, **When** the updated menu
+   is shown, **Then** option 2 is recommended if safe dotfile or font changes
+   remain.
+3. **Given** the maintainer declines the tool install confirmation, **When** no
+   tool changes are applied, **Then** setup returns to the menu with the same
+   recommendation and no files are written.
+4. **Given** the machine state cannot be fully evaluated or changes after a
+   menu action, **When** the menu is re-rendered, **Then** the refreshed
+   recommendation reflects the latest audited state instead of staying stale.
+
+---
+
+### User Story 3 - Keep Documentation And Menu Behavior Aligned (Priority: P2)
+
+A maintainer reads the README or getting-started guide before running setup and
+wants the actual menu to match the documented examples, so the documentation is
+a reliable guide rather than a separate idealized flow.
+
+**Why this priority**: The issue was discovered through a mismatch between the
+expected documented guidance and what the maintainer noticed in the interactive
+menu.
+
+**Independent Test**: Can be tested by checking that documentation examples,
+setup output examples, and automated menu-state checks use the same option
+labels, recommendation wording, and state transitions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the README describes a fresh-machine menu, **When** the setup menu
+   is shown for missing tools, **Then** the option label and recommendation text
+   match the documented intent.
+2. **Given** the getting-started guide describes option 2 as highlighted after
+   tools are installed, **When** setup returns after tool installation, **Then**
+   the updated menu reflects that documented state.
+3. **Given** a menu option label changes, **When** documentation and tests are
+   reviewed, **Then** stale examples are identified before the change is
+   accepted.
+
+### Edge Cases
+
+- The machine state cannot be fully evaluated because a status command fails.
+- The terminal does not display colors or styling.
+- Tool installation is canceled after the preview.
+- Tool installation succeeds for some tools but leaves at least one tool
+  missing or unverified.
+- Safe dotfile or font actions are pending while protected/manual files are also
+  present.
+- Only protected/manual files are pending.
+- Authentication guidance is available but no writable setup action is pending.
+- The machine is fully current and choosing apply would perform no useful work.
+- Blocking issues exist that would make apply stop before completing.
+- The menu is re-rendered after an action and the audited state changed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The machine setup menu MUST display exactly one recommended option
+  for every evaluated machine state.
+- **FR-002**: The recommendation MUST be visible in plain text and MUST NOT rely
+  only on color, cursor position, or terminal styling.
+- **FR-003**: The recommendation MUST include both a menu-option marker and a
+  short reason near the menu, so users understand why that option is next.
+- **FR-004**: When developer tools are missing or unverified after an install
+  attempt, the menu MUST recommend the tool install/update option.
+- **FR-005**: When developer tools are present and safe non-protected dotfile or
+  font actions are pending, the menu MUST recommend the safe apply option.
+- **FR-006**: When blocking setup issues are present, the menu MUST recommend
+  inspecting full details before applying changes.
+- **FR-007**: When no setup, tool, font, blocker, or auth-guidance action is
+  pending, the menu MUST recommend exiting without writing.
+- **FR-008**: When only manual authentication guidance is pending, the menu MUST
+  recommend viewing tool and sign-in guidance instead of applying changes.
+- **FR-009**: The machine setup summary and the menu recommendation MUST agree
+  about the next action; the summary MUST NOT describe only option 2 when a
+  different option is recommended.
+- **FR-010**: After the user completes or cancels the tool install/update
+  action, setup MUST return to a refreshed machine summary and menu rather than
+  ending the guided session.
+- **FR-011**: The menu option numbers MUST remain stable across states: option 1
+  for tool install/update, option 2 for safe apply, option 3 for full details,
+  option 4 for tool/sign-in guidance, and option 5 for exit.
+- **FR-012**: Choosing a non-recommended option MUST remain allowed; the
+  recommendation guides the default path but does not block deliberate user
+  choices.
+- **FR-013**: Safe apply behavior MUST continue to require explicit confirmation
+  and MUST preserve backup and protected-file behavior.
+- **FR-014**: The recommendation decision MUST be derived from the same audited
+  machine status that is shown to the user.
+- **FR-015**: Documentation MUST describe the same recommendation states,
+  option labels, and fresh-machine transition that users see in the setup menu.
+- **FR-016**: Automated validation MUST cover at least the missing-tools,
+  safe-changes-pending, blockers-present, auth-guidance-only, and fully-current
+  menu states.
+- **FR-017**: When required status data cannot be collected or the machine
+  state is incomplete, the menu MUST recommend option 3 and explain that full
+  details should be inspected before applying changes.
+
+### Key Entities
+
+- **Machine Setup State**: The evaluated condition of the user's machine,
+  including tool availability, safe writable changes, protected/manual items,
+  blockers, font actions, and authentication guidance.
+- **Recommended Option**: The single menu option that best matches the current
+  machine setup state, including its option number, label, and reason.
+- **Machine Setup Menu**: The stable five-option interactive menu shown by
+  `./setup` for machine setup.
+- **Guided Setup Session**: The sequence from status audit to menu choice, action
+  preview, confirmation, action result, and any refreshed follow-up menu.
+- **Documentation Example**: README or getting-started guidance that describes
+  the expected menu labels, recommendation marker, and state transition.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In automated checks for missing tools, 100% of setup menu outputs
+  mark option 1 as recommended and do not mark any other option as recommended.
+- **SC-002**: In automated checks for pending safe dotfile or font changes with
+  tools present, 100% of setup menu outputs mark option 2 as recommended and do
+  not mark any other option as recommended.
+- **SC-003**: In automated checks for blocking issues, 100% of setup menu
+  outputs recommend inspecting full details before apply.
+- **SC-004**: In automated checks for fully current machines, 100% of setup menu
+  outputs state that no write action is needed and recommend exiting without
+  writing.
+- **SC-005**: In automated checks for auth-guidance-only machines, 100% of setup
+  menu outputs recommend viewing tool and sign-in guidance.
+- **SC-006**: In the fresh-machine flow, after a confirmed tool install action,
+  setup shows a refreshed machine summary and menu in the same session in 100%
+  of successful test runs.
+- **SC-007**: Every recommendation is visible in plain captured output without
+  relying on color or styling.
+- **SC-008**: README and getting-started examples match the implemented menu
+  option labels and recommendation states in all automated documentation checks.
+- **SC-009**: In automated checks for incomplete or failed status audits, 100%
+  of setup menu outputs recommend option 3 and include a reason that the audit
+  is incomplete.
+
+## Assumptions
+
+- The scope is the machine setup flow shown by running `./setup` with no
+  arguments; project-folder menus are out of scope for this feature.
+- The five existing menu option numbers remain stable to preserve documented
+  muscle memory.
+- A recommendation may guide users to inspect details or exit when applying
+  changes would be unsafe or unnecessary.
+- Existing protected-file, backup, explicit-confirmation, and no-secret
+  guarantees remain unchanged.
+- Plain-text visibility is required even if terminal color is later added.

--- a/specs/002-setup-menu-recommendation/tasks.md
+++ b/specs/002-setup-menu-recommendation/tasks.md
@@ -1,0 +1,230 @@
+# Tasks: Setup Menu Recommendation Guidance
+
+**Input**: Design documents from `/specs/002-setup-menu-recommendation/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/setup-menu.md, quickstart.md
+
+**Tests**: Tests are required for this feature because the specification requires automated validation of recommendation states and the constitution requires validation for setup behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Shell wrapper: `setup`
+- Python recommendation logic and summary rendering: `dotfiles_tools/machine_summary.py`
+- Existing setup/action planning support: `dotfiles_tools/bootstrap.py`, `dotfiles_tools/tool_installer.py`, `dotfiles_tools/baseline.py`
+- Tests: `tests/test_machine_summary.py`, `tests/test_setup_script.py`, `tests/test_docs.py`
+- User docs: `README.md`, `docs/getting-started.md`
+- Feature docs: `specs/002-setup-menu-recommendation/`
+
+## Dotfiles Constitution Gates
+
+- Preserve `.template` source behavior and AGENTS.md symlink conventions.
+- Do not edit protected files: `git/config`, `fish/fish_plugins`, `.gitignore`, `agents/CLAUDE.md.template`, or `agents/GEMINI.md.template`.
+- Preserve explicit write approval, backup behavior, and protected/manual file handling.
+- Use `uv` for Python validation commands.
+- Do not add lock files or runtime dependencies.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm requirement quality and prepare the existing test surfaces for story work.
+
+- [ ] T001 Review `specs/002-setup-menu-recommendation/checklists/menu-recommendation.md` and update `specs/002-setup-menu-recommendation/spec.md` or `specs/002-setup-menu-recommendation/contracts/setup-menu.md` for any failed requirements-quality checklist item before coding. This is a governance gate, not a user-story implementation task.
+- [ ] T002 [P] Add shared assertion helpers for recommended option markers and reason text to `tests/test_machine_summary.py`.
+- [ ] T003 [P] Add shared setup-output assertion helpers for exactly one `[recommended]` marker to `tests/test_setup_script.py`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish one recommendation model used by summary rendering and the shell menu.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Define a recommendation decision representation with option number, label, reason, and state category in `dotfiles_tools/machine_summary.py`.
+- [ ] T005 Implement machine-state extraction helpers for blockers, missing/unverified tools, status-audit failures, safe file actions, font actions, protected/manual items, auth guidance, and current state in `dotfiles_tools/machine_summary.py`.
+- [ ] T006 Implement recommendation priority ordering from `specs/002-setup-menu-recommendation/contracts/setup-menu.md` in `dotfiles_tools/machine_summary.py`.
+- [ ] T007 Add a machine summary CLI mode that emits the recommended option and reason for shell consumption in `dotfiles_tools/machine_summary.py`.
+
+**Checkpoint**: Recommendation data can be derived without changing the existing interactive flow.
+
+---
+
+## Phase 3: User Story 1 - See The Recommended Next Step (Priority: P1) MVP
+
+**Goal**: The machine setup menu clearly identifies the single recommended next step for the current audited machine state.
+
+**Independent Test**: Run focused unit tests for recommendation states and setup-output tests proving exactly one visible recommendation appears with a matching reason.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T008 [P] [US1] Add unit tests for missing-tools, safe-changes, blockers-present, auth-guidance-only, manual-only, fully-current, and incomplete-status-data recommendation decisions in `tests/test_machine_summary.py`.
+- [ ] T009 [P] [US1] Add summary rendering tests for the plain-text `Recommended next step:` line and exact `[recommended]` marker behavior in `tests/test_machine_summary.py`.
+- [ ] T010 [P] [US1] Add setup wrapper output tests for option 1, option 2, option 3, option 4, option 5, and incomplete-status-data recommendation markers in `tests/test_setup_script.py`.
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Update `render_reports` so the machine summary includes the same recommended option and reason used by the menu in `dotfiles_tools/machine_summary.py`.
+- [ ] T012 [US1] Update `machine_menu_loop` to accept a recommended option and reason, print `Recommended next step:`, and mark only that option with `[recommended]` in `setup`.
+- [ ] T013 [US1] Replace `run_machine_menu_mode` and `run_machine_missing_tool_count` usage with the new recommendation output path in `setup`.
+- [ ] T014 [US1] Preserve existing non-recommended option behavior for choices 1 through 5 while using the new recommendation marker in `setup`.
+
+**Checkpoint**: User Story 1 is complete when the menu always shows exactly one plain-text recommendation that agrees with the summary.
+
+---
+
+## Phase 4: User Story 2 - Follow The Fresh-Machine Flow (Priority: P1)
+
+**Goal**: A fresh-machine session moves from tool install/update guidance to an updated apply recommendation without requiring the user to rerun `./setup`.
+
+**Independent Test**: Run setup wrapper tests that simulate missing tools, declined tool install, and completed tool install, then verify the summary/menu refreshes in the same session.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T015 [P] [US2] Add a setup wrapper test proving declined option 1 tool install returns to a refreshed menu without writes in `tests/test_setup_script.py`.
+- [ ] T016 [P] [US2] Add a setup wrapper test proving completed option 1 tool install returns to a refreshed summary and updated recommendation in `tests/test_setup_script.py`.
+- [ ] T017 [P] [US2] Add a setup wrapper test for partial or unverified tool installation keeping option 1 recommended after refresh in `tests/test_setup_script.py`.
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Refactor `cmd_machine_setup` so each interactive iteration refreshes the machine summary and recommendation before rendering the menu in `setup`.
+- [ ] T019 [US2] Change option 1 handling so `run_machine_install_tools_with_confirm` returns to the machine menu after completion or cancellation instead of exiting the guided session in `setup`.
+- [ ] T020 [US2] Ensure option 3 full details and option 4 tool/sign-in guidance return to the refreshed menu while option 5 exits without writes in `setup`.
+
+**Checkpoint**: User Story 2 is complete when the documented fresh-machine flow works in one `./setup` session.
+
+---
+
+## Phase 5: User Story 3 - Keep Documentation And Menu Behavior Aligned (Priority: P2)
+
+**Goal**: README and getting-started examples match the implemented menu labels, recommendation wording, and fresh-machine transition.
+
+**Independent Test**: Run documentation checks proving docs mention the stable option labels, `Recommended next step:`, and the option 1 to option 2 transition.
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T021 [P] [US3] Add README documentation checks for stable option labels, `Recommended next step:`, and fresh-machine option 1 then option 2 flow in `tests/test_docs.py`.
+- [ ] T022 [P] [US3] Add getting-started documentation checks for stable option labels, `Recommended next step:`, and refreshed-menu behavior in `tests/test_docs.py`.
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Update fresh-machine and configured-machine menu examples to include `Recommended next step:` and exact recommendation markers in `README.md`.
+- [ ] T024 [US3] Update first-time setup and ongoing maintenance menu examples to include `Recommended next step:` and refreshed-menu behavior in `docs/getting-started.md`.
+- [ ] T025 [US3] Align `specs/002-setup-menu-recommendation/quickstart.md` with the final menu wording if implementation changes the planned recommendation text.
+
+**Checkpoint**: User Story 3 is complete when docs and automated documentation checks match the implemented menu contract.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the complete feature and preserve repo safety rules.
+
+- [ ] T026 Run supplemental focused validation command `uv run python -m unittest tests.test_machine_summary tests.test_setup_script tests.test_docs` and fix failures in `dotfiles_tools/machine_summary.py`, `setup`, `tests/test_machine_summary.py`, `tests/test_setup_script.py`, or `tests/test_docs.py`.
+- [ ] T027 Run full validation command `uv run python -m unittest discover -s tests` and fix any regressions in `dotfiles_tools/`, `setup`, or `tests/`.
+- [ ] T028 Run quickstart review from `specs/002-setup-menu-recommendation/quickstart.md` and update `README.md`, `docs/getting-started.md`, or `specs/002-setup-menu-recommendation/quickstart.md` if observed wording differs.
+- [ ] T029 Review `git diff -- setup dotfiles_tools/machine_summary.py tests/test_machine_summary.py tests/test_setup_script.py tests/test_docs.py README.md docs/getting-started.md specs/002-setup-menu-recommendation` for protected-file edits, secrets, lock files, and unintended scope.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; complete before implementation work.
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Phase 2; MVP and prerequisite for user-visible recommendation behavior.
+- **User Story 2 (Phase 4)**: Depends on Phase 3 because it reuses the new recommendation rendering.
+- **User Story 3 (Phase 5)**: Can begin after Phase 3 output wording stabilizes; docs should finish after Phase 4 refresh behavior is implemented.
+- **Polish (Phase 6)**: Depends on all selected user stories.
+
+### User Story Dependencies
+
+- **US1 - See The Recommended Next Step (P1)**: Starts after foundational recommendation model; no dependency on US2 or US3.
+- **US2 - Follow The Fresh-Machine Flow (P1)**: Depends on US1 recommendation rendering so refreshed menus use the same contract.
+- **US3 - Keep Documentation And Menu Behavior Aligned (P2)**: Depends on final wording from US1 and final refreshed-menu behavior from US2.
+
+### Within Each User Story
+
+- Write the test tasks first and confirm they fail for missing behavior.
+- Implement the smallest story-specific code path.
+- Stop at each checkpoint and run the independent test command for that story.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel because they touch different test files.
+- T008, T009, and T010 can run in parallel after Phase 2 because they cover separate test assertions.
+- T015, T016, and T017 can run in parallel because they add separate wrapper scenarios.
+- T021 and T022 can run in parallel because they add separate documentation checks.
+- US3 documentation edits T023 and T024 can run in parallel after wording is stable.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T008 [P] [US1] Add unit tests for missing-tools, safe-changes, blockers-present, auth-guidance-only, manual-only, and fully-current recommendation decisions in tests/test_machine_summary.py"
+Task: "T009 [P] [US1] Add summary rendering tests for the plain-text Recommended next step line and exact recommended marker behavior in tests/test_machine_summary.py"
+Task: "T010 [P] [US1] Add setup wrapper output tests for option 1, option 2, option 3, option 4, and option 5 recommendation markers in tests/test_setup_script.py"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T015 [P] [US2] Add a setup wrapper test proving declined option 1 tool install returns to a refreshed menu without writes in tests/test_setup_script.py"
+Task: "T016 [P] [US2] Add a setup wrapper test proving completed option 1 tool install returns to a refreshed summary and updated recommendation in tests/test_setup_script.py"
+Task: "T017 [P] [US2] Add a setup wrapper test for partial or unverified tool installation keeping option 1 recommended after refresh in tests/test_setup_script.py"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T021 [P] [US3] Add README documentation checks for stable option labels, Recommended next step, and fresh-machine option 1 then option 2 flow in tests/test_docs.py"
+Task: "T022 [P] [US3] Add getting-started documentation checks for stable option labels, Recommended next step, and refreshed-menu behavior in tests/test_docs.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 tests and implementation.
+3. Run focused tests for `tests.test_machine_summary` and the relevant setup-output tests.
+4. Validate that every menu render has one visible recommendation that agrees with the summary.
+
+### Incremental Delivery
+
+1. Add the shared recommendation decision model.
+2. Deliver US1 so the menu always highlights the right next step.
+3. Deliver US2 so the fresh-machine session refreshes after tool install/update.
+4. Deliver US3 so docs and documentation checks match the implemented behavior.
+5. Run focused and full validation before merging.
+
+### Parallel Team Strategy
+
+With multiple implementers:
+
+1. One person owns `dotfiles_tools/machine_summary.py` recommendation logic.
+2. One person owns `setup` shell refresh behavior after the foundational model is available.
+3. One person owns documentation and `tests/test_docs.py` after wording stabilizes.
+
+## Notes
+
+- `[P]` tasks target separate files or independent test scenarios.
+- Story labels map tasks to the user stories in `spec.md`.
+- Do not edit protected files.
+- Do not add runtime dependencies or lock files.
+- Keep all Python validation commands under `uv`.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,10 +2,54 @@ from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
 class DocsTests(DotfilesTestCase):
-    def test_readme_includes_canonical_commands_and_coverage(self):
+    def test_readme_is_short_and_points_into_docs(self):
         readme = (REPO_ROOT / "README.md").read_text()
-        for command in ["doctor", "plan", "apply", "init-project"]:
-            self.assertIn(f"dotfiles_tools {command}", readme)
-        self.assertIn("uv run python -m unittest discover -s tests", readme)
-        self.assertIn("coverage xml", readme)
-        self.assertIn("docs/codacy-coverage-rollout.md", readme)
+        self.assertIn("docs/README.md", readme)
+        self.assertIn("docs/getting-started.md", readme)
+        self.assertIn("docs/setup-reference.md", readme)
+        self.assertIn("docs/validation.md", readme)
+        self.assertIn("docs/architecture/setup-flow.md", readme)
+        self.assertIn("docs/architecture/scaffold-flow.md", readme)
+        self.assertIn("CHANGELOG.md", readme)
+        self.assertIn("flowchart", readme)
+        self.assertNotIn("dotfiles_tools doctor", readme)
+        self.assertNotIn("coverage==7.5.4", readme)
+
+    def test_docs_hub_points_to_the_split_pages(self):
+        docs_readme = (REPO_ROOT / "docs/README.md").read_text()
+        self.assertIn("Getting Started", docs_readme)
+        self.assertIn("Setup Reference", docs_readme)
+        self.assertIn("Repo Layout", docs_readme)
+        self.assertIn("Protected Files", docs_readme)
+        self.assertIn("Validation", docs_readme)
+        self.assertIn("Troubleshooting", docs_readme)
+        self.assertIn("architecture/setup-flow.md", docs_readme)
+        self.assertIn("architecture/scaffold-flow.md", docs_readme)
+
+    def test_coverage_config_targets_production_python_only(self):
+        coveragerc = (REPO_ROOT / ".coveragerc").read_text()
+        self.assertIn("source =", coveragerc)
+        self.assertIn("dotfiles_tools", coveragerc)
+        self.assertIn("tests/*", coveragerc)
+        self.assertIn("docs/*", coveragerc)
+
+    def test_setup_reference_contains_wrapper_and_direct_cli_commands(self):
+        setup_ref = (REPO_ROOT / "docs/setup-reference.md").read_text()
+        self.assertIn("./setup", setup_ref)
+        self.assertIn("dotfiles_tools doctor", setup_ref)
+        self.assertIn("bootstrap-apply", setup_ref)
+        self.assertIn("dotfiles-setup verify", setup_ref)
+
+    def test_validation_doc_mentions_pinned_coverage(self):
+        validation = (REPO_ROOT / "docs/validation.md").read_text()
+        self.assertIn("coverage==7.5.4", validation)
+        self.assertIn(".coveragerc", validation)
+        self.assertIn("Codacy Static Code Analysis", validation)
+
+    def test_architecture_docs_cover_setup_and_scaffold_flows(self):
+        setup_flow = (REPO_ROOT / "docs/architecture/setup-flow.md").read_text()
+        scaffold_flow = (REPO_ROOT / "docs/architecture/scaffold-flow.md").read_text()
+        self.assertIn("recommended option", setup_flow)
+        self.assertIn("5-option menu", setup_flow)
+        self.assertIn("project agent docs", scaffold_flow)
+        self.assertIn("project-vars.json", scaffold_flow)

--- a/tests/test_machine_summary.py
+++ b/tests/test_machine_summary.py
@@ -4,17 +4,30 @@ from pathlib import Path
 
 from unittest import mock
 
-from dotfiles_tools.machine_summary import (
-    render_menu_mode,
-    render_missing_tool_count,
-    render_reports,
-)
+from dotfiles_tools.machine_summary import render_menu_mode, render_missing_tool_count, render_reports
 from dotfiles_tools.reports import Report
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
-def doctor(home: Path, *, errors: list[dict[str, str] | str] | None = None) -> Report:
-    return Report("doctor", "warning", str(REPO_ROOT), home=str(home), profile="machine", errors=errors or [])
+def doctor(
+    home: Path,
+    *,
+    errors: list[dict[str, str] | str] | None = None,
+    tool_checks: list[dict[str, str]] | None = None,
+    auth_guidance: list[dict[str, str]] | None = None,
+) -> Report:
+    return Report(
+        "doctor",
+        "warning",
+        str(REPO_ROOT),
+        home=str(home),
+        profile="machine",
+        errors=errors or [],
+        extra={
+            "tool_checks": tool_checks or [],
+            "auth_guidance": auth_guidance or [],
+        },
+    )
 
 
 def plan(
@@ -119,7 +132,7 @@ class MachineSummaryTests(DotfilesTestCase):
         text = self.render(plan_report)
 
         self.assertIn("Machine setup summary", text)
-        self.assertIn("Option 2 will:", text)
+        self.assertIn("Recommended next step: 2. Apply safe non-protected dotfiles - Safe non-protected setup changes are pending.", text)
         self.assertIn("Update existing files with backups:", text)
         self.assertIn("~/.claude/settings.json", text)
         self.assertIn("Create missing files:", text)
@@ -141,6 +154,58 @@ class MachineSummaryTests(DotfilesTestCase):
         self.assertNotIn("terminal face:", text)
         self.assertNotIn("terminal impact:", text)
 
+    def test_incomplete_audit_recommends_details(self) -> None:
+        home = self.make_home()
+        plan_report = plan(home, errors=[{"message": "manifest parse failed"}])
+
+        text = self.render(plan_report, doctor_report=doctor(home))
+
+        self.assertIn("Recommended next step: 3. Show full technical details - The audit is incomplete.", text)
+        self.assertIn("The audit is incomplete; inspect the full technical details.", text)
+        self.assertIn("Plan errors:", text)
+        self.assertIn("manifest parse failed", text)
+
+    def test_missing_tools_recommend_install_first(self) -> None:
+        home = self.make_home()
+        plan_report = plan(home)
+        doctor_report = doctor(
+            home,
+            tool_checks=[
+                {"command": "gh", "state": "missing", "install_hint": "install gh"},
+                {"command": "uv", "state": "available", "install_hint": ""},
+            ],
+        )
+
+        text = self.render(plan_report, doctor_report=doctor_report)
+
+        self.assertIn("Recommended next step: 1. Install / update developer tools - Developer tools should be installed or updated first.", text)
+        self.assertIn("1 developer tools are missing or unverified.", text)
+        self.assertIn("gh: install gh", text)
+
+    def test_auth_guidance_recommends_sign_in_help(self) -> None:
+        home = self.make_home()
+        plan_report = plan(home)
+        doctor_report = doctor(
+            home,
+            auth_guidance=[
+                {"command": "gh auth status", "state": "available", "guidance": "gh auth status"},
+            ],
+        )
+
+        text = self.render(plan_report, doctor_report=doctor_report)
+
+        self.assertIn("Recommended next step: 4. Show tool and sign-in guidance - Sign-in guidance is the useful next step.", text)
+        self.assertIn("Tool and sign-in guidance: gh auth status.", text)
+
+    def test_current_setup_recommends_exit(self) -> None:
+        home = self.make_home()
+        plan_report = plan(home)
+
+        text = self.render(plan_report)
+
+        self.assertIn("Recommended next step: 5. Exit without writing - Setup is current and no write action is needed.", text)
+        self.assertIn("Setup is current and no write action is needed.", text)
+
     def test_all_fonts_ok_collapses_to_already_ok(self) -> None:
         home = self.make_home()
         fonts = [nerd_font("installed"), apt_font("installed")]
@@ -148,7 +213,7 @@ class MachineSummaryTests(DotfilesTestCase):
 
         text = self.render(plan_report)
 
-        self.assertIn("Run no font install/update actions.", text)
+        self.assertIn("Recommended next step: 5. Exit without writing - Setup is current and no write action is needed.", text)
         self.assertIn("Nerd Fonts:", text)
         self.assertIn("Apt fallback fonts:", text)
         self.assertIn("none to install/update", text)
@@ -208,8 +273,10 @@ class MachineSummaryTests(DotfilesTestCase):
 
         text = self.render(plan_report, doctor_report=doctor(home, errors=[{"message": "doctor failed"}]))
 
-        self.assertIn("Stop on 3 blocking issues; fix before applying.", text)
-        self.assertIn("Skip 1 manual/unsupported font item; see Fonts below.", text)
+        self.assertIn("Recommended next step: 3. Show full technical details - The audit is incomplete.", text)
+        self.assertIn("The audit is incomplete; inspect the full technical details.", text)
+        self.assertIn("Manual/skipped:", text)
+        self.assertIn("JetBrainsMono Nerd Font: manual check needed", text)
         self.assertIn("Needs attention before apply:", text)
         self.assertIn("~/.claude/settings.json: target is a directory", text)
         self.assertIn("Doctor errors:", text)

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -47,6 +47,7 @@ class SetupScriptTests(DotfilesTestCase):
         "mktemp",
         "grep",
         "sed",
+        "head",
         "find",
         "mkdir",
         "cp",
@@ -69,7 +70,7 @@ class SetupScriptTests(DotfilesTestCase):
             (bin_dir / name).symlink_to(target)
         return bin_dir
 
-    def env_for(self, bin_dir: Path, home: Path) -> dict[str, str]:
+    def env_for(self, bin_dir: Path, home: Path, *, machine_summary_output: str | None = None) -> dict[str, str]:
         env = os.environ.copy()
         env["PATH"] = str(bin_dir)
         env["HOME"] = str(home)
@@ -78,6 +79,8 @@ class SetupScriptTests(DotfilesTestCase):
         # so option numbers stay stable. Tests that need the fresh-box flow
         # explicitly override this.
         env["DOTFILES_TOOL_PLATFORM"] = "darwin"
+        if machine_summary_output is not None:
+            env["FAKE_MACHINE_SUMMARY_OUTPUT"] = machine_summary_output
         return env
 
     def write_executable(self, path: Path, text: str) -> None:
@@ -107,12 +110,28 @@ if [[ "${{1:-}}" == "self" && "${{2:-}}" == "update" ]]; then
 fi
 if [[ "${{1:-}}" == "run" ]]; then
   shift
+  if [[ -n "${{FAKE_MACHINE_SUMMARY_OUTPUT:-}}" && "${{1:-}}" == "python" && "${{2:-}}" == "-m" && "${{3:-}}" == "dotfiles_tools.machine_summary" ]]; then
+    printf '%s' "$FAKE_MACHINE_SUMMARY_OUTPUT"
+    exit 0
+  fi
   exec "$@"
 fi
 echo "fake uv unsupported: $*" >&2
 exit 64
 """,
         )
+
+    def machine_summary_output(self, option_number: int, label: str, reason: str, *lines: str) -> str:
+        output_lines = [
+            "Machine setup summary",
+            "Repo: /tmp/fake-repo",
+            "Home: /tmp/fake-home",
+            "Profile: machine",
+            "",
+            f"Recommended next step: {option_number}. {label} - {reason}",
+            *lines,
+        ]
+        return "\n".join(output_lines) + "\n"
 
     def write_uv_installer(self, installer_path: Path, *, version: str) -> None:
         installer_path.write_text(
@@ -158,15 +177,13 @@ cat "{installer_path}"
         self.assertIn("uv found at", result.stdout)
         self.assertIn("uv self update completed.", result.stdout)
         self.assertIn("Machine setup summary", result.stdout)
-        self.assertIn("Option 2 will:", result.stdout)
+        self.assertIn("Recommended next step: 1. Install / update developer tools - Developer tools should be installed or updated first.", result.stdout)
         self.assertIn("Fonts:", result.stdout)
         self.assertIn("Create missing files:", result.stdout)
         self.assertIn("1. Install / update developer tools", result.stdout)
         self.assertIn("3. Show full technical details.", result.stdout)
-        # tools_present: option 2 (apply) is recommended, not option 1 (install tools)
-        self.assertIn("2. Apply safe non-protected dotfiles", result.stdout)
-        self.assertRegex(result.stdout, r"2\..*\[recommended\]")
-        self.assertNotRegex(result.stdout, r"1\..*\[recommended\]")
+        self.assertIn("1. Install / update developer tools (preview, then apply). [recommended]", result.stdout)
+        self.assertNotRegex(result.stdout, r"2\..*\[recommended\]")
         self.assertNotIn("entries:", result.stdout)
         self.assertNotIn("operations:", result.stdout)
         self.assertIn("No changes applied.", result.stdout)
@@ -241,11 +258,18 @@ cat "{installer_path}"
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_uv(bin_dir, home / "uv.log")
+        summary = self.machine_summary_output(
+            4,
+            "Show tool and sign-in guidance",
+            "Sign-in guidance is the useful next step.",
+            "  - Tool and sign-in guidance: gh auth status.",
+        )
 
-        result = run_setup(env=self.env_for(bin_dir, home), input_text="4\n5\n")
+        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="4\n5\n")
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("Show tool and sign-in guidance.", result.stdout)
+        self.assertIn("Recommended next step: 4. Show tool and sign-in guidance - Sign-in guidance is the useful next step.", result.stdout)
+        self.assertIn("4. Show tool and sign-in guidance. [recommended]", result.stdout)
         self.assertIn("Tool status:", result.stdout)
         self.assertIn("Missing tools:", result.stdout)
         self.assertIn("Sign-in checks unavailable until the tool is installed:", result.stdout)
@@ -255,16 +279,44 @@ cat "{installer_path}"
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_uv(bin_dir, home / "uv.log")
+        summary = self.machine_summary_output(
+            3,
+            "Show full technical details",
+            "The audit is incomplete.",
+            "  - The audit is incomplete; inspect the full technical details.",
+        )
 
-        result = run_setup(env=self.env_for(bin_dir, home), input_text="3\n5\n")
+        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="3\n5\n")
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Recommended next step: 3. Show full technical details - The audit is incomplete.", result.stdout)
+        self.assertIn("3. Show full technical details. [recommended]", result.stdout)
         self.assertIn("Full machine doctor:", result.stdout)
         self.assertIn("doctor:", result.stdout)
         self.assertIn("Full machine plan:", result.stdout)
         self.assertIn("font actions:", result.stdout)
         self.assertIn("operations:", result.stdout)
         self.assertIn("Show full technical details.", result.stdout)
+
+    def test_no_arg_install_choice_refreshes_summary_after_cancel(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+        summary = self.machine_summary_output(
+            1,
+            "Install / update developer tools",
+            "Developer tools should be installed or updated first.",
+            "  - 2 developer tools are missing or unverified.",
+            "    - gh: install gh",
+        )
+
+        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="1\nn\n5\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertGreaterEqual(result.stdout.count("Machine setup summary"), 2)
+        self.assertGreaterEqual(result.stdout.count("Recommended next step: 1. Install / update developer tools - Developer tools should be installed or updated first."), 2)
+        self.assertGreaterEqual(result.stdout.count("1. Install / update developer tools (preview, then apply). [recommended]"), 2)
+        self.assertIn("No tool changes applied.", result.stdout)
 
     def test_help_subcommand(self) -> None:
         result = run_setup("help")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,6 +4,9 @@ from tests.helpers import DotfilesTestCase, REPO_ROOT
 class WorkflowTests(DotfilesTestCase):
     def test_workflow_generates_coverage_and_gates_codacy_upload(self):
         workflow = (REPO_ROOT / ".github/workflows/dotfiles-validation.yml").read_text()
+        self.assertIn("concurrency:", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("coverage==7.5.4", workflow)
         self.assertIn("coverage run -m unittest discover -s tests", workflow)
         self.assertIn("coverage xml", workflow)
         self.assertIn("coverage.xml", workflow)


### PR DESCRIPTION
Splits the long root README into a short landing page plus topic-based docs under `docs/`, and tightens the coverage workflow by scoping coverage to production Python code and canceling stale runs.

Highlights:
- root README now stays short and links to topic docs
- docs are split into getting-started, setup reference, repo layout, protected files, validation, troubleshooting, and architecture pages
- coverage is scoped to `dotfiles_tools/` via `.coveragerc`
- workflow pins coverage, adds concurrency cancellation, and keeps Codacy upload on push only

Validation:
- uv run python -m unittest tests.test_docs tests.test_workflow
- uv run python -m unittest discover -s tests