### PR TITLE
test: add coverage for codacy-cli bootstrap baseline entry

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from dotfiles_tools.bootstrap import (
+    WARNING_STATES,
+    FAILED_STATES,
+    _renumber_operations,
+    _status,
+    _has_manual_or_refused_work,
+    _collect_post_install_backups,
+    build_bootstrap_plan,
+    apply_bootstrap,
+    build_tool_install_subplan,
+    apply_tool_installs,
+)
+from dotfiles_tools.reports import Report
+from tests.helpers import DotfilesTestCase, REPO_ROOT
+
+
+class FakeRunner:
+    def __init__(self, *, which: dict[str, str] | None = None) -> None:
+        self.which_map = which or {}
+        self.installed_dpkg: set[str] = set()
+
+    def which(self, command: str) -> str | None:
+        return self.which_map.get(command)
+
+    def download(self, url: str, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("#!/bin/sh\necho fake\n")
+
+    def run(
+        self,
+        args: list[str],
+        *,
+        capture_output: bool = False,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = Path(args[0]).name if args else ""
+        if command == "dpkg-query":
+            package = args[-1]
+            if package in self.installed_dpkg:
+                return subprocess.CompletedProcess(args, 0, stdout="install ok installed", stderr="")
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="not installed")
+        if command == "dpkg" and "--print-architecture" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="amd64\n", stderr="")
+        if "--version" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="dummy 1.2.3\n", stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+class RenumberOperationsTests(DotfilesTestCase):
+    def test_renumbers_from_one(self):
+        ops = [{"operation_id": "op-099"}, {"operation_id": "op-007"}]
+        _renumber_operations(ops)
+        self.assertEqual(ops[0]["operation_id"], "op-001")
+        self.assertEqual(ops[1]["operation_id"], "op-002")
+
+    def test_empty_list_is_noop(self):
+        ops: list = []
+        _renumber_operations(ops)
+        self.assertEqual(ops, [])
+
+
+class StatusTests(DotfilesTestCase):
+    def test_ok_when_no_entries_or_ops(self):
+        self.assertEqual(_status([], [], []), "ok")
+
+    def test_failed_when_errors_present(self):
+        self.assertEqual(_status([], [], [{"message": "boom"}]), "failed")
+
+    def test_failed_when_entry_has_failed_state(self):
+        for state in FAILED_STATES:
+            with self.subTest(state=state):
+                self.assertEqual(_status([{"state": state}], [], []), "failed")
+
+    def test_warning_when_operations_present(self):
+        self.assertEqual(_status([], [{"type": "copy"}], []), "warning")
+
+    def test_warning_when_entry_has_warning_state(self):
+        for state in WARNING_STATES:
+            with self.subTest(state=state):
+                self.assertEqual(_status([{"state": state}], [], []), "warning")
+
+    def test_failed_takes_precedence_over_warning(self):
+        entries = [{"state": "invalid"}, {"state": "missing"}]
+        self.assertEqual(_status(entries, [], []), "failed")
+
+
+class HasManualOrRefusedWorkTests(DotfilesTestCase):
+    def _report(self, ops=None, entries=None):
+        return Report("cmd", "ok", "/repo", operations=ops or [], entries=entries or [])
+
+    def test_false_when_nothing_special(self):
+        self.assertFalse(_has_manual_or_refused_work(self._report()))
+
+    def test_true_when_refuse_op(self):
+        r = self._report(ops=[{"type": "refuse"}])
+        self.assertTrue(_has_manual_or_refused_work(r))
+
+    def test_true_when_font_manual_op(self):
+        r = self._report(ops=[{"type": "font_manual"}])
+        self.assertTrue(_has_manual_or_refused_work(r))
+
+    def test_true_when_protected_entry(self):
+        r = self._report(entries=[{"state": "protected"}])
+        self.assertTrue(_has_manual_or_refused_work(r))
+
+    def test_true_when_manual_entry(self):
+        r = self._report(entries=[{"state": "manual"}])
+        self.assertTrue(_has_manual_or_refused_work(r))
+
+    def test_true_when_unsupported_entry(self):
+        r = self._report(entries=[{"state": "unsupported"}])
+        self.assertTrue(_has_manual_or_refused_work(r))
+
+
+class CollectPostInstallBackupsTests(DotfilesTestCase):
+    def test_returns_empty_when_no_actions(self):
+        self.assertEqual(_collect_post_install_backups([]), [])
+
+    def test_returns_empty_when_no_backups_key(self):
+        actions = [{"status": "ran", "tool": "gh"}]
+        self.assertEqual(_collect_post_install_backups(actions), [])
+
+    def test_collects_backups_from_all_actions(self):
+        b1 = {"entry_id": "a", "backup_target": "/tmp/a"}
+        b2 = {"entry_id": "b", "backup_target": "/tmp/b"}
+        actions = [
+            {"status": "ran", "backups": [b1]},
+            {"status": "ran", "backups": [b2]},
+        ]
+        result = _collect_post_install_backups(actions)
+        self.assertEqual(result, [b1, b2])
+
+    def test_skips_none_backups(self):
+        actions = [{"status": "ran", "backups": None}]
+        self.assertEqual(_collect_post_install_backups(actions), [])
+
+
+class BuildBootstrapPlanTests(DotfilesTestCase):
+    def test_returns_report_with_correct_command(self):
+        home = self.make_home()
+        report = build_bootstrap_plan(REPO_ROOT, home, profile="machine")
+        self.assertEqual(report.command, "bootstrap-plan")
+
+    def test_profile_stored_in_report(self):
+        home = self.make_home()
+        report = build_bootstrap_plan(REPO_ROOT, home, profile="machine")
+        self.assertEqual(report.profile, "machine")
+
+    def test_machine_profile_includes_font_context(self):
+        home = self.make_home()
+        report = build_bootstrap_plan(REPO_ROOT, home, profile="machine")
+        self.assertIn("fonts", report.extra)
+        self.assertIn("font_context", report.extra)
+
+    def test_operations_are_renumbered_sequentially(self):
+        home = self.make_home()
+        report = build_bootstrap_plan(REPO_ROOT, home, profile="machine")
+        ids = [op["operation_id"] for op in report.operations]
+        expected = [f"op-{i:03d}" for i in range(1, len(ids) + 1)]
+        self.assertEqual(ids, expected)
+
+    def test_repo_and_home_are_absolute(self):
+        home = self.make_home()
+        report = build_bootstrap_plan(REPO_ROOT, home, profile="machine")
+        self.assertTrue(report.repo.startswith("/"))
+        self.assertTrue(report.home.startswith("/"))
+
+
+class ApplyBootstrapTests(DotfilesTestCase):
+    def test_requires_yes_flag(self):
+        home = self.make_home()
+        report = apply_bootstrap(REPO_ROOT, home, yes=False)
+        self.assertEqual(report.status, "failed")
+        self.assertTrue(any("--yes" in str(e) for e in report.errors))
+
+    def test_applies_with_yes(self):
+        home = self.make_home()
+        runner = FakeRunner()
+        report = apply_bootstrap(
+            REPO_ROOT, home,
+            profile="machine",
+            backup_dir=home / ".dotfiles-backups",
+            yes=True,
+            runner=runner,
+        )
+        self.assertIn(report.status, {"ok", "warning", "partial"})
+        self.assertEqual(report.command, "bootstrap-apply")
+
+    def test_default_backup_dir_inside_home(self):
+        home = self.make_home()
+        runner = FakeRunner()
+        report = apply_bootstrap(
+            REPO_ROOT, home,
+            profile="machine",
+            yes=True,
+            runner=runner,
+        )
+        self.assertNotEqual(report.status, "failed")
+
+
+class BuildToolInstallSubplanTests(DotfilesTestCase):
+    def test_returns_report_with_correct_command(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home)
+        self.assertEqual(report.command, "bootstrap-install-tools-plan")
+
+    def test_profile_is_machine(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home)
+        self.assertEqual(report.profile, "machine")
+
+    def test_tools_key_present_in_extra(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home)
+        self.assertIn("tools", report.extra)
+
+    def test_operations_renumbered(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home)
+        ids = [op["operation_id"] for op in report.operations]
+        expected = [f"op-{i:03d}" for i in range(1, len(ids) + 1)]
+        self.assertEqual(ids, expected)
+
+
+class ApplyToolInstallsTests(DotfilesTestCase):
+    def test_requires_yes_flag(self):
+        home = self.make_home()
+        report = apply_tool_installs(REPO_ROOT, home, yes=False)
+        self.assertEqual(report.status, "failed")
+        self.assertTrue(any("--yes" in str(e) for e in report.errors))
+
+    def test_command_set_to_bootstrap_install_tools(self):
+        home = self.make_home()
+        runner = FakeRunner()
+        report = apply_tool_installs(
+            REPO_ROOT, home,
+            backup_dir=home / ".dotfiles-backups",
+            yes=True,
+            runner=runner,
+        )
+        self.assertEqual(report.command, "bootstrap-install-tools")

