### PR TITLE
fix(hooks): redirect pre-push stdin so unittest does not consume push refs

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -21,11 +21,21 @@ FAILED=0
 # ----------------------------------------------------------------------------
 # 1. UNIT TESTS (Hard requirement)
 # ----------------------------------------------------------------------------
+# `git push` feeds the list of refs to the hook on stdin; some children read
+# that stdin and behave incorrectly. Redirect stdin to /dev/null up-front.
+exec </dev/null
+
 echo -e "\n${YELLOW}[1/5] Running unit tests...${NC}"
-if uv run python -m unittest discover -s tests; then
+# `git push` exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE for the hook;
+# subprocess-based tests that shell out to git inherit those and resolve to
+# this repo even when chdir'd elsewhere. Unset them for the test run only.
+if env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+        -u GIT_REFLOG_ACTION -u GIT_EXEC_PATH \
+        uv run python -m unittest discover -s tests; then
     echo -e "${GREEN}✓ All unit tests passed${NC}"
 else
-    echo -e "${RED}✗ Unit tests failed - BLOCKING${NC}"
+    rc=$?
+    echo -e "${RED}✗ Unit tests failed (exit $rc) - BLOCKING${NC}"
     FAILED=1
 fi
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,9 +1,131 @@
 #!/usr/bin/env bash
