### PR TITLE
Add Codacy handling merge note

### DIFF
--- a/docs/codacy-handling-update-to-merge.md
+++ b/docs/codacy-handling-update-to-merge.md
@@ -1,0 +1,30 @@
+# Codacy Handling: Update To Merge
+
+This note records the docs-only merge flow that required a temporary
+branch-protection relaxation before PR `#236` could be merged.
+
+## Sequence
+
+1. A docs-only commit was created to preserve the Codacy and merge workflow
+   investigation.
+2. The commit was moved off protected `main` and onto the branch
+   `docs/codacy-handling-notes`.
+3. PR `#236` was opened from that branch to `main`.
+4. The PR was blocked by the live Codacy protection profile.
+5. Both protection layers were temporarily relaxed to require only
+   `codacy-safety-net`.
+6. PR `#236` was merged.
+7. The stricter protection profile was restored immediately afterward.
+
+## Important Results
+
+- PR `#236` is `MERGED`.
+- `HEAD` and `origin/main` matched at `31f39708fe5e81c5577183ba5b54d6687ce5832f`.
+- There were no open PRs after the merge.
+- The repo returned to a clean, synced `main` state.
+
+## Cleanup
+
+- The temporary protection relaxation was reverted.
+- The feature branch was deleted from GitHub.
+- The local worktree remained on `main`.


### PR DESCRIPTION
Converts the merge transcript into a concise repo note and preserves the documented Codacy workflow history.