### PR TITLE
chore: gitignore local Codacy artifacts and resolve staged hooks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ __pycache__/
 !.agents/skills/**
 .vscode/
 skills-lock.json
+.codacy/
+*.sarif


### PR DESCRIPTION
## Summary

- Add `.codacy/` and `*.sarif` to `.gitignore` so local Codacy CLI runs (`./setup quality`, `codacy-cli analyze`) stop leaving untracked artifacts in `git status`.
- Document the decision on a separate staged-but-unmerged `hooks.json` change, which is **not** included here.

## Context (Unit 12 of repo audit)

The user's main checkout had two pieces of uncommitted local state:

1. Untracked `.codacy/` and `pylint.sarif` (CLI outputs from `codacy-cli analyze` / pylint runs).
2. A staged change to `.claude/plugins/dotfiles-quality-gate/hooks/hooks.json` converting the `SessionStart` hook from `type: command` (bash echo banner) to `type: prompt` (LLM-driven missing-plugin check).

This PR resolves the first piece. The second is left untouched; rationale below.

## Part 1 — gitignore

Two new entries appended to `.gitignore`:

```
.codacy/
*.sarif
```

Why these choices:

- **`.codacy/`** — Codacy CLI's local working directory. Inspecting `.codacy/.gitignore` from the user's checkout shows Codacy itself ignores `tools-configs/`, `.gitignore`, `cli-config.yaml`, and `logs/` *internally*. From the project's perspective, the entire directory is regenerated by the CLI and should never be committed; ignoring it wholesale is simpler and future-proofs against new files Codacy may add (e.g. `codacy.yaml` was already present in the user's checkout, not listed in Codacy's nested `.gitignore`).
- **`*.sarif`** — Codacy CLI dispatches individual analyzers (pylint, semgrep, eslint, pmd, trivy, ...) and each writes a SARIF file in the repo root. The `pylint.sarif` observed in the user's checkout is just the first one to land; ignoring all `*.sarif` covers the rest.

Per-file approval was given for this `.gitignore` edit; no other lines touched.

## Part 2 — hooks.json (intentionally not included)

The staged diff (in the main checkout, mid-rebase on branch `20260503-024509-setup-fixes`):

```diff
-"type": "command",
-"command": "bash -c 'cat <<EOF\n... static banner ...\nEOF'",
-"timeout": 5
+"type": "prompt",
+"prompt": "User just started Claude Code with dotfiles-quality-gate plugin installed. Check which recommended plugins are missing: superpowers, plugin-dev, mcp-server-dev, desktop-commander. For each missing plugin, provide install command: `claude plugin install <plugin-name>`. Keep it brief (2-3 sentences max) and don't block the session."
```

**Assessment**: the change is coherent and an improvement.

- `prompt`-type hooks let the LLM produce dynamic, conditional output instead of a static banner. The new behavior surfaces install commands only for plugins the user is actually missing — less noise on every session start.
- The JSON is well-formed for the prompt-hook schema (`type` + `prompt`, no `timeout`).
- Mild weakness: the prompt asks Claude to "check which plugins are missing" but doesn't supply a plugin-listing tool. The model has to infer from session context (typically the harness's plugin list it's already seen). Worst case it just lists all four anyway — no regression vs the static banner.

**Why it's not in this PR**: the change lives in an in-flight rebase (`20260503-024509-setup-fixes`) that has its own commit trail and unmerged conflicts. Cherry-picking it into a gitignore PR would (a) duplicate the change in two branches, (b) blur this PR's scope, (c) risk it being merged twice if the rebase eventually resumes. The right place for it is whichever PR comes out of that rebase. Leaving the staged change in place; this PR doesn't touch the file.

## Test plan

- [x] `git status` clean after changes (no untracked `.codacy/`, no untracked `pylint.sarif`).
- [x] `git diff main...HEAD --stat` shows only `.gitignore | 2 ++`.
- [x] `uv run python -m unittest discover -s tests` — 125 passed, 2 skipped.
- [ ] On merge: confirm a fresh `./setup quality` run no longer leaves untracked files visible to `git status`.