### PR TITLE
Simplify CI: drop local codacy-cli, keep tests + coverage upload

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -1,4 +1,4 @@
-name: Codacy Safety Net
+name: Dotfiles Validation
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: codacy-safety-net-${{ github.ref }}
+  group: dotfiles-validation-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,70 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Check if Codacy already has data for this commit
-        id: codacy_status
-        run: |
-          if [ -z "$CODACY_PROJECT_TOKEN" ]; then
-            echo "status=missing" >> "$GITHUB_OUTPUT"
-            echo "No CODACY_PROJECT_TOKEN configured; will run analysis."
-            exit 0
-          fi
-          STATUS=$(curl -s -H "api-token: $CODACY_PROJECT_TOKEN" \
-            "https://api.codacy.com/2.0/commit/$SHA/quality-status" \
-            | grep -oE '"state"[[:space:]]*:[[:space:]]*"[^"]*"' \
-            | head -1 \
-            | sed -E 's/.*"state"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
-            || echo "missing")
-          STATUS="${STATUS:-missing}"
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "Codacy status for $SHA: $STATUS"
-
-      - name: Skip if Codacy already analyzed this commit
-        if: steps.codacy_status.outputs.status == 'analyzed'
-        run: echo "Codacy already has data for $SHA. Local pre-push hook ran successfully. Nothing to do."
-
       - name: Set up uv
-        if: steps.codacy_status.outputs.status != 'analyzed'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
-        with:
-          cache-dependency-glob: |
-            scripts/quality-pipeline.sh
 
-      - name: Install Codacy CLI
-        if: steps.codacy_status.outputs.status != 'analyzed'
-        run: |
-          set -euo pipefail
-          # Run the upstream installer in "download" mode so it just fetches
-          # the binary into $HOME/.cache/codacy/codacy-cli-v2/<version>/ and
-          # exits, rather than executing the CLI with no arguments.
-          bash <(curl -Ls https://raw.githubusercontent.com/codacy/codacy-cli-v2/main/codacy-cli.sh) download
-          # The binary is named codacy-cli-v2; expose it on PATH under both
-          # that name and the historical "codacy-cli" alias for any caller
-          # that still uses the old name. Each step runs in a fresh shell, so
-          # we publish the install dir via $GITHUB_PATH instead of `export`.
-          CLI_PATH=$(find "$HOME/.cache/codacy/codacy-cli-v2" -name 'codacy-cli-v2' -type f -executable 2>/dev/null | head -1)
-          if [ -z "$CLI_PATH" ]; then
-            echo "codacy-cli-v2 binary not found after install" >&2
-            exit 1
-          fi
-          INSTALL_DIR="$HOME/.local/bin"
-          mkdir -p "$INSTALL_DIR"
-          ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli-v2"
-          ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli"
-          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-          echo "Installed codacy-cli-v2 at $CLI_PATH; symlinked into $INSTALL_DIR"
+      - name: Run unit tests with coverage
+        run: uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests
 
-      - name: Run quality pipeline (fallback path)
-        if: steps.codacy_status.outputs.status != 'analyzed'
-        run: bash scripts/quality-pipeline.sh
+      - name: Generate coverage XML
+        run: uv run --with coverage==7.5.4 coverage xml
 
       - name: Upload coverage to Codacy
-        if: steps.codacy_status.outputs.status != 'analyzed' && env.CODACY_PROJECT_TOKEN != ''
+        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
         continue-on-error: true
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report \

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -25,27 +25,24 @@ class WorkflowTests(DotfilesTestCase):
 
         self.assertEqual([], mutable_refs)
 
-    def test_workflow_is_thin_codacy_safety_net(self):
+    def test_workflow_runs_tests_and_uploads_coverage(self):
         workflow = (REPO_ROOT / ".github/workflows/dotfiles-validation.yml").read_text()
-        self.assertIn("name: Codacy Safety Net", workflow)
+        self.assertIn("name: Dotfiles Validation", workflow)
+        # job name must stay codacy-safety-net — required by branch protection ruleset
+        self.assertIn("codacy-safety-net:", workflow)
         self.assertIn("CODACY_PROJECT_TOKEN", workflow)
         self.assertIn("concurrency:", workflow)
-        self.assertIn("codacy-safety-net-${{ github.ref }}", workflow)
-        self.assertIn("quality-status", workflow)
-        self.assertIn("steps.codacy_status.outputs.status == 'analyzed'", workflow)
-        self.assertIn("steps.codacy_status.outputs.status != 'analyzed'", workflow)
-        self.assertIn("scripts/quality-pipeline.sh", workflow)
+        self.assertIn("coverage run -m unittest discover -s tests", workflow)
+        self.assertIn("coverage xml", workflow)
         self.assertIn("coverage.xml", workflow)
         self.assertIn("coverage.codacy.com/get.sh", workflow)
         self.assertIn("continue-on-error: true", workflow)
-        self.assertIn("codacy-cli-v2/main/codacy-cli.sh) download", workflow)
-        self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli-v2"', workflow)
-        self.assertIn('ln -sf "$CLI_PATH" "$INSTALL_DIR/codacy-cli"', workflow)
-        self.assertIn("cache-dependency-glob:", workflow)
-        self.assertIn("scripts/quality-pipeline.sh", workflow)
         # Pinned action SHAs must be preserved.
         self.assertIn("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", workflow)
         self.assertIn("astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b", workflow)
+        # Codacy CLI and quality pipeline must not run in CI — cloud analysis covers it.
+        self.assertNotIn("codacy-cli", workflow)
+        self.assertNotIn("quality-pipeline.sh", workflow)
 
     def test_quality_pipeline_is_non_blocking_and_uses_local_prereqs(self):
         pipeline = (REPO_ROOT / "scripts/quality-pipeline.sh").read_text()


### PR DESCRIPTION
## Summary

- Removes codacy-cli install, quality-pipeline fallback, and commit-status pre-check from the CI workflow
- Codacy cloud runs all 13 analysis tools automatically; local SARIF uploads were supplementary only (\"Run analysis on your build server\" is OFF)
- Keeps unit tests, coverage XML generation, and coverage upload to Codacy
- Job name stays `codacy-safety-net` to preserve the branch protection required-status-check context
- Renames workflow to \"Dotfiles Validation\" and updates concurrency group to match

## Test plan

- [x] All 233 tests pass locally
- [x] `test_workflow_runs_tests_and_uploads_coverage` updated to assert simplified structure
- [x] Asserts codacy-cli and quality-pipeline.sh are absent from workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)