### PR TITLE
feat(setup): add repair-codacy-env non-interactive subcommand

### DIFF
--- a/setup
+++ b/setup
@@ -73,6 +73,12 @@ Commands:
       base, poll the four required Codacy checks, then squash-merge. Requires
       CODACY_PROJECT_TOKEN and an authenticated gh.
 
+  repair-codacy-env [<project>] [--project PATH] [--owner OWNER] [--repo REPO]
+      Non-interactive: regenerate the managed Codacy block in
+      <project>/.envrc.local based on token files present in \$HOME/.codacy/.
+      Detects owner/repo from the project's origin remote unless provided.
+      Exits non-zero if owner/repo cannot be resolved or no token files exist.
+
   help, -h, --help
       Show this message.
 
@@ -1448,6 +1454,98 @@ EOF
   fi
 }
 
+cmd_repair_codacy_env() {
+  local project="" owner="" repo=""
+  while (($#)); do
+    case "$1" in
+      -h|--help)
+        usage
+        return 0
+        ;;
+      --project)
+        [[ $# -ge 2 ]] || die "--project requires a value"
+        project="$2"; shift 2
+        ;;
+      --owner)
+        [[ $# -ge 2 ]] || die "--owner requires a value"
+        owner="$2"; shift 2
+        ;;
+      --repo)
+        [[ $# -ge 2 ]] || die "--repo requires a value"
+        repo="$2"; shift 2
+        ;;
+      -*)
+        die "unknown flag for repair-codacy-env: $1"
+        ;;
+      *)
+        [[ -z "$project" ]] || die "repair-codacy-env accepts at most one project path"
+        project="$1"; shift
+        ;;
+    esac
+  done
+  [[ -n "$project" ]] || project="$PWD"
+  [[ -d "$project" ]] || die "project path is not a directory: $project"
+  project="$(cd -P "$project" && pwd)"
+  if [[ -z "$owner" || -z "$repo" ]]; then
+    local detected detected_lines
+    if detected="$(detect_github_identity "$project")"; then
+      mapfile -t detected_lines <<<"$detected"
+      [[ -n "$owner" ]] || owner="${detected_lines[0]:-}"
+      [[ -n "$repo"  ]] || repo="${detected_lines[1]:-}"
+    fi
+  fi
+  if [[ -z "$owner" || -z "$repo" ]]; then
+    die "could not detect GitHub owner/repo from origin remote in '$project'; pass --owner and --repo"
+  fi
+
+  local token_dir="$HOME/.codacy"
+  local account_file="$token_dir/account-token"
+  local project_basename="$(codacy_safe_name "$owner")-$(codacy_safe_name "$repo").project-token"
+  local project_file="$token_dir/$project_basename"
+  local has_account=0 has_project=0
+  [[ -f "$account_file" ]] && has_account=1
+  [[ -f "$project_file" ]] && has_project=1
+  if [[ "$has_account" -eq 0 && "$has_project" -eq 0 ]]; then
+    die "no Codacy token files found under '$token_dir'; create $account_file or $project_file first"
+  fi
+
+  local provider owner_escaped repo_escaped
+  provider="$(escape_env_double_quoted "gh")"
+  owner_escaped="$(escape_env_double_quoted "$owner")"
+  repo_escaped="$(escape_env_double_quoted "$repo")"
+
+  local block=""
+  block+="$CODACY_SECTION_BEGIN"$'\n'
+  block+="export CODACY_ORGANIZATION_PROVIDER=\"$provider\""$'\n'
+  block+="export CODACY_USERNAME=\"$owner_escaped\""$'\n'
+  block+="export CODACY_PROJECT_NAME=\"$repo_escaped\""$'\n'
+  local exported=()
+  if [[ "$has_account" -eq 1 ]]; then
+    block+="export CODACY_ACCOUNT_TOKEN=\"\$(cat \"$account_file\")\""$'\n'
+    block+="export CODACY_API_TOKEN=\"\$(cat \"$account_file\")\""$'\n'
+    exported+=("CODACY_ACCOUNT_TOKEN" "CODACY_API_TOKEN")
+  fi
+  if [[ "$has_project" -eq 1 ]]; then
+    block+="export CODACY_PROJECT_TOKEN=\"\$(cat \"$project_file\")\""$'\n'
+    exported+=("CODACY_PROJECT_TOKEN")
+  fi
+  block+="$CODACY_SECTION_END"
+
+  local envrc_local="$project/.envrc.local"
+  local envrc_local_content
+  envrc_local_content="$(build_envrc_local_content "$envrc_local" "$block")"
+  write_file_if_changed "$envrc_local" "$envrc_local_content" 600
+
+  echo "Codacy environment repaired for $owner/$repo"
+  echo "  Project: $project"
+  echo "  Wrote: $envrc_local"
+  echo "  Token files detected:"
+  [[ "$has_account" -eq 1 ]] && echo "    - $account_file"
+  [[ "$has_project" -eq 1 ]] && echo "    - $project_file"
+  local IFS=' '
+  echo "  Exports written: ${exported[*]}"
+}
+
 configure_machine_api_tokens() {
   while true; do
     echo
@@ -1706,6 +1804,7 @@ main() {
     doctor) cmd_doctor "$@" ;;
     quality) cmd_quality "$@" ;;
     ship)   cmd_ship "$@" ;;
+    repair-codacy-env) cmd_repair_codacy_env "$@" ;;
     help|-h|--help) usage ;;
     *)
       if [[ $# -eq 0 && -d "$sub" ]]; then

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1060,6 +1060,143 @@ exit 64
         self.assertIn("required checks are green but mergeStateStatus is UNSTABLE", result.stdout)
         self.assertIn("PR #17 is MERGED", result.stdout)
 
+    def make_repair_project(self, *, with_remote: bool = True) -> Path:
+        project = self.make_project()
+        subprocess.run(  # nosec B603
+            [shutil.which("git") or "git", "init", "-q"],
+            capture_output=True,
+            text=True,
+            cwd=str(project),
+            check=True,
+        )
+        if with_remote:
+            subprocess.run(  # nosec B603
+                [shutil.which("git") or "git", "remote", "add", "origin", "https://github.com/test/test.git"],
+                capture_output=True,
+                text=True,
+                cwd=str(project),
+                check=True,
+            )
+        return project
+
+    def write_codacy_token(self, home: Path, basename: str, value: str) -> Path:
+        token_dir = home / ".codacy"
+        token_dir.mkdir(parents=True, exist_ok=True)
+        token_dir.chmod(0o700)
+        path = token_dir / basename
+        path.write_text(value + "\n")
+        path.chmod(0o600)
+        return path
+
+    def test_repair_codacy_env_regenerates_block_for_existing_token_files(self) -> None:
+        project = self.make_repair_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_codacy_token(home, "account-token", "fake-account")
+        self.write_codacy_token(home, "test-test.project-token", "fake-project")
+
+        result = run_setup(
+            "repair-codacy-env", "--owner", "test", "--repo", "test", "--project", str(project),
+            env=self.env_for(bin_dir, home),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        local_text = (project / ".envrc.local").read_text()
+        self.assertIn("# BEGIN DOTFILES CODACY", local_text)
+        self.assertIn("# END DOTFILES CODACY", local_text)
+        self.assertIn('CODACY_ORGANIZATION_PROVIDER="gh"', local_text)
+        self.assertIn('CODACY_USERNAME="test"', local_text)
+        self.assertIn('CODACY_PROJECT_NAME="test"', local_text)
+        self.assertIn("export CODACY_ACCOUNT_TOKEN=", local_text)
+        self.assertIn("export CODACY_API_TOKEN=", local_text)
+        self.assertIn("export CODACY_PROJECT_TOKEN=", local_text)
+        self.assertNotIn("fake-account", local_text)
+        self.assertNotIn("fake-project", local_text)
+        self.assertNotIn("fake-account", result.stdout)
+        self.assertNotIn("fake-project", result.stdout)
+        self.assertEqual(oct((project / ".envrc.local").stat().st_mode & 0o777), "0o600")
+
+    def test_repair_codacy_env_only_one_token(self) -> None:
+        project = self.make_repair_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_codacy_token(home, "test-test.project-token", "fake-project")
+
+        result = run_setup(
+            "repair-codacy-env", "--owner", "test", "--repo", "test", "--project", str(project),
+            env=self.env_for(bin_dir, home),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        local_text = (project / ".envrc.local").read_text()
+        self.assertIn("export CODACY_PROJECT_TOKEN=", local_text)
+        self.assertNotIn("export CODACY_API_TOKEN=", local_text)
+        self.assertNotIn("export CODACY_ACCOUNT_TOKEN=", local_text)
+
+    def test_repair_codacy_env_fails_clearly_when_no_token_files_found(self) -> None:
+        project = self.make_repair_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        (home / ".codacy").mkdir()
+
+        result = run_setup(
+            "repair-codacy-env", "--owner", "test", "--repo", "test", "--project", str(project),
+            env=self.env_for(bin_dir, home),
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("no Codacy token files found", result.stderr)
+        self.assertFalse((project / ".envrc.local").exists())
+
+    def test_repair_codacy_env_fails_when_owner_repo_cannot_be_detected(self) -> None:
+        project = self.make_repair_project(with_remote=False)
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_codacy_token(home, "account-token", "fake-account")
+
+        result = run_setup(
+            "repair-codacy-env", "--project", str(project),
+            env=self.env_for(bin_dir, home),
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("could not detect GitHub owner/repo", result.stderr)
+        self.assertFalse((project / ".envrc.local").exists())
+
+    def test_repair_codacy_env_preserves_user_managed_envrc_local_lines(self) -> None:
+        project = self.make_repair_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_codacy_token(home, "account-token", "fake-account")
+        (project / ".envrc.local").write_text("# user header\nexport USER_VAR=1\n")
+
+        result = run_setup(
+            "repair-codacy-env", "--owner", "test", "--repo", "test", "--project", str(project),
+            env=self.env_for(bin_dir, home),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        local_text = (project / ".envrc.local").read_text()
+        self.assertIn("# user header", local_text)
+        self.assertIn("export USER_VAR=1", local_text)
+        self.assertEqual(local_text.count("# BEGIN DOTFILES CODACY"), 1)
+        self.assertEqual(local_text.count("# END DOTFILES CODACY"), 1)
+
+    def test_repair_codacy_env_detects_owner_repo_from_origin_remote(self) -> None:
+        project = self.make_repair_project()
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_codacy_token(home, "test-test.project-token", "fake-project")
+
+        env = self.env_for(bin_dir, home)
+        result = run_setup("repair-codacy-env", cwd=project, env=env)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        local_text = (project / ".envrc.local").read_text()
+        self.assertIn('CODACY_USERNAME="test"', local_text)
+        self.assertIn('CODACY_PROJECT_NAME="test"', local_text)
+        self.assertIn("export CODACY_PROJECT_TOKEN=", local_text)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## Summary
- Adds `./setup repair-codacy-env [<project>] [--owner OWNER] [--repo REPO] [--project PATH]` — a non-interactive subcommand that regenerates the managed Codacy block in `<project>/.envrc.local` based on the token files actually present under `$HOME/.codacy/`.
- Owner/repo are detected from the project's `origin` remote (via the existing `detect_github_identity`) unless overridden by flags. Exits non-zero with a clear message when owner/repo cannot be resolved or no token files are found.
- Walks `~/.codacy/account-token` and `~/.codacy/<safe-owner>-<safe-repo>.project-token`; emits one `export ...` line per token file that exists, plus the `CODACY_ORGANIZATION_PROVIDER`/`CODACY_USERNAME`/`CODACY_PROJECT_NAME` metadata exports. Token values are never printed or written into the project file (block uses `$(cat "...")` at direnv-load time).
- Self-contained block construction so this unit can ship independently of any sibling refactor of `build_codacy_managed_section`.
- Reuses existing helpers: `detect_github_identity`, `codacy_safe_name`, `escape_env_double_quoted`, `build_envrc_local_content`, `write_file_if_changed`.

Motivates: `./setup ship 192` previously failed because `.envrc.local` (generated when option 2 was picked in the Codacy menu) never wrote a `CODACY_PROJECT_TOKEN` export, even though `~/.codacy/<owner>-<repo>.project-token` existed on disk. This subcommand lets users (and scripts) re-emit the managed block from disk truth.

## Test plan
- [x] `uv run python -m unittest discover -s tests` — 223 tests pass
- [x] `bash -n setup` — clean
- [x] Manual smoke: both tokens, only project token, no tokens (non-zero exit), no remote no flags (non-zero exit), preserves user-managed lines outside the managed block
- [x] Six new tests in `tests/test_setup_script.py` cover all four required scenarios plus the auto-detect-from-remote path

🤖 Generated with [Claude Code](https://claude.com/claude-code)