### PR TITLE
refactor(ci): thin Codacy safety-net workflow

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -1,73 +1,76 @@
-name: Dotfiles Validation
+name: Codacy Safety Net
 
 on:
   push:
+    branches:
+      - main
+      - "release/**"
   pull_request:
 
 concurrency:
-  group: dotfiles-validation-${{ github.ref }}
+  group: codacy-safety-net-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  coverage:
+  codacy-safety-net:
     runs-on: ubuntu-latest
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+      - name: Check if Codacy already has data for this commit
+        id: codacy_status
+        run: |
+          if [ -z "$CODACY_PROJECT_TOKEN" ]; then
+            echo "status=missing" >> "$GITHUB_OUTPUT"
+            echo "No CODACY_PROJECT_TOKEN configured; will run analysis."
+            exit 0
+          fi
+          STATUS=$(curl -s -H "api-token: $CODACY_PROJECT_TOKEN" \
+            "https://api.codacy.com/2.0/commit/$SHA/quality-status" \
+            | grep -oE '"state"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -1 \
+            | sed -E 's/.*"state"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
+            || echo "missing")
+          STATUS="${STATUS:-missing}"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "Codacy status for $SHA: $STATUS"
 
-      - name: Run unit tests with coverage
-        run: uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
-
-      - name: Generate coverage XML
-        run: uv run --with coverage==7.5.4 coverage xml
-
-      - name: Upload coverage to Codacy
-        if: ${{ github.event_name == 'push' && env.CODACY_PROJECT_TOKEN != '' }}
-        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
-
-  codacy-static-analysis:
-    runs-on: ubuntu-latest
-    env:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      CODACY_COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Skip if Codacy already analyzed this commit
+        if: steps.codacy_status.outputs.status == 'analyzed'
+        run: echo "Codacy already has data for $SHA. Local pre-push hook ran successfully. Nothing to do."
 
       - name: Set up uv
+        if: steps.codacy_status.outputs.status != 'analyzed'
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
 
-      - name: Set up Codacy CLI
+      - name: Install Codacy CLI
+        if: steps.codacy_status.outputs.status != 'analyzed'
         run: |
           set -euo pipefail
