### PR TITLE
fix(quality): drop broken codacy-cli coverage upload from pipeline

### DIFF
--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -55,13 +55,14 @@ echo "[2/5] Generating coverage..."
 uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
 uv run --with coverage==7.5.4 coverage xml
 
-echo "[3/5] Running pylint analysis..."
+echo "[3/4] Running pylint analysis..."
 codacy-cli analyze --tool pylint --format sarif -o pylint.sarif
 
-echo "[4/5] Uploading coverage to Codacy (commit $SHA)..."
-codacy-cli upload -s coverage.xml -c "$SHA" -t "$TOKEN"
+# Coverage upload is handled by the workflow's codacy-coverage-reporter-action
+# step (see .github/workflows/dotfiles-validation.yml). codacy-cli upload only
+# accepts SARIF, not coverage XML — passing coverage.xml here always failed.
 
-echo "[5/5] Uploading pylint analysis to Codacy (commit $SHA)..."
+echo "[4/4] Uploading pylint analysis to Codacy (commit $SHA)..."
 codacy-cli upload -s pylint.sarif -c "$SHA" -t "$TOKEN"
 
 echo ""


### PR DESCRIPTION
Stage 4 of `scripts/quality-pipeline.sh` calls `codacy-cli upload -s coverage.xml`, but `codacy-cli upload` only accepts SARIF, not coverage XML. Every workflow run dies at this step:

```
Loading SARIF file from path: coverage.xml
Parsing SARIF file...
Error parsing SARIF file: invalid character '<' looking for beginning of value
##[error]Process completed with exit code 1.
```

When the workflow exits non-zero, the subsequent codacy/codacy-coverage-reporter-action step (which IS the correct uploader for coverage.xml) is skipped — so `Codacy Coverage Variation` and `Codacy Diff Coverage` never post. Every PR is blocked behind branch protection.

This PR removes the broken `codacy-cli upload -s coverage.xml` line. The remaining pylint SARIF upload stays — pylint.sarif is real SARIF and works. Coverage upload is correctly handled by `codacy-coverage-reporter-action` in `.github/workflows/dotfiles-validation.yml`.

Renumbers stage banners from `[X/5]` to `[X/4]`.

## Test plan
- [x] uv run python -m unittest discover -s tests — 210 OK
- [ ] codacy-safety-net job reaches codacy-coverage-reporter-action step
- [ ] Codacy Coverage Variation and Codacy Diff Coverage post on this PR