### PR TITLE
docs: add Local API Access section with direnv credential guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,24 @@ dotfiles-manifest.json  Source of truth for what installs where
 - Placeholders follow the pattern `{ {UPPER_SNAKE_CASE} }` (double-braces with no spaces) and must all be replaced before use.
 - No secrets, tokens, or API keys are stored anywhere in this repo. Auth files are excluded by `.gitignore` and the global git ignore.
 
+## Local API Access
+
+When this repo is opened in a shell that has loaded `.envrc` and `.envrc.local`,
+agents may use the following environment variables for local Codacy and GitHub
+billing workflows:
+
+- `CODACY_ACCOUNT_TOKEN`
+- `CODACY_ORGANIZATION_PROVIDER`
+- `CODACY_PROJECT_NAME`
+- `CODACY_PROJECT_TOKEN`
+- `CODACY_USERNAME`
+- `GH_BILLING_TOKEN`
+
+These values come from direnv-managed local environment files, not from the
+repository. Do not commit them, print them, or add them to tracked config. If
+the shell output shows `direnv: export ...`, treat those exports as available
+for the current session only.
+
 ## Symlink Convention
 
 `CLAUDE.md` and `GEMINI.md` at the repo root are symlinks to `AGENTS.md`. At the project level, `agents/CLAUDE.md.template` and `agents/GEMINI.md.template` are symlinks to `agents/AGENTS.md.template`. This keeps one source of truth per scope.


### PR DESCRIPTION
## Summary
- Add Local API Access section to AGENTS.md documenting how agents use direnv-loaded credentials
- Documents required variables: CODACY_ACCOUNT_TOKEN, CODACY_PROJECT_TOKEN, CODACY_USERNAME, CODACY_ORGANIZATION_PROVIDER, GH_BILLING_TOKEN
- Clarifies credentials come from .envrc/.envrc.local and must never be committed
- Instructs agents to treat direnv exports as session-only values

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm no secrets or tokens are present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)