--- a/tests/test_codacy_cli_bootstrap.py
+++ b/tests/test_codacy_cli_bootstrap.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from dotfiles_tools.baseline import TOOL_BASELINE
+from dotfiles_tools.tool_installer import (
+    build_tool_install_plan,
+    execute_tool_install_operation,
+    verify_installed_tools,
+    run_post_install_actions,
+    TOOL_CACHE_REL,
+)
+from tests.helpers import DotfilesTestCase
+from tests.test_tool_installer import FakeRunner
+
+
+CODACY_ENTRY_ID = "tools.codacy-cli"
+CODACY_INSTALL_URL = "https://raw.githubusercontent.com/codacy/codacy-cli-v2/main/codacy-cli.sh"
+CODACY_SCRIPT_NAME = "codacy-cli.sh"
+
+
+class CodacyCliBaselineEntryTests(DotfilesTestCase):
+    def _get_baseline_entry(self) -> dict:
+        return next(e for e in TOOL_BASELINE if e["id"] == "codacy-cli")
+
+    def test_codacy_cli_present_in_tool_baseline(self) -> None:
+        ids = [e["id"] for e in TOOL_BASELINE]
+        self.assertIn("codacy-cli", ids)
+
+    def test_codacy_cli_baseline_fields(self) -> None:
+        entry = self._get_baseline_entry()
+        self.assertEqual(entry["command"], "codacy-cli")
+        self.assertEqual(entry["install_method"], "curl_installer")
+        self.assertTrue(entry["bootstrap"])
+        self.assertFalse(entry["requires_sudo"])
+        self.assertEqual(entry["post_install"], ())
+
+    def test_codacy_cli_install_args_url_and_script(self) -> None:
+        entry = self._get_baseline_entry()
+        args = entry["install_args"]
+        self.assertEqual(args["url"], CODACY_INSTALL_URL)
+        self.assertEqual(args["script_name"], CODACY_SCRIPT_NAME)
+
+    def test_codacy_cli_interpreter_is_bash(self) -> None:
+        entry = self._get_baseline_entry()
+        self.assertEqual(entry["install_args"]["interpreter"], "bash")
+
+
+class CodacyCliPlanTests(DotfilesTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._platform = mock.patch("dotfiles_tools.tool_installer.sys.platform", "linux")
+        self._platform.start()
+        self.addCleanup(self._platform.stop)
+        self._euid = mock.patch("dotfiles_tools.tool_installer.os.geteuid", return_value=1000, create=True)
+        self._euid.start()
+        self.addCleanup(self._euid.stop)
+
+    def test_plan_emits_curl_install_op_when_missing(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        ops = [op for op in plan["operations"] if op.get("entry_id") == CODACY_ENTRY_ID]
+        self.assertEqual(len(ops), 1)
+        op = ops[0]
+        self.assertEqual(op["type"], "tool_install_curl")
+        self.assertEqual(op["mode"], "install")
+        self.assertEqual(op["url"], CODACY_INSTALL_URL)
+        self.assertEqual(op["script_name"], CODACY_SCRIPT_NAME)
+        self.assertEqual(op["interpreter"], "bash")
+
+    def test_plan_emits_curl_upgrade_op_when_present(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query", "codacy-cli": "/usr/local/bin/codacy-cli"},
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        ops = [op for op in plan["operations"] if op.get("entry_id") == CODACY_ENTRY_ID]
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["type"], "tool_install_curl")
+        self.assertEqual(ops[0]["mode"], "upgrade")
+
+    def test_plan_entry_state_missing_when_not_found(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        entry = next(e for e in plan["entries"] if e.get("entry_id") == CODACY_ENTRY_ID)
+        self.assertEqual(entry["state"], "missing")
+        self.assertEqual(entry["action"], "install")
+
+    def test_plan_entry_state_installed_when_found(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query", "codacy-cli": "/usr/local/bin/codacy-cli"},
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        entry = next(e for e in plan["entries"] if e.get("entry_id") == CODACY_ENTRY_ID)
+        self.assertEqual(entry["state"], "installed")
+        self.assertEqual(entry["action"], "upgrade")
+        self.assertEqual(entry["current_path"], "/usr/local/bin/codacy-cli")
+
+    def test_plan_op_requires_no_sudo(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, runner=runner)
+        ops = [op for op in plan["operations"] if op.get("entry_id") == CODACY_ENTRY_ID]
+        self.assertFalse(ops[0]["requires_sudo"])
+
+
+class CodacyCliExecuteTests(DotfilesTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._euid = mock.patch("dotfiles_tools.tool_installer.os.geteuid", return_value=1000, create=True)
+        self._euid.start()
+        self.addCleanup(self._euid.stop)
+
+    def _make_curl_op(self, cache_dir: Path) -> dict:
+        return {
+            "type": "tool_install_curl",
+            "mode": "install",
+            "url": CODACY_INSTALL_URL,
+            "script_name": CODACY_SCRIPT_NAME,
+            "interpreter": "bash",
+            "requires_sudo": False,
+            "cache_dir": str(cache_dir),
+        }
+
+    def test_execute_downloads_and_runs_script(self) -> None:
+        home = self.make_home()
+        cache_dir = home / TOOL_CACHE_REL
+        runner = FakeRunner(which={"bash": "/bin/bash"})
+        op = self._make_curl_op(cache_dir)
+        result = execute_tool_install_operation(op, runner=runner, cache_dir=cache_dir)
+        self.assertEqual(result, 1)
+        self.assertEqual(len(runner.downloads), 1)
+        downloaded_url, downloaded_path = runner.downloads[0]
+        self.assertEqual(downloaded_url, CODACY_INSTALL_URL)
+        self.assertEqual(downloaded_path.name, CODACY_SCRIPT_NAME)
+        ran = [cmd for cmd in runner.commands if CODACY_SCRIPT_NAME in " ".join(str(c) for c in cmd)]
+        self.assertTrue(ran, "installer script was not executed")
+
+    def test_execute_uses_bash_not_sh(self) -> None:
+        home = self.make_home()
+        cache_dir = home / TOOL_CACHE_REL
+        runner = FakeRunner(which={"bash": "/bin/bash"})
+        execute_tool_install_operation(self._make_curl_op(cache_dir), runner=runner, cache_dir=cache_dir)
+        script_cmds = [cmd for cmd in runner.commands if CODACY_SCRIPT_NAME in " ".join(str(c) for c in cmd)]
+        self.assertTrue(script_cmds)
+        self.assertEqual(Path(script_cmds[0][0]).name, "bash")
+
+    def test_execute_no_sudo_prefix_when_requires_sudo_false(self) -> None:
+        home = self.make_home()
+        cache_dir = home / TOOL_CACHE_REL
+        runner = FakeRunner(which={"bash": "/bin/bash"})
+        execute_tool_install_operation(self._make_curl_op(cache_dir), runner=runner, cache_dir=cache_dir)
+        script_cmds = [cmd for cmd in runner.commands if CODACY_SCRIPT_NAME in " ".join(str(c) for c in cmd)]
+        self.assertTrue(script_cmds)
+        self.assertNotIn("sudo", script_cmds[0])
+
+
+class CodacyCliVerifyTests(DotfilesTestCase):
+    def test_verify_returns_result_for_codacy_cli(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"codacy-cli": "/usr/local/bin/codacy-cli"})
+        results = verify_installed_tools(home, runner=runner, env={})
+        codacy_result = next((r for r in results if r["entry_id"] == CODACY_ENTRY_ID), None)
+        self.assertIsNotNone(codacy_result)
+        self.assertTrue(codacy_result["verified"])
+        self.assertEqual(codacy_result["path"], "/usr/local/bin/codacy-cli")
+        self.assertEqual(codacy_result["command"], "codacy-cli")
+
+    def test_verify_unverified_when_not_found(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={})
+        results = verify_installed_tools(home, runner=runner, env={})
+        codacy_result = next((r for r in results if r["entry_id"] == CODACY_ENTRY_ID), None)
+        self.assertIsNotNone(codacy_result)
+        self.assertFalse(codacy_result["verified"])
+        self.assertIsNone(codacy_result["path"])
+
+    def test_post_install_skipped_when_not_present(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={})
+        results = run_post_install_actions(home, runner=runner, env={})
+        codacy_results = [r for r in results if r.get("tool") == "codacy-cli"]
+        self.assertEqual(codacy_results, [], "no post_install actions expected for codacy-cli")


### PR DESCRIPTION
## Summary

- 15 tests across 4 classes covering the `codacy-cli` `TOOL_BASELINE` entry end-to-end
- `CodacyCliBaselineEntryTests`: validates entry fields (`command`, `install_method`, `bootstrap`, `requires_sudo`, `post_install`, `install_args.url/script_name/interpreter`)
- `CodacyCliPlanTests`: verifies `build_tool_install_plan` emits correct curl install/upgrade ops and entry states
- `CodacyCliExecuteTests`: confirms `execute_tool_install_operation` downloads the script, invokes bash (not sh), and omits sudo prefix when `requires_sudo=False`
- `CodacyCliVerifyTests`: checks `verify_installed_tools` and `run_post_install_actions` behave correctly for codacy-cli

## Test plan

- [x] `uv run python -m unittest tests.test_codacy_cli_bootstrap -v` — all 15 pass
- [x] Full suite `uv run python -m unittest discover -s tests` — no regressions (pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)