### PR TITLE
fix(fonts): normalize _execute_* return semantics and narrow exception handling

### DIFF
--- a/dotfiles_tools/fonts.py
+++ b/dotfiles_tools/fonts.py
@@ -248,8 +248,31 @@ def _font_operation_handlers(
 
 
 def _execute_systemd(op: dict[str, Any], runner: CommandRunner, *args: str) -> int:
+    # State-change command (no file write). Returns 1 because callers track this
+    # for partial-apply accounting; if a later op fails, we want to know systemd
+    # state has already been mutated.
     runner.run(["sudo", "systemctl", *args])
     return 1
+
+
+_RELEASE_FETCH_ERRORS: tuple[type[BaseException], ...] = (OSError, json.JSONDecodeError, UnicodeDecodeError)
+
+
+def _classify_release_lookup_error(exc: BaseException) -> str:
+    import socket
+    import urllib.error
+
+    if isinstance(exc, urllib.error.HTTPError):
+        return "http"
+    if isinstance(exc, urllib.error.URLError):
+        return "network"
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return "timeout"
+    if isinstance(exc, (json.JSONDecodeError, UnicodeDecodeError)):
+        return "decode"
+    if isinstance(exc, FileNotFoundError):
+        return "offline"
+    return "network"
 
 
 def _release_metadata(home: Path, env: Mapping[str, str], runner: CommandRunner, *, fetch: bool) -> dict[str, Any]:
@@ -259,10 +282,14 @@ def _release_metadata(home: Path, env: Mapping[str, str], runner: CommandRunner,
     if fetch or _truthy(env.get("DOTFILES_FONT_CHECK_LATEST")):
         try:
             release = runner.fetch_json(NERD_FONTS_RELEASE_URL)
-        except Exception as exc:
+        except _RELEASE_FETCH_ERRORS as exc:
             cached = _read_version(cache_path)
-            if cached:
-                cached["lookup_error"] = str(exc)
+            if not cached:
+                raise FontError(
+                    f"nerd-fonts release lookup failed and no cache exists at {cache_path}: {exc}"
+                ) from exc
+            cached["lookup_error"] = str(exc)
+            cached["lookup_error_kind"] = _classify_release_lookup_error(exc)
             return cached
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(release, indent=2, sort_keys=True) + "\n")
@@ -427,12 +454,16 @@ def _execute_install_linux(op: dict[str, Any]) -> int:
     fonts = _installed_font_files(source)
     if not fonts:
         raise FontError(f"no extracted font files found in {source}")
+    version = _read_version(Path(op.get("version_source", "")))
+    marker_path = target / FONT_MARKER_NAME
+    if version and _read_version(marker_path) == version and all((target / font.name).exists() for font in fonts):
+        op["result"] = f"already installed at {version.get('tag_name', 'cached version')}"
+        return 0
     target.mkdir(parents=True, exist_ok=True)
     for font in fonts:
         shutil.copy2(font, target / font.name)
-    version = _read_version(Path(op.get("version_source", "")))
     if version:
-        (target / FONT_MARKER_NAME).write_text(json.dumps(version, indent=2, sort_keys=True) + "\n")
+        marker_path.write_text(json.dumps(version, indent=2, sort_keys=True) + "\n")
     return 1
 
 
@@ -490,6 +521,11 @@ def _execute_install_packages(op: dict[str, Any], runner: CommandRunner) -> int:
     return 1
 
 
+# ttyd_html, ttyd_service: targets are root-owned (/etc/...) so we cannot read
+# them to compare against generated content without invoking sudo (which itself
+# has side effects). Returning 1 honestly: every call to these handlers performs
+# a sudo install and a backup. Callers that want idempotence should gate at the
+# plan level, not here.
 def _execute_ttyd_html(op: dict[str, Any], runner: CommandRunner, backups: list[dict[str, Any]]) -> int:
     source_dir = Path(op["source"])
     font = _regular_mono_font(source_dir)
@@ -537,6 +573,13 @@ def _first_mono_font(fonts: list[Path], *, require_regular: bool) -> Path | None
 
 def _execute_pixel_avf_prompt(op: dict[str, Any]) -> int:
     target = Path(op["target"])
+    desired = pixel_avf_prompt_text()
+    try:
+        if target.read_text() == desired:
+            op["result"] = "prompt fallback already current"
+            return 0
+    except OSError:
+        pass
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(pixel_avf_prompt_text())
+    target.write_text(desired)
     return 1

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
 import subprocess
+import zipfile
 from pathlib import Path
 
+from dotfiles_tools.font_catalog import NERD_FONT_CATALOG, EXPECTED_TTF
 from dotfiles_tools.bootstrap import (
     WARNING_STATES,
     FAILED_STATES,
@@ -27,9 +30,24 @@ class FakeRunner:
     def which(self, command: str) -> str | None:
         return self.which_map.get(command)
 
+    def fetch_json(self, url: str) -> dict:
+        return {
+            "tag_name": "v3.4.0",
+            "assets": [
+                {"name": item.asset_name, "browser_download_url": f"https://example/{item.asset_name}", "size": 12}
+                for item in NERD_FONT_CATALOG
+            ],
+        }
+
     def download(self, url: str, target: Path) -> None:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text("#!/bin/sh\necho fake\n")
+        if target.suffix.lower() == ".zip":
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr(EXPECTED_TTF, b"fake-font-bytes")
+            target.write_bytes(buf.getvalue())
+        else:
+            target.write_text("#!/bin/sh\necho fake\n")
 
     def run(
         self,

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import subprocess  # nosec B404
+import urllib.error
 import zipfile
 
 from dotfiles_tools.bootstrap import build_bootstrap_plan
+from dotfiles_tools.font_assets import pixel_avf_prompt_text
+from dotfiles_tools.font_catalog import FONT_MARKER_NAME
 from dotfiles_tools.fonts import (
     APT_FONT_CATALOG,
     EXPECTED_TTF,
@@ -159,9 +163,12 @@ class FontCatalogTests(DotfilesTestCase):
 
     def test_linux_font_install_reuses_cached_archives_extracts_installs_and_verifies_mono_faces(self) -> None:
         home = self.make_home()
+        cache_root = home / ".cache/000-dotfiles/fonts"
         for item in NERD_FONT_CATALOG:
-            archive = home / ".cache/000-dotfiles/fonts" / item.asset_name
+            archive = cache_root / item.asset_name
             write_font_zip(archive, item.expected_regular)
+        cache_root.mkdir(parents=True, exist_ok=True)
+        (cache_root / "nerd-fonts.latest.json").write_text(json.dumps(release_inventory()))
         runner = FakeRunner(which={"fc-cache": "/usr/bin/fc-cache", "fc-match": "/usr/bin/fc-match"}, fail_fetch=True)
         plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
 
@@ -298,3 +305,154 @@ class FontCatalogTests(DotfilesTestCase):
         for key in ("family", "source_type", "state", "installed_version", "target", "terminal_face"):
             self.assertIn(key, first)
         self.assertIn("font_download", {op["type"] for op in data["operations"]})
+
+
+class FontReturnSemanticsTests(DotfilesTestCase):
+    def test_install_linux_returns_zero_when_marker_and_files_already_match(self) -> None:
+        home = self.make_home()
+        source = home / "src"
+        target = home / "target"
+        source.mkdir()
+        target.mkdir()
+        (source / EXPECTED_TTF).write_bytes(b"font-bytes")
+        version = {"tag_name": "v9.9.9"}
+        version_source = home / "version.json"
+        version_source.write_text(json.dumps(version))
+        op = {"type": "font_install_linux", "source": str(source), "target": str(target), "version_source": str(version_source)}
+
+        first = execute_font_operation(op, runner=FakeRunner())
+        second = execute_font_operation(op, runner=FakeRunner())
+
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)
+        self.assertEqual((target / FONT_MARKER_NAME).read_text().strip(), json.dumps(version, indent=2, sort_keys=True))
+
+    def test_install_linux_returns_one_when_marker_differs(self) -> None:
+        home = self.make_home()
+        source = home / "src"
+        target = home / "target"
+        source.mkdir()
+        target.mkdir()
+        (source / EXPECTED_TTF).write_bytes(b"font-bytes")
+        (target / EXPECTED_TTF).write_bytes(b"font-bytes")
+        (target / FONT_MARKER_NAME).write_text(json.dumps({"tag_name": "v0.0.1"}, indent=2, sort_keys=True) + "\n")
+        version_source = home / "version.json"
+        version_source.write_text(json.dumps({"tag_name": "v9.9.9"}))
+        op = {"type": "font_install_linux", "source": str(source), "target": str(target), "version_source": str(version_source)}
+
+        result = execute_font_operation(op, runner=FakeRunner())
+
+        self.assertEqual(result, 1)
+
+    def test_pixel_avf_prompt_returns_zero_when_already_current(self) -> None:
+        home = self.make_home()
+        target = home / "fish-prompt.fish"
+        target.write_text(pixel_avf_prompt_text())
+        op = {"type": "font_pixel_avf_prompt", "target": str(target)}
+
+        result = execute_font_operation(op, runner=FakeRunner())
+
+        self.assertEqual(result, 0)
+
+    def test_pixel_avf_prompt_returns_one_on_first_write(self) -> None:
+        home = self.make_home()
+        target = home / "fish-prompt.fish"
+        op = {"type": "font_pixel_avf_prompt", "target": str(target)}
+
+        result = execute_font_operation(op, runner=FakeRunner())
+
+        self.assertEqual(result, 1)
+        self.assertEqual(target.read_text(), pixel_avf_prompt_text())
+
+    def test_systemd_returns_one_to_record_state_change(self) -> None:
+        runner = FakeRunner(which={"systemctl": "/usr/bin/systemctl"})
+        op = {"type": "font_systemd_daemon_reload", "target": "systemd"}
+
+        result = execute_font_operation(op, runner=runner)
+
+        self.assertEqual(result, 1)
+        self.assertTrue(any("systemctl" in arg for arg in runner.commands[0]))
+
+    def test_ttyd_html_and_service_return_one(self) -> None:
+        home = self.make_home()
+        source = home / "src"
+        source.mkdir()
+        (source / EXPECTED_TTF).write_bytes(b"font-bytes")
+        cache = home / "cache"
+        target_html = home / "fake-ttyd-index.html"
+        target_service = home / "fake-ttyd.service"
+
+        html_result = execute_font_operation(
+            {
+                "type": "font_ttyd_write_html",
+                "source": str(source),
+                "target": str(target_html),
+                "cache_dir": str(cache),
+                "entry_id": "test",
+            },
+            runner=FakeRunner(),
+            backups=[],
+        )
+        service_result = execute_font_operation(
+            {
+                "type": "font_ttyd_write_service",
+                "target": str(target_service),
+                "cache_dir": str(cache),
+                "entry_id": "test",
+            },
+            runner=FakeRunner(),
+            backups=[],
+        )
+
+        self.assertEqual(html_result, 1)
+        self.assertEqual(service_result, 1)
+
+
+class FontReleaseMetadataTests(DotfilesTestCase):
+    def test_release_lookup_failure_with_cache_attaches_error_kind(self) -> None:
+        home = self.make_home()
+        cache_root = home / ".cache/000-dotfiles/fonts"
+        cache_root.mkdir(parents=True)
+        (cache_root / "nerd-fonts.latest.json").write_text(json.dumps(release_inventory("v1.2.3")))
+        runner = FakeRunner(fail_fetch=True)
+
+        plan = build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+        nerd_summary = next(item for item in plan["fonts"] if item["source_type"] == "nerd_font_release")
+
+        self.assertEqual(nerd_summary["latest_version"], "v1.2.3")
+
+    def test_release_lookup_failure_without_cache_raises_font_error(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(fail_fetch=True)
+
+        with self.assertRaises(FontError):
+            build_font_plan(home, env={"DOTFILES_PLATFORM": "linux"}, path="", runner=runner)
+
+    def test_release_lookup_classifies_url_error_as_network(self) -> None:
+        from dotfiles_tools.fonts import _classify_release_lookup_error
+
+        self.assertEqual(_classify_release_lookup_error(urllib.error.URLError("boom")), "network")
+        self.assertEqual(_classify_release_lookup_error(urllib.error.HTTPError("u", 500, "msg", {}, None)), "http")
+        self.assertEqual(_classify_release_lookup_error(TimeoutError("slow")), "timeout")
+        self.assertEqual(_classify_release_lookup_error(json.JSONDecodeError("oops", "doc", 0)), "decode")
+        self.assertEqual(_classify_release_lookup_error(FileNotFoundError("missing")), "offline")
+
+    def test_release_metadata_cached_lookup_records_error_kind(self) -> None:
+        from dotfiles_tools.fonts import _release_metadata
+        from dotfiles_tools.font_runner import CommandRunner as RealRunner
+
+        home = self.make_home()
+        cache_root = home / ".cache/000-dotfiles/fonts"
+        cache_root.mkdir(parents=True)
+        (cache_root / "nerd-fonts.latest.json").write_text(json.dumps({"tag_name": "v1.2.3", "assets": []}))
+
+        class TimeoutRunner(RealRunner):
+            def fetch_json(self, url: str) -> dict:
+                raise TimeoutError("slow")
+
+        runner = TimeoutRunner(env={}, path="")
+        result = _release_metadata(home, {}, runner, fetch=True)
+
+        self.assertEqual(result["tag_name"], "v1.2.3")
+        self.assertEqual(result["lookup_error_kind"], "timeout")
+        self.assertIn("slow", result["lookup_error"])


### PR DESCRIPTION
## Summary

- `_execute_install_linux` and `_execute_pixel_avf_prompt` now return 0 when the target is already at the correct version (idempotent), 1 on write
- `_execute_systemd` documents why it returns 1 for state-change ops (partial-apply accounting)
- `_execute_ttyd_html/service` comment explains why idempotency check is omitted (root-owned targets, sudo side effects)
- `_release_metadata` narrows `except Exception` to `_RELEASE_FETCH_ERRORS` tuple, raises `FontError` when cache is absent, and attaches `lookup_error_kind` for structured error classification via `_classify_release_lookup_error`

## Test plan

- [ ] `FontReturnSemanticsTests`: install_linux 0/1, pixel_avf_prompt 0/1, systemd returns 1, ttyd returns 1
- [ ] `FontReleaseMetadataTests`: lookup failure with/without cache, error classification, lookup_error_kind field
- [ ] Full suite: `uv run python -m unittest discover -s tests` → 159 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)