### PR TITLE
fix(ship): pass -o/-p/-r flags to codacy-cli upload for reliable project mapping

### DIFF
--- a/setup
+++ b/setup
@@ -657,7 +657,7 @@ cmd_ship() {
 
   echo "[ship] step 1: verifying CODACY_PROJECT_TOKEN"
   [[ -n "${CODACY_PROJECT_TOKEN:-}" ]] \
-    || die "CODACY_PROJECT_TOKEN is not set; export it (cat ~/.codacy/<owner>-<repo>.project-token) before running ./setup ship"
+    || die "CODACY_PROJECT_TOKEN is not set — run: ./setup repair-codacy-env"
 
   echo "[ship] step 2: verifying required CLIs (codacy-cli gh git jq)"
   local missing=()
@@ -776,7 +776,7 @@ cmd_ship() {
       || die "codacy-cli analyze produced no SARIF at $_ship_head_sarif (check .codacy/codacy.yaml in the head worktree)"
 
     echo "[ship] step 4e: uploading SARIF for HEAD ($head_oid)"
-    ( cd "$_ship_head_wt" && codacy-cli upload -s "$_ship_head_sarif" -c "$head_oid" -t "$CODACY_PROJECT_TOKEN" ) \
+    ship_upload_sarif "$_ship_head_wt" "$_ship_head_sarif" "$head_oid" \
       || die "codacy-cli upload (HEAD) failed"
 
     echo "[ship] step 4f: fetching base branch origin/$base_ref_name"
@@ -796,7 +796,7 @@ cmd_ship() {
       || die "codacy-cli analyze produced no SARIF at $_ship_base_sarif (check .codacy/codacy.yaml in the base worktree)"
 
     echo "[ship] step 4i: uploading SARIF for base ($base_sha)"
-    ( cd "$_ship_base_wt" && codacy-cli upload -s "$_ship_base_sarif" -c "$base_sha" -t "$CODACY_PROJECT_TOKEN" ) \
+    ship_upload_sarif "$_ship_base_wt" "$_ship_base_sarif" "$base_sha" \
       || die "codacy-cli upload (base) failed"
 
     local interval="${SHIP_CHECK_INTERVAL:-15}" timeout="${SHIP_CHECK_TIMEOUT:-900}"
@@ -1160,6 +1160,17 @@ detect_github_identity() {
     [[ -n "$owner" && -n "$repo" && "$repo_part" == */* ]] || return 1
   }
   printf '%s\n%s\n' "$owner" "$repo"
+}
+
+ship_upload_sarif() {
+  local worktree="$1" sarif="$2" commit="$3"
+  ( cd "$worktree" && codacy-cli upload \
+      -s "$sarif" \
+      -c "$commit" \
+      -t "$CODACY_PROJECT_TOKEN" \
+      -o "${CODACY_USERNAME:-}" \
+      -p "${CODACY_ORGANIZATION_PROVIDER:-gh}" \
+      -r "${CODACY_PROJECT_NAME:-}" )
 }
 
 ship_prepare_codacy_worktree() {


### PR DESCRIPTION
## Summary

- Extracts `ship_upload_sarif(worktree, sarif, commit)` helper alongside `ship_prepare_codacy_worktree`
- New helper explicitly passes `-o/${CODACY_USERNAME}`, `-p/${CODACY_ORGANIZATION_PROVIDER:-gh}`, `-r/${CODACY_PROJECT_NAME}` to every `codacy-cli upload` call
- Simplifies `CODACY_PROJECT_TOKEN` die message to point at `./setup repair-codacy-env`

## Why

The two inline `codacy-cli upload` calls only passed `-s/-c/-t`. Without `-o/-p/-r`, Codacy has to infer the project from env vars — which weren't loaded in agent sessions because the SessionStart hook didn't exist yet. This was the root cause behind PR #192's 30-commit fix loop: uploads succeeded (200 OK) but Codacy mapped them to no project, leaving `Codacy Static Code Analysis` stuck at `action_required`.

## Test plan

- [x] `bash -n setup` — syntax clean
- [ ] CI `codacy-safety-net` check passes
- [ ] `./setup ship <PR#>` completes without the `Codacy Static Code Analysis` stuck at action_required

🤖 Generated with [Claude Code](https://claude.com/claude-code)