### PR TITLE
fix(tool_installer): raise on curl download failure instead of silent return

### DIFF
--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -508,8 +508,9 @@ def _execute_curl(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) ->
     script = cache_dir / op["script_name"]
     runner.download(op["url"], script)
     if not script.exists():
-        op["result"] = f"failed to download installer from {op['url']}"
-        return 0
+        message = f"failed to download installer from {op['url']}"
+        op["result"] = message
+        raise RuntimeError(message)
     script.chmod(0o755)
     prefix = _sudo_prefix() if op.get("requires_sudo") else []
     runner.run([*prefix, interpreter, str(script)])

--- a/tests/test_apply_failures.py
+++ b/tests/test_apply_failures.py
@@ -1,5 +1,27 @@
+from pathlib import Path
+
+from dotfiles_tools.bootstrap import _execute_bootstrap_operations
 from dotfiles_tools.installer import apply_plan
+from dotfiles_tools.reports import Report
 from tests.helpers import DotfilesTestCase, REPO_ROOT
+
+
+class _NoDownloadRunner:
+    """Runner whose download() is a no-op so the installer script never lands on disk."""
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.downloads: list[tuple[str, Path]] = []
+
+    def which(self, command: str) -> str | None:
+        return "/bin/bash" if command == "bash" else None
+
+    def run(self, args, *, capture_output: bool = False, check: bool = True):  # pragma: no cover
+        self.commands.append(list(args))
+        raise AssertionError("runner.run should not be invoked when download fails")
+
+    def download(self, url: str, target: Path) -> None:
+        self.downloads.append((url, target))
 
 
 class ApplyFailureTests(DotfilesTestCase):
@@ -17,3 +39,36 @@ class ApplyFailureTests(DotfilesTestCase):
         report = apply_plan(REPO_ROOT, home, backup_dir=home / ".dotfiles-backups", yes=True)
         self.assertIn(report.status, {"failed", "partial"})
         self.assertTrue(report.errors)
+
+    def test_curl_install_download_failure_propagates_to_failed_report(self):
+        home = self.make_home()
+        cache_dir = home / ".cache" / "tool-installers"
+        op = {
+            "operation_id": "op-001",
+            "entry_id": "tools.claude",
+            "recipe": "tool_installs",
+            "type": "tool_install_curl",
+            "url": "https://claude.ai/install.sh",
+            "script_name": "claude-install.sh",
+            "interpreter": "bash",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+        report = Report(
+            "bootstrap-install-tools",
+            "warning",
+            str(REPO_ROOT),
+            home=str(home),
+            profile="machine",
+            operations=[op],
+        )
+        runner = _NoDownloadRunner()
+        result = _execute_bootstrap_operations(
+            report, REPO_ROOT, home / ".dotfiles-backups", runner
+        )
+        self.assertEqual(result.status, "failed")
+        self.assertTrue(result.errors)
+        first_error = result.errors[0]
+        self.assertEqual(first_error["entry_id"], "tools.claude")
+        self.assertIn("failed to download installer", first_error["message"])
+        self.assertIn("https://claude.ai/install.sh", first_error["message"])

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -305,6 +305,26 @@ class ToolInstallExecuteTests(DotfilesTestCase):
         execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
         self.assertEqual(runner.commands[-1][0], "/usr/bin/bash")
 
+    def test_curl_installer_raises_when_download_leaves_no_script(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"bash": "/bin/bash"})
+        runner.download = lambda url, target: runner.downloads.append((url, target))  # type: ignore[assignment]
+        cache_dir = home / ".cache" / "tool-installers"
+        op = {
+            "entry_id": "tools.claude",
+            "recipe": "tool_installs",
+            "type": "tool_install_curl",
+            "url": "https://claude.ai/install.sh",
+            "script_name": "claude-install.sh",
+            "interpreter": "bash",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+        with self.assertRaisesRegex(RuntimeError, r"failed to download installer from https://claude\.ai/install\.sh"):
+            execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(op["result"], "failed to download installer from https://claude.ai/install.sh")
+        self.assertFalse(any(cmd and cmd[0] == "/bin/bash" for cmd in runner.commands))
+
     def test_curl_installer_honors_interpreter_override(self) -> None:
         home = self.make_home()
         runner = FakeRunner(which={"python3": "/usr/bin/python3"})


### PR DESCRIPTION
## Summary
- `_execute_curl` previously set `op["result"]` and returned 0 when `runner.download` left no script on disk; the bootstrap loop sums integer returns, so the failure was silently swallowed and reported as success. Raise `RuntimeError` instead — `bootstrap.py:204` already catches `RuntimeError` and routes it through `_failed_report`, surfacing the URL in `report.errors`.
- Diagnostic `op["result"]` is preserved for context before the raise.
- Other `_execute_*` soft-skip paths (`_execute_apt`, `_execute_npm`, `_execute_uv_tool`, `_execute_apt_keyring`) intentionally treat "tool not on PATH" as a deferral, not a failure — left untouched as out of scope.

## Tests
- `tests/test_tool_installer.py::test_curl_installer_raises_when_download_leaves_no_script` — monkey-patches `FakeRunner.download` to a no-op and asserts `RuntimeError`, plus that the interpreter is never invoked.
- `tests/test_apply_failures.py::test_curl_install_download_failure_propagates_to_failed_report` — drives `_execute_bootstrap_operations` with a synthetic curl op and a download-less runner; asserts `status="failed"` and the error entry carries the entry_id plus the URL.

## Test plan
- [x] `uv run python -m unittest discover -s tests` (127 passed, 2 skipped)
- [x] `uv run python -m dotfiles_tools doctor --repo . --home "$HOME"` still works
- [x] Pre-push quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)