### PR TITLE
fix(doctor): detect missing nested keys at any depth (Codacy MCP env)

### DIFF
--- a/.claude/.mcp.json.template
+++ b/.claude/.mcp.json.template
@@ -1,4 +1,5 @@
 {
+  "_comment": "env blocks below are required for MCP server auth (CODACY_ACCOUNT_TOKEN, GITHUB_TOKEN). Do not strip — doctor will flag and apply re-merges.",
   "mcpServers": {
     "github": {
       "command": "npx",

--- a/dotfiles_tools/doctor.py
+++ b/dotfiles_tools/doctor.py
@@ -132,36 +132,27 @@ def _json_merge_target_state(
     return _state(result, "needs_merge", f"missing entries: {missing_str}")
 
 
-def _check_missing_key(key: str, source_value: Any, target: dict[str, Any], missing: list[str]) -> None:
-    if not isinstance(source_value, dict):
-        if key not in target:
-            missing.append(key)
-        return
-    _missing_nested_keys(key, source_value, target, missing)
-
-
-def _missing_nested_keys(
-    key: str,
-    source_value: dict[str, Any],
-    target: dict[str, Any],
-    missing: list[str],
-) -> None:
-    target_sub = target.get(key, {})
-    if not isinstance(target_sub, dict):
-        missing.append(key)
-        return
-    for sub_key in source_value:
-        if sub_key not in target_sub:
-            missing.append(f"{key}.{sub_key}")
-
-
 def _missing_json_keys(source: Any, target: Any) -> list[str]:
     if not isinstance(source, dict) or not isinstance(target, dict):
         return []
     missing: list[str] = []
-    for key, source_value in source.items():
-        _check_missing_key(key, source_value, target, missing)
+    _walk_missing(source, target, "", missing)
     return sorted(missing)
+
+
+def _walk_missing(source: dict[str, Any], target: dict[str, Any], prefix: str, missing: list[str]) -> None:
+    for key, source_value in source.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if key not in target:
+            missing.append(path)
+            continue
+        if not isinstance(source_value, dict):
+            continue
+        target_value = target[key]
+        if not isinstance(target_value, dict):
+            missing.append(path)
+            continue
+        _walk_missing(source_value, target_value, path, missing)
 
 
 def _base_result(entry: ManifestEntry, source_path: Path, target_path: Path) -> dict[str, Any]:

--- a/dotfiles_tools/doctor.py
+++ b/dotfiles_tools/doctor.py
@@ -133,10 +133,10 @@ def _json_merge_target_state(
 
 
 def _missing_json_keys(source: Any, target: Any) -> list[str]:
-    if not isinstance(source, dict) or not isinstance(target, dict):
+    if not isinstance(source, dict):
         return []
     missing: list[str] = []
-    _walk_missing(source, target, "", missing)
+    _walk_missing(source, target if isinstance(target, dict) else {}, "", missing)
     return sorted(missing)
 
 

--- a/tests/test_apply_install.py
+++ b/tests/test_apply_install.py
@@ -1,4 +1,6 @@
-from dotfiles_tools.installer import apply_plan
+import json
+
+from dotfiles_tools.installer import _deep_merge, apply_plan
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
@@ -10,3 +12,42 @@ class ApplyInstallTests(DotfilesTestCase):
         self.assertTrue((home / ".claude" / "settings.json").exists())
         self.assertTrue((home / ".config" / "fish" / "functions" / "direnv.fish").exists())
         self.assertFalse((home / ".config" / "git" / "config").exists())
+
+    def test_apply_merge_restores_missing_env_blocks_in_stale_mcp_json(self):
+        home = self.make_home()
+        target = home / ".claude" / ".mcp.json"
+        target.parent.mkdir(parents=True)
+        stale = {
+            "mcpServers": {
+                "github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]},
+                "codacy": {"command": "npx", "args": ["-y", "@codacy/codacy-mcp@latest"]},
+            }
+        }
+        target.write_text(json.dumps(stale))
+
+        report = apply_plan(REPO_ROOT, home, backup_dir=home / ".dotfiles-backups", yes=True)
+        self.assertNotEqual(report.status, "failed")
+
+        merged = json.loads(target.read_text())
+        self.assertEqual(
+            merged["mcpServers"]["codacy"]["env"]["CODACY_ACCOUNT_TOKEN"],
+            "$CODACY_ACCOUNT_TOKEN",
+        )
+        self.assertEqual(
+            merged["mcpServers"]["github"]["env"]["GITHUB_TOKEN"],
+            "$GITHUB_TOKEN",
+        )
+        self.assertEqual(merged["mcpServers"]["codacy"]["command"], "npx")
+
+    def test_deep_merge_adds_missing_nested_subtree(self):
+        source = json.loads((REPO_ROOT / ".claude" / ".mcp.json.template").read_text())
+        target = {
+            "mcpServers": {
+                "github": {"command": "npx"},
+                "codacy": {"command": "npx"},
+            }
+        }
+        merged = _deep_merge(source, target)
+        self.assertIn("env", merged["mcpServers"]["github"])
+        self.assertIn("env", merged["mcpServers"]["codacy"])
+        self.assertEqual(merged["mcpServers"]["github"]["env"]["GITHUB_TOKEN"], "$GITHUB_TOKEN")

--- a/tests/test_doctor_reports.py
+++ b/tests/test_doctor_reports.py
@@ -1,6 +1,6 @@
 import json
 
-from dotfiles_tools.doctor import run_doctor
+from dotfiles_tools.doctor import _missing_json_keys, run_doctor
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
@@ -25,3 +25,59 @@ class DoctorReportTests(DotfilesTestCase):
         self.assertGreaterEqual(tool_ids, {"uv", "git", "gh", "fish", "direnv", "codex", "claude", "gemini", "copilot", "specify"})
         auth_commands = {item["command"] for item in data["auth_guidance"]}
         self.assertIn("gh auth status", auth_commands)
+
+    def test_stale_mcp_target_without_env_blocks_is_flagged(self):
+        home = self.make_home()
+        target = home / ".claude" / ".mcp.json"
+        target.parent.mkdir(parents=True)
+        target.write_text(json.dumps({
+            "mcpServers": {
+                "github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]},
+                "codacy": {"command": "npx", "args": ["-y", "@codacy/codacy-mcp@latest"]},
+            }
+        }))
+        report = run_doctor(REPO_ROOT, home)
+        entry = next(e for e in report.entries if e["entry_id"] == "claude.mcp-servers")
+        self.assertEqual(entry["state"], "needs_merge")
+        self.assertIn("mcpServers.codacy.env", entry["reason"])
+        self.assertIn("mcpServers.github.env", entry["reason"])
+
+
+class MissingJsonKeysTests(DotfilesTestCase):
+    def test_missing_top_level_key(self):
+        source = {"a": 1, "b": 2}
+        target = {"a": 1}
+        self.assertEqual(_missing_json_keys(source, target), ["b"])
+
+    def test_missing_second_level_key(self):
+        source = {"servers": {"github": {}, "codacy": {}}}
+        target = {"servers": {"github": {}}}
+        self.assertEqual(_missing_json_keys(source, target), ["servers.codacy"])
+
+    def test_missing_third_level_key_regression(self):
+        source = {
+            "mcpServers": {
+                "codacy": {"command": "npx", "env": {"CODACY_ACCOUNT_TOKEN": "$CODACY_ACCOUNT_TOKEN"}},
+                "github": {"command": "npx", "env": {"GITHUB_TOKEN": "$GITHUB_TOKEN"}},
+            }
+        }
+        target = {
+            "mcpServers": {
+                "codacy": {"command": "npx"},
+                "github": {"command": "npx"},
+            }
+        }
+        self.assertEqual(
+            _missing_json_keys(source, target),
+            ["mcpServers.codacy.env", "mcpServers.github.env"],
+        )
+
+    def test_no_missing_keys_returns_empty(self):
+        source = {"mcpServers": {"codacy": {"env": {"K": "v"}}}}
+        target = {"mcpServers": {"codacy": {"env": {"K": "v"}, "extra": "ok"}}}
+        self.assertEqual(_missing_json_keys(source, target), [])
+
+    def test_target_intermediate_not_dict_reports_path(self):
+        source = {"a": {"b": {"c": 1}}}
+        target = {"a": "not-a-dict"}
+        self.assertEqual(_missing_json_keys(source, target), ["a"])


### PR DESCRIPTION
## Bug

Deployed ~/.claude/.mcp.json was missing env blocks for CODACY_ACCOUNT_TOKEN and GITHUB_TOKEN. The Codacy MCP server returned Unauthorized in every session, blocking local CICD with Codacy quality protection. The template was correct — the problem was that doctor never reported the drift, so apply was never re-run.

## Root Cause

`_missing_nested_keys` in dotfiles_tools/doctor.py only inspected two nesting levels. For source path mcpServers.github.env, it checked if mcpServers.github existed in the target, saw "yes", stopped — never recursing to discover env was missing. So doctor reported "current" while the target was critically stale.

## Fix

Replaced the two-level helper with a single recursive `_walk_missing(source, target, prefix, missing)` that walks the source dict and emits dot-separated path strings (e.g. `mcpServers.codacy.env`) for any key missing at any depth. Type-mismatched intermediates (target says "string" where source says dict) are reported at the path where the mismatch occurs. The downstream `_deep_merge` in installer.py was already correct — it just needed doctor to surface the drift.

## Verification

- `uv run python -m unittest discover -s tests` — all pass.
- `uv run python -m dotfiles_tools doctor --repo . --home "$HOME"` against the real broken target now reports:

  ```
  claude.mcp-servers: needs_merge (missing entries: _comment, mcpServers.codacy.env, mcpServers.github.env)
  ```

  This is the real-world regression check from the audit — exactly the signal that was missing.

## Tests Added

- `MissingJsonKeysTests` (5 cases): top-level, 2nd-level (existing behavior), 3rd-level regression, no-missing, intermediate-not-dict.
- `DoctorReportTests.test_stale_mcp_target_without_env_blocks_is_flagged`: end-to-end doctor regression for the exact incident.
- `ApplyInstallTests.test_apply_merge_restores_missing_env_blocks_in_stale_mcp_json`: apply-flow regression — synthesize a stale target, run apply, assert env blocks land in merged output.
- `ApplyInstallTests.test_deep_merge_adds_missing_nested_subtree`: direct `_deep_merge` test using the actual `.claude/.mcp.json.template`.

## Template Note

Added a top-level `_comment` field in `.claude/.mcp.json.template` documenting that the env blocks are required for MCP server auth and must not be stripped. Unknown top-level keys are ignored by Claude Code's MCP loader and are preserved through `_deep_merge`.

## Files Changed

- dotfiles_tools/doctor.py
- tests/test_doctor_reports.py
- tests/test_apply_install.py
- .claude/.mcp.json.template

🤖 Generated with [Claude Code](https://claude.com/claude-code)