+          # Run the upstream installer in "download" mode so it just fetches
+          # the binary into $HOME/.cache/codacy/codacy-cli-v2/<version>/ and
+          # exits, rather than executing the CLI with no arguments.
           bash <(curl -Ls https://raw.githubusercontent.com/codacy/codacy-cli-v2/main/codacy-cli.sh) download
-          cli_path=$(find "$HOME/.cache/codacy/codacy-cli-v2" -name codacy-cli-v2 -type f -executable | head -1)
-          if [[ -z "$cli_path" ]]; then
+          # The binary is named codacy-cli-v2; expose it on PATH under both
+          # that name and the historical "codacy-cli" alias for any caller
+          # that still uses the old name. Each step runs in a fresh shell, so
+          # we publish the install dir via $GITHUB_PATH instead of `export`.
+          CLI_PATH=$(find "$HOME/.cache/codacy/codacy-cli-v2" -name 'codacy-cli-v2' -type f -executable 2>/dev/null | head -1)
+          if [ -z "$CLI_PATH" ]; then
             echo "codacy-cli-v2 binary not found after install" >&2
             exit 1
           fi
-          mkdir -p "$HOME/.local/bin"
-          ln -sf "$cli_path" "$HOME/.local/bin/codacy-cli-v2"
-          ln -sf "$cli_path" "$HOME/.local/bin/codacy-cli"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli-v2"
+          ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli"
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+          echo "Installed codacy-cli-v2 at $CLI_PATH; symlinked into $INSTALL_DIR"
 
-      - name: Initialize Codacy config
-        run: codacy-cli init
-
-      - name: Install Codacy tools
-        run: codacy-cli install
-
-      - name: Run Codacy pylint analysis
-        run: codacy-cli analyze --tool pylint --format sarif -o pylint.sarif
-
-      - name: Upload pylint SARIF to Codacy
-        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
-        run: codacy-cli upload -s pylint.sarif -c "${CODACY_COMMIT_SHA}" -t "${CODACY_PROJECT_TOKEN}"
+      - name: Run quality pipeline (fallback path)
+        if: steps.codacy_status.outputs.status != 'analyzed'
+        run: bash scripts/quality-pipeline.sh

--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -74,3 +74,10 @@ jobs:
       - name: Run quality pipeline (fallback path)
         if: steps.codacy_status.outputs.status != 'analyzed'
         run: bash scripts/quality-pipeline.sh
+
+      - name: Upload coverage to Codacy
+        if: steps.codacy_status.outputs.status != 'analyzed' && env.CODACY_PROJECT_TOKEN != ''
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,19 +2,19 @@ from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
 class WorkflowTests(DotfilesTestCase):
-    def test_workflow_generates_coverage_and_gates_codacy_upload(self):
+    def test_workflow_is_thin_codacy_safety_net(self):
         workflow = (REPO_ROOT / ".github/workflows/dotfiles-validation.yml").read_text()
-        self.assertIn("coverage:", workflow)
-        self.assertIn("codacy-static-analysis:", workflow)
-        self.assertIn("codacy-cli-v2/main/codacy-cli.sh) download", workflow)
-        self.assertIn('ln -sf "$cli_path" "$HOME/.local/bin/codacy-cli"', workflow)
-        self.assertIn("codacy-cli analyze --tool pylint --format sarif -o pylint.sarif", workflow)
-        self.assertIn("codacy-cli upload -s pylint.sarif", workflow)
-        self.assertIn("CODACY_COMMIT_SHA", workflow)
-        self.assertIn("coverage run -m unittest discover -s tests", workflow)
-        self.assertIn("coverage xml", workflow)
-        self.assertIn("coverage.xml", workflow)
+        self.assertIn("name: Codacy Safety Net", workflow)
         self.assertIn("CODACY_PROJECT_TOKEN", workflow)
-        self.assertIn("github.event_name == 'push'", workflow)
-        self.assertIn("project-token:", workflow)
-        self.assertIn("codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699", workflow)
+        self.assertIn("concurrency:", workflow)
+        self.assertIn("codacy-safety-net-${{ github.ref }}", workflow)
+        self.assertIn("quality-status", workflow)
+        self.assertIn("steps.codacy_status.outputs.status == 'analyzed'", workflow)
+        self.assertIn("steps.codacy_status.outputs.status != 'analyzed'", workflow)
+        self.assertIn("scripts/quality-pipeline.sh", workflow)
+        self.assertIn("codacy-cli-v2/main/codacy-cli.sh) download", workflow)
+        self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli-v2"', workflow)
+        self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli"', workflow)
+        # Pinned action SHAs must be preserved.
+        self.assertIn("actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", workflow)
+        self.assertIn("astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86", workflow)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -12,6 +12,8 @@ class WorkflowTests(DotfilesTestCase):
         self.assertIn("steps.codacy_status.outputs.status == 'analyzed'", workflow)
         self.assertIn("steps.codacy_status.outputs.status != 'analyzed'", workflow)
         self.assertIn("scripts/quality-pipeline.sh", workflow)
+        self.assertIn("coverage.xml", workflow)
+        self.assertIn("codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699", workflow)
         self.assertIn("codacy-cli-v2/main/codacy-cli.sh) download", workflow)
         self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli-v2"', workflow)
         self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli"', workflow)


### PR DESCRIPTION
## Summary

Replaces the always-run `coverage` and `codacy-static-analysis` jobs in `.github/workflows/dotfiles-validation.yml` with a single thin `codacy-safety-net` job that:

- **Fast-paths in <20s** when Codacy already has data for the head commit. The local pre-push hook (#168) and `setup quality` subcommand (#169) call `scripts/quality-pipeline.sh` (#167) which uploads coverage + pylint analysis to Codacy directly, so most pushes will hit this fast path.
- **Falls through to the full quality pipeline** (`bash scripts/quality-pipeline.sh`) only when the local hook was bypassed (no `quality-status: analyzed` for the SHA), or when `CODACY_PROJECT_TOKEN` isn't configured for the workflow.

Pinned action SHAs (`actions/checkout`, `astral-sh/setup-uv`) are preserved verbatim from the previous workflow. The new workflow keeps the same `concurrency` cancel-in-progress group pattern under a renamed key.

## Local-side counterparts

- #167 — `scripts/quality-pipeline.sh`
- #168 — pre-push hook wiring
- #169 — `setup quality` subcommand

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/dotfiles-validation.yml"))'` — YAML parses.
- [x] `grep -E 'uses:.*@[a-f0-9]{40}'` shows both pinned SHAs.
- [x] `grep -A1 'concurrency:'` shows `codacy-safety-net-${{ github.ref }}`.
- [x] `uv run python -m unittest discover -s tests` — only the 3 known unrelated `test_setup_script.py` failures remain; `tests/test_workflow.py` was updated to assert the new contract.
- [ ] After merge: confirm a follow-up push that the local hook has already analyzed shows the workflow finishing on the "Skip if Codacy already analyzed this commit" step.
- [ ] After merge: confirm a push with the hook bypassed (`git push --no-verify`) falls through and runs `scripts/quality-pipeline.sh`.