-# Pre-push hook: runs the canonical quality pipeline (tests, coverage,
-# Codacy analysis, upload) before allowing the push.
-# Bypass with: git push --no-verify (the GitHub Actions safety-net will
-# catch missed analysis uploads, but tests will not be re-run.)
+# Pre-push hook: enforce quality checks before pushing to remote.
+# Bypass with: git push --no-verify (not recommended).
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-exec bash "$REPO_ROOT/scripts/quality-pipeline.sh"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}Running Pre-Push Quality Checks${NC}"
+echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"
+
+FAILED=0
+
+# ----------------------------------------------------------------------------
+# 1. UNIT TESTS (Hard requirement)
+# ----------------------------------------------------------------------------
+echo -e "\n${YELLOW}[1/5] Running unit tests...${NC}"
+if uv run python -m unittest discover -s tests; then
+    echo -e "${GREEN}✓ All unit tests passed${NC}"
+else
+    echo -e "${RED}✗ Unit tests failed - BLOCKING${NC}"
+    FAILED=1
+fi
+
+# Subsequent steps look at modified Python files in dotfiles_tools/.
+MODIFIED_FILES=$(git diff origin/main...HEAD --name-only --diff-filter=ACM 2>/dev/null \
+    | grep 'dotfiles_tools/.*\.py$' || true)
+
+# ----------------------------------------------------------------------------
+# 2. COMPLEXITY CHECK (radon)
+# ----------------------------------------------------------------------------
+echo -e "\n${YELLOW}[2/5] Checking complexity of modified files...${NC}"
+if [ -z "$MODIFIED_FILES" ]; then
+    echo -e "${GREEN}✓ No modified Python files to check${NC}"
+else
+    for file in $MODIFIED_FILES; do
+        echo "   Analyzing: $file"
+        RESULT=$(uv run --with radon radon cc "$file" -a 2>&1 | tail -1)
+        echo "   $RESULT"
+        AVG=$(echo "$RESULT" | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        if [ -n "$AVG" ] && awk "BEGIN {exit !($AVG > 5)}"; then
+            echo -e "   ${RED}✗ Average complexity $AVG exceeds 5.0${NC}"
+            FAILED=1
+        fi
+    done
+fi
+
+# ----------------------------------------------------------------------------
+# 3. TYPE ANNOTATIONS (warning only)
+# ----------------------------------------------------------------------------
+echo -e "\n${YELLOW}[3/5] Checking type annotations in modified files...${NC}"
+if [ -z "$MODIFIED_FILES" ]; then
+    echo -e "${GREEN}✓ No modified Python files to check${NC}"
+else
+    MISSING=0
+    for file in $MODIFIED_FILES; do
+        TOTAL=$(grep -c "^def " "$file" 2>/dev/null || echo 0)
+        ANNOTATED=$(grep -c "^def .* -> " "$file" 2>/dev/null || echo 0)
+        PRIVATE=$(grep -c "^def _" "$file" 2>/dev/null || echo 0)
+        MISSING_COUNT=$((TOTAL - ANNOTATED - PRIVATE))
+        if [ "$MISSING_COUNT" -gt 0 ]; then
+            echo -e "   ${YELLOW}⚠ $file: $MISSING_COUNT public functions may lack return types${NC}"
+            MISSING=$((MISSING + MISSING_COUNT))
+        fi
+    done
+    if [ "$MISSING" -eq 0 ]; then
+        echo -e "${GREEN}✓ Type annotations look good${NC}"
+    else
+        echo -e "   ${YELLOW}(Warnings only - not blocking)${NC}"
+    fi
+fi
+
+# ----------------------------------------------------------------------------
+# 4. LINE LENGTH (warning only)
+# ----------------------------------------------------------------------------
+echo -e "\n${YELLOW}[4/5] Checking line length in modified files...${NC}"
+if [ -z "$MODIFIED_FILES" ]; then
+    echo -e "${GREEN}✓ No modified Python files to check${NC}"
+else
+    LONG_LINES=0
+    for file in $MODIFIED_FILES; do
+        COUNT=$(awk 'length > 79 {count++} END {print count+0}' "$file")
+        if [ "$COUNT" -gt 0 ]; then
+            echo -e "   ${YELLOW}⚠ $file: $COUNT lines exceed 79 characters${NC}"
+            LONG_LINES=$((LONG_LINES + COUNT))
+        fi
+    done
+    if [ "$LONG_LINES" -eq 0 ]; then
+        echo -e "${GREEN}✓ Line length looks good${NC}"
+    else
+        echo -e "   ${YELLOW}(Warnings only - not blocking)${NC}"
+    fi
+fi
+
+# ----------------------------------------------------------------------------
+# 5. CODACY STATIC-ANALYSIS SARIF UPLOAD
+# ----------------------------------------------------------------------------
+echo -e "\n${YELLOW}[5/5] Codacy static-analysis SARIF upload...${NC}"
+if [[ -z "${CODACY_PROJECT_TOKEN:-}" ]]; then
+    echo -e "${GREEN}✓ CODACY_PROJECT_TOKEN unset — skipping (no upload to GitHub App).${NC}"
+elif [[ "${SKIP_CODACY_UPLOAD:-0}" == "1" ]]; then
+    echo -e "${GREEN}✓ SKIP_CODACY_UPLOAD=1 — skipping by request.${NC}"
+else
+    if bash "$REPO_ROOT/scripts/quality-pipeline.sh" --codacy-only; then
+        echo -e "${GREEN}✓ Codacy SARIF uploaded${NC}"
+    else
+        echo -e "${RED}✗ Codacy SARIF upload failed - BLOCKING${NC}"
+        FAILED=1
+    fi
+fi
+
+# ----------------------------------------------------------------------------
+# RESULT
+# ----------------------------------------------------------------------------
+echo -e "\n${BLUE}════════════════════════════════════════════════════════${NC}"
+if [ "$FAILED" -eq 0 ]; then
+    echo -e "${GREEN}✓ All critical checks passed!${NC}"
+    echo -e "${BLUE}Ready to push to remote${NC}"
+else
+    echo -e "${RED}✗ Critical checks failed!${NC}"
+    echo -e "${RED}Fix the issues above and try again.${NC}"
+    exit 1
+fi
+echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"

--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
-# Local quality pipeline: tests -> coverage -> static analysis -> upload to Codacy.
-# Invoked from scripts/hooks/pre-push and `setup quality`.
-# Fails fast on any step. Blocks if Codacy upload fails.
+# Local quality pipeline.
+#
+# Stages:
+#   1. Unit tests
+#   2. Coverage XML
+#   3. Pylint analysis (SARIF)
+#   4. Coverage upload to Codacy
+#   5. SARIF upload to Codacy (HEAD)
+#   6. SARIF upload to Codacy (merge-base) -- so PR diff has a baseline
+#   7. Codacy server-side gate (informational)
+#
+# Modes:
+#   (default)        run stages 1-7
+#   --codacy-only    run only stages 3, 5, 6, 7 against working tree HEAD.
+#                    Used by the pre-push hook so the static-analysis SARIF
+#                    is uploaded BEFORE the push completes; lets the four
+#                    required GitHub checks go green automatically.
 #
 # Exit codes:
 #   0  pipeline passed
@@ -12,22 +26,31 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+CODACY_ONLY=0
+if [[ "${1:-}" == "--codacy-only" ]]; then
+  CODACY_ONLY=1
+fi
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
 # ----------------------------------------------------------------------------
-# Prerequisite validation: check everything up front, report all problems,
-# then exit 3 if anything is missing. Avoids the "fix one, hit the next" loop.
+# Prerequisite validation
 # ----------------------------------------------------------------------------
 missing=()
 
-for cmd in gh uv codacy-cli; do
+required_cmds=(codacy-cli)
+if (( CODACY_ONLY == 0 )); then
+  required_cmds=(gh uv codacy-cli)
+fi
+
+for cmd in "${required_cmds[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing+=("command not on PATH: $cmd")
-  fi
-done
-
-# CODACY_PROJECT_TOKEN is what `codacy-cli upload` actually uses.
-for var in CODACY_PROJECT_TOKEN; do
-  if [[ -z "${!var:-}" ]]; then
-    missing+=("env var unset or empty: $var")
   fi
 done
 
@@ -42,34 +65,91 @@ if (( ${#missing[@]} > 0 )); then
   exit 3
 fi
 
-SHA="$(git rev-parse HEAD)"
-TOKEN="$CODACY_PROJECT_TOKEN"
+# Token may be absent in local dev; we skip the upload then rather than fail.
+TOKEN="${CODACY_PROJECT_TOKEN:-}"
 
 # ----------------------------------------------------------------------------
-# Pipeline stages
+# Stages 1-2: tests + coverage (skipped in --codacy-only mode)
 # ----------------------------------------------------------------------------
-echo "[1/5] Running unit tests..."
-uv run python -m unittest discover -s tests
+if (( CODACY_ONLY == 0 )); then
+  echo -e "${CYAN}[STAGE 1/7] Running unit tests...${NC}"
+  uv run python -m unittest discover -s tests
 
-echo "[2/5] Generating coverage..."
-uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
-uv run --with coverage==7.5.4 coverage xml
+  echo -e "${CYAN}[STAGE 2/7] Generating coverage XML...${NC}"
+  uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
+  uv run --with coverage==7.5.4 coverage xml
+fi
 
-echo "[3/5] Running pylint analysis..."
-codacy-cli analyze --tool pylint --format sarif -o pylint.sarif
+# ----------------------------------------------------------------------------
+# Stage 3: pylint SARIF analysis
+# ----------------------------------------------------------------------------
+echo -e "\n${CYAN}[STAGE 3/7] Running pylint analysis...${NC}"
+SARIF="/tmp/pylint-$$.sarif"
+codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
 
-echo "[4/5] Uploading coverage to Codacy (commit $SHA)..."
-codacy-cli upload -s coverage.xml -c "$SHA" -t "$TOKEN"
+# ----------------------------------------------------------------------------
+# Stage 4: coverage upload (skipped in --codacy-only mode and when no token)
+# ----------------------------------------------------------------------------
+HEAD_SHA="$(git rev-parse HEAD)"
 
-echo "[5/5] Uploading pylint analysis to Codacy (commit $SHA)..."
-codacy-cli upload -s pylint.sarif -c "$SHA" -t "$TOKEN"
+if (( CODACY_ONLY == 0 )); then
+  echo -e "\n${CYAN}[STAGE 4/7] Uploading coverage to Codacy (commit $HEAD_SHA)...${NC}"
+  if [[ -z "$TOKEN" ]]; then
+    echo -e "${YELLOW}⚠ CODACY_PROJECT_TOKEN not set — skipping coverage upload.${NC}"
+  elif [[ "${SKIP_CODACY_UPLOAD:-0}" = "1" ]]; then
+    echo -e "${YELLOW}⚠ SKIP_CODACY_UPLOAD=1 — skipping coverage upload by request.${NC}"
+  else
+    codacy-cli upload -s coverage.xml -c "$HEAD_SHA" -t "$TOKEN"
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Stages 5-6: SARIF upload for HEAD and merge-base (with retry)
+# ----------------------------------------------------------------------------
+echo -e "\n${CYAN}[STAGE 5/7] CODACY STATIC CODE ANALYSIS — SARIF UPLOAD${NC}"
+
+if [[ -z "$TOKEN" ]]; then
+  echo -e "${YELLOW}⚠ CODACY_PROJECT_TOKEN not set — skipping SARIF upload (the GH App may not post the static-analysis check without it).${NC}"
+elif [[ "${SKIP_CODACY_UPLOAD:-0}" = "1" ]]; then
+  echo -e "${YELLOW}⚠ SKIP_CODACY_UPLOAD=1 — skipping SARIF upload by request.${NC}"
+else
+  BASE_SHA="$(git merge-base HEAD origin/main 2>/dev/null || git rev-parse origin/main 2>/dev/null || echo "")"
+
+  upload_with_retry() {
+    local sha="$1"
+    local attempt
+    for attempt in 1 2; do
+      if codacy-cli upload -s "$SARIF" -c "$sha" -t "$TOKEN"; then
+        return 0
+      fi
+      echo -e "${YELLOW}Upload attempt $attempt failed for $sha; retrying in 5s...${NC}"
+      sleep 5
+    done
+    echo -e "${RED}✗ Codacy upload failed twice for $sha${NC}"
+    return 1
+  }
+
+  upload_with_retry "$HEAD_SHA" || exit 1
+
+  echo -e "\n${CYAN}[STAGE 6/7] SARIF upload for merge-base...${NC}"
+  if [[ -n "$BASE_SHA" && "$BASE_SHA" != "$HEAD_SHA" ]]; then
+    upload_with_retry "$BASE_SHA" || exit 1
+    echo -e "${GREEN}✓ SARIF uploaded for HEAD ($HEAD_SHA) and base ($BASE_SHA).${NC}"
+  else
+    echo -e "${GREEN}✓ HEAD is the merge-base; single upload covers PR diff.${NC}"
+  fi
+fi
+
+rm -f "$SARIF"
+
+# ----------------------------------------------------------------------------
+# Stage 7: server-side gate (informational)
+# ----------------------------------------------------------------------------
+echo -e "\n${CYAN}[STAGE 7/7] Codacy server-side gate (informational)${NC}"
+echo "  Codacy processes the uploaded artifacts asynchronously."
+echo "  The four required GitHub checks (incl. 'Codacy Static Code Analysis')"
+echo "  will turn green automatically once Codacy finishes processing."
 
 echo ""
-echo "Stage 7 (Codacy server-side gate): MANUAL"
-echo "  Local stages 1-5 passed. Codacy will process the uploaded artifacts"
-echo "  asynchronously. To verify the gate result, invoke the Codacy MCP tool"
-echo "  'codacy_get_repository_pull_request' from a Claude Code session, or"
-echo "  watch the GitHub PR status checks."
-echo ""
-echo "Exiting 0: local stages succeeded; Stage 7 remains informational."
+echo -e "${GREEN}✓ Quality pipeline complete${NC}"
 exit 0

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -26,6 +26,14 @@ class WorkflowTests(DotfilesTestCase):
     def test_quality_pipeline_is_non_blocking_and_uses_local_prereqs(self):
         pipeline = (REPO_ROOT / "scripts/quality-pipeline.sh").read_text()
         self.assertIn("exit 0", pipeline)
-        self.assertIn("Stage 7 (Codacy server-side gate): MANUAL", pipeline)
+        # Stage 7 is the server-side Codacy gate; it stays informational so a
+        # missing CODACY_PROJECT_TOKEN does not break local pre-push runs.
+        self.assertIn("[STAGE 7/7] Codacy server-side gate", pipeline)
+        # --codacy-only is the entry point used by the pre-push hook.
+        self.assertIn("--codacy-only", pipeline)
+        # SARIF must be uploaded for both HEAD and merge-base so Codacy can
+        # diff the PR; without the base upload, the GH App posts nothing.
+        self.assertIn("upload_with_retry", pipeline)
+        self.assertIn("git merge-base HEAD origin/main", pipeline)
         self.assertNotIn("CODACY_ACCOUNT_TOKEN", pipeline)
         self.assertNotIn("GITHUB_TOKEN", pipeline)


### PR DESCRIPTION
Auto-opened draft PR for `20260504-230504-codacy-pipeline-fix`. Ahead 2, behind 4. Unmerged-branch sweep — **triage required**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrZVV5FSa6KDxH15tEssHv)_