### PR TITLE
fix(ship): point CODACY_PROJECT_TOKEN error at repair-codacy-env

### DIFF
--- a/setup
+++ b/setup
@@ -657,7 +657,7 @@ cmd_ship() {
 
   echo "[ship] step 1: verifying CODACY_PROJECT_TOKEN"
   [[ -n "${CODACY_PROJECT_TOKEN:-}" ]] \
-    || die "CODACY_PROJECT_TOKEN is not set; export it (cat ~/.codacy/<owner>-<repo>.project-token) before running ./setup ship"
+    || die "CODACY_PROJECT_TOKEN is not set. Run './setup repair-codacy-env' to regenerate .envrc.local with all existing token exports, then 'direnv allow .' before retrying ./setup ship."
 
   echo "[ship] step 2: verifying required CLIs (codacy-cli gh git jq)"
   local missing=()

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -946,6 +946,17 @@ exit 64
         self.assertEqual(extra_args.returncode, 2)
         self.assertIn("ship accepts at most one PR number", extra_args.stderr)
 
+    def test_ship_missing_token_error_mentions_repair_command(self) -> None:
+        setup_text = SETUP.read_text()
+        die_lines = [
+            line for line in setup_text.splitlines()
+            if "CODACY_PROJECT_TOKEN is not set" in line
+        ]
+        self.assertEqual(len(die_lines), 1, die_lines)
+        die_line = die_lines[0]
+        self.assertIn("repair-codacy-env", die_line)
+        self.assertIn("direnv allow", die_line)
+
     def test_ship_rejects_ambiguous_auto_detected_prs(self) -> None:
         repo, _base_sha, head_sha = self.make_ship_repo()
         home = self.make_home()


### PR DESCRIPTION
## Summary
- Replace the ad-hoc `cat ~/.codacy/<owner>-<repo>.project-token` hint in the `./setup ship` step-1 error with a pointer to the new `./setup repair-codacy-env` subcommand and `direnv allow .`, so users land on the durable fix instead of a one-off shell export.
- Add `test_ship_missing_token_error_mentions_repair_command` to `tests/test_setup_script.py` so the message keeps mentioning both `repair-codacy-env` and `direnv allow`.

## Context
This is Unit 4 of 5 in a parallel decomposition. The sibling Unit 2 PR adds the `repair-codacy-env` subcommand; this message is forward-looking and assumes that lands as well.

## Test plan
- [x] `uv run python -m unittest discover -s tests` (218 tests, all green)
- [x] Manual smoke: `unset CODACY_PROJECT_TOKEN; ./setup ship 192 2>&1 | head -3` shows the new message verbatim.