### PR TITLE
fix(quality): drop broken codacy-cli coverage.xml upload from Stage 4

### DIFF
--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -88,20 +88,13 @@ SARIF="/tmp/pylint-$$.sarif"
 codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
 
 # ----------------------------------------------------------------------------
-# Stage 4: coverage upload (skipped in --codacy-only mode and when no token)
+# Stage 4: coverage upload — handled by .github/workflows/dotfiles-validation.yml
+# via codacy/codacy-coverage-reporter-action. We do NOT upload coverage here:
+# `codacy-cli upload` accepts only SARIF, not coverage.xml, and would die with
+# "invalid character '<'", killing the pipeline before SARIF upload runs.
+# Local push: the workflow uploads coverage on its own schedule.
 # ----------------------------------------------------------------------------
 HEAD_SHA="$(git rev-parse HEAD)"
-
-if (( CODACY_ONLY == 0 )); then
-  echo -e "\n${CYAN}[STAGE 4/7] Uploading coverage to Codacy (commit $HEAD_SHA)...${NC}"
-  if [[ -z "$TOKEN" ]]; then
-    echo -e "${YELLOW}⚠ CODACY_PROJECT_TOKEN not set — skipping coverage upload.${NC}"
-  elif [[ "${SKIP_CODACY_UPLOAD:-0}" = "1" ]]; then
-    echo -e "${YELLOW}⚠ SKIP_CODACY_UPLOAD=1 — skipping coverage upload by request.${NC}"
-  else
-    codacy-cli upload -s coverage.xml -c "$HEAD_SHA" -t "$TOKEN"
-  fi
-fi
 
 # ----------------------------------------------------------------------------
 # Stages 5-6: SARIF upload for HEAD and merge-base (with retry)


### PR DESCRIPTION
PR #186 wrapped Stage 4's broken `codacy-cli upload -s coverage.xml` call in a token check, but preserved the broken call itself. With CODACY_PROJECT_TOKEN set in CI, every workflow still dies at Stage 4 with:

```
Loading SARIF file from path: coverage.xml
Parsing SARIF file...
Error parsing SARIF file: invalid character '<' looking for beginning of value
##[error]Process completed with exit code 1.
```

`set -e` aborts the pipeline before Stage 5 (the SARIF upload that actually works) runs, so `Codacy Coverage Variation` / `Codacy Diff Coverage` never post. PR #184 currently sits blocked because of this.

Coverage upload belongs to the workflow's `codacy-coverage-reporter-action` step (`.github/workflows/dotfiles-validation.yml`), which is the correct uploader for `coverage.xml`. Stage 4 was duplicating that work with the wrong tool.

This PR removes Stage 4 entirely. Stages 5+ (SARIF analysis upload) keep working.

## Test plan
- [x] `uv run python -m unittest discover -s tests` — 210 OK
- [ ] codacy-safety-net workflow on this PR reaches the codacy-coverage-reporter-action step
- [ ] All four required Codacy checks post