### PR TITLE
Fix coverage upload: use modern get.sh endpoint + wire GITHUB_TOKEN after gh auth

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -80,7 +80,8 @@ jobs:
 
       - name: Upload coverage to Codacy
         if: steps.codacy_status.outputs.status != 'analyzed' && env.CODACY_PROJECT_TOKEN != ''
-        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
+        continue-on-error: true
+        run: |
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+            --project-token "$CODACY_PROJECT_TOKEN" \
+            -r coverage.xml

--- a/setup
+++ b/setup
@@ -1635,7 +1635,22 @@ EOF
   done
 }
 
+ensure_github_token_in_envrc_local() {
+  local envrc_local="$1"
+  local token_line='export GITHUB_TOKEN="$(gh auth token 2>/dev/null)"'
+  if grep -qF 'GITHUB_TOKEN' "$envrc_local" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s\n' "$token_line" >> "$envrc_local"
+  chmod 600 "$envrc_local"
+  echo "  GITHUB_TOKEN added to $envrc_local"
+  if command -v direnv >/dev/null 2>&1; then
+    direnv allow "$(dirname "$envrc_local")" 2>/dev/null || true
+  fi
+}
+
 configure_gh_auth() {
+  local project="${1:-}"
   echo
   echo "Setting up GitHub (gh) authentication..."
   if ! command -v gh >/dev/null 2>&1; then
@@ -1660,6 +1675,12 @@ configure_gh_auth() {
     gh auth login
     if gh auth status >/dev/null 2>&1; then
       echo "✓ GitHub authentication configured"
+      if [[ -n "$project" ]]; then
+        local envrc_local="$project/.envrc.local"
+        if [[ -f "$envrc_local" ]]; then
+          ensure_github_token_in_envrc_local "$envrc_local"
+        fi
+      fi
     fi
   fi
 }
@@ -1749,7 +1770,7 @@ optional_integrations_menu() {
       echo "No optional integration selection received; project files were not changed."
       return 10
     elif [[ -n "$gh_num" && "$choice" == "$gh_num" ]]; then
-      configure_gh_auth
+      configure_gh_auth "$project"
     elif [[ "$choice" == "$codacy_num" ]]; then
       configure_codacy_env "$project"
     else


### PR DESCRIPTION
## Summary

- Replace deprecated `codacy/codacy-coverage-reporter-action` (hitting dead API endpoint) with direct `https://coverage.codacy.com/get.sh` call
- Add `continue-on-error: true` on upload step so coverage failure doesn't block the safety-net job
- Add `ensure_github_token_in_envrc_local()` helper in `setup` to idempotently append `GITHUB_TOKEN` to `.envrc.local` after `gh auth login`

## Why the old action failed

The `codacy-coverage-reporter-action@89d6c85` was calling a legacy API URL that now returns 404. The new direct `get.sh` approach uses the current `https://coverage.codacy.com` endpoint.

## Test plan

- [ ] Codacy Safety Net workflow runs and passes on this PR
- [ ] Coverage step completes without failing the job
- [ ] `uv run python -m unittest discover -s tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)