### PR TITLE
[codex] verify sign-in guidance

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -15,7 +15,7 @@ jobs:
   codacy-safety-net:
     runs-on: ubuntu-latest
     env:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -30,9 +30,9 @@ jobs:
         run: uv run --with coverage==7.5.4 coverage xml
 
       - name: Upload coverage to Codacy
-        if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
+        if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
         continue-on-error: true
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-            --project-token "$CODACY_PROJECT_TOKEN" \
+            --api-token "$CODACY_ACCOUNT_TOKEN" \
             -r coverage.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Two MCP servers are available to agents when the required tokens are set.
 
 ### Token loading — automatic
 
-A user-global `SessionStart` hook (`~/.claude/hooks/load-project-env.sh`) sources
+A user-global `SessionStart` hook (`~/.claude/hooks/load-project-env.sh`) loads
 each project's `.envrc` / `.envrc.local` at session start and exports the token
 allowlist into every Bash tool call for the session. The allowlist covers:
 `CODACY_ACCOUNT_TOKEN`, `CODACY_API_TOKEN`, `CODACY_PROJECT_TOKEN`,

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ uv run --with coverage coverage run -m unittest discover -s tests
 uv run --with coverage coverage xml
 ```
 
-CI runs the same validation suite on pushes and pull requests and generates `coverage.xml`. Codacy upload is attempted on push events only when the `CODACY_PROJECT_TOKEN` GitHub secret is configured. See `docs/codacy-coverage-rollout.md` for replicating this pattern in other repos.
+CI runs the same validation suite on pushes and pull requests and generates `coverage.xml`. Codacy upload is attempted on push events only when the `CODACY_ACCOUNT_TOKEN` GitHub secret is configured. See `docs/codacy-coverage-rollout.md` for replicating this pattern in other repos.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ other tools know your codebase conventions.
 ```bash
 git clone https://github.com/kairin/000-dotfiles.git ~/000-dotfiles
 ~/000-dotfiles/setup
-# → Menu appears. Choose 1 (install tools), then 2 (apply configs). Done in ~5 min.
+# → Menu appears. Choose 1 (open the phased tool submenu), then 2 (open safe changes). Done in ~5 min.
 ```
 
 ### Scaffold AI agent docs in a project
@@ -57,9 +57,10 @@ cd ~/Apps/my-project
 
 ## How it works — setup flow
 
-When you run `./setup`, the script audits your machine and shows a **5-option menu**. The
+When you run `./setup`, the script audits your machine and shows a **6-option menu**. The
 option numbers **never change**, but the `[recommended]` tag highlights which action fits
-your current state.
+your current state. Option 2 opens a safe-changes submenu so you can see which files and
+fonts are affected before you apply anything.
 
 ### Fresh machine (tools missing)
 
@@ -74,32 +75,59 @@ $ ~/000-dotfiles/setup
         ╚═══════════════════════════════════════╝
                          ↓
    1. Install / update developer tools   [recommended] ← CHOOSE THIS
-   2. Apply safe non-protected dotfiles
+   2. Apply safe non-protected dotfiles.
    3. Show full technical details
    4. Show tool and sign-in guidance
-   5. Exit without writing
+   5. Configure / verify API tokens
+   6. Exit without writing
                          ↓
-        Choose [1-5]: 1
+        Choose [1-6]: 1
                          ↓
-   [Preview shows: uv, git, gh, fish, direnv, claude,
-    codex, gemini, copilot, specify to be installed]
+   [Developer tool phases submenu opens]
+   1. Preview dev-base packages
+   2. Apply dev-base packages
+   3. Preview individual tool installers
+   4. Apply individual tool installers
+   5. Split post-install verification and guidance
+   6. Back to main menu
                          ↓
-   Apply tool install/update actions? [y/N]: y
+   Choose [1-6]: 2
                          ↓
-   [Tools installed; 5 min...]
-   [Prints sign-in commands: gh auth login, claude /login, etc.]
+   [Preview shows the dev-base apt bundle]
                          ↓
-   Menu reappears. Now tool count shows 10/10.
+   Apply dev-base packages actions? [y/N]: y
+                         ↓
+   [Dev-base packages updated]
+   [Return to the submenu or run option 5 for verification/sign-in guidance]
+                         ↓
+   Menu reappears. Now tool count reflects the phase you just applied.
                          ↓
    1. Install / update developer tools
-   2. Apply safe non-protected dotfiles   [recommended] ← NOW CHOOSE THIS
+   2. Apply safe non-protected dotfiles.  [recommended] ← NOW CHOOSE THIS
    3. Show full technical details
    4. Show tool and sign-in guidance
-   5. Exit without writing
+   5. Configure / verify API tokens
+   6. Exit without writing
                          ↓
-        Choose [1-5]: 2
+        Choose [1-6]: 2
+                         ↓
+   [Safe changes submenu shows dotfiles vs fonts]
+                         ↓
+        Choose [1-4]: 3
                          ↓
    [Configs + fonts installed; backups created]
+                         ↓
+   1. Install / update developer tools
+   2. Apply safe non-protected dotfiles.
+   3. Show full technical details
+   4. Show tool and sign-in guidance
+   5. Configure / verify API tokens. Opens a submenu that splits
+      verification-only, auto post-install actions, and manual guidance.
+   6. Exit without writing
+                         ↓
+        Choose [1-6]: 5
+                         ↓
+   [Post-install submenu shows verify / auto / guidance]
                          ↓
         DONE. Run these sign-in commands:
         $ gh auth login
@@ -122,12 +150,17 @@ $ ~/000-dotfiles/setup
         ╚═══════════════════════════════════════╝
                          ↓
    1. Install / update developer tools
-   2. Apply safe non-protected dotfiles   [recommended] ← CHOOSE THIS
+   2. Apply safe non-protected dotfiles.  [recommended] ← CHOOSE THIS
    3. Show full technical details
    4. Show tool and sign-in guidance
-   5. Exit without writing
+   5. Configure / verify API tokens
+   6. Exit without writing
                          ↓
-        Choose [1-5]: 2
+        Choose [1-6]: 2
+                         ↓
+   [Safe changes submenu shows dotfiles vs fonts]
+                         ↓
+        Choose [1-4]: 3
                          ↓
    [2 files written with backups]
    [Fonts already installed, no changes]
@@ -212,7 +245,7 @@ Files ending in `.template` are copy-and-customize sources. Placeholders follow 
 
 | Command | What it does |
 |---|---|
-| `./setup` | Audit machine, present a menu, optionally apply non-protected dotfiles + font recipes |
+| `./setup` | Audit machine, present a menu, optionally apply a safe-changes submenu for non-protected dotfiles + fonts |
 | `./setup /path/to/project` | Inspect project folder, offer agent-doc actions |
 | `./setup init [--project PATH] [--vars FILE] [--copilot] --yes` | Render `AGENTS.md` + `CLAUDE.md`/`GEMINI.md` symlinks; auto-discovers `project-vars.json` or `.dotfiles/project-vars.json` and infers defaults from `package.json`/`pyproject.toml`/`Cargo.toml`/`go.mod`/Makefile when missing |
 | `./setup verify [--project PATH] [--copilot]` | Read-only check: requires no `uv`, suitable for CI |
@@ -221,8 +254,11 @@ Files ending in `.template` are copy-and-customize sources. Placeholders follow 
 | `./setup ship [<pr-number>]` | Finalize a PR: refresh branch, re-upload Codacy SARIF, poll required checks, squash-merge |
 
 Menu options during `./setup`:
-- **Option 1:** Install or update developer tools
-- **Option 2:** Apply safe non-protected dotfiles (backed up before overwrite)
+- **Option 1:** Install or update developer tools. Opens a submenu that
+  splits dev-base packages, tool installers, and post-install verification so
+  you can isolate slow phases.
+- **Option 2:** Apply safe non-protected dotfiles. Opens a submenu that separates
+  dotfiles/config files from fonts before applying the combined safe changes.
 - **Option 3:** Show full technical details (machine state, versions, all pending operations)
 - **Option 4:** Manage optional integrations (GitHub auth, HuggingFace token configuration, Codacy setup). GitHub CLI installs via `apt`; HuggingFace CLI (`hf`) installs via `uv tool install huggingface-hub`; use `hf auth login` to authenticate. Machine bootstrap calls `ensure_mcp_servers()`, which auto-registers the **GitHub MCP** server (uses `GITHUB_TOKEN`) and **Codacy MCP** server (uses `CODACY_ACCOUNT_TOKEN`) with the Claude CLI.
 

--- a/claude/CLAUDE.md.template
+++ b/claude/CLAUDE.md.template
@@ -26,7 +26,7 @@ Project-specific instructions live in each repo's `CLAUDE.md` (or `AGENTS.md` wi
 
 ## Project env is auto-loaded
 
-A user-global `SessionStart` hook (`~/.claude/hooks/load-project-env.sh`) sources
+A user-global `SessionStart` hook (`~/.claude/hooks/load-project-env.sh`) loads
 each project's `.envrc` / `.envrc.local` at session start and exports a token
 allowlist (`CODACY_*`, `GITHUB_TOKEN`, `GH_TOKEN`, `HF_TOKEN`, `OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, etc.) into every Bash tool call for the session.

--- a/claude/hooks/load-project-env.sh.template
+++ b/claude/hooks/load-project-env.sh.template
@@ -28,23 +28,19 @@ if [[ -z "$project_root" ]]; then
   finish
 fi
 
-if ! command -v direnv >/dev/null 2>&1; then
-  log "direnv not installed; skipping"
-  finish
-fi
-
 if ! cd "$project_root"; then
   log "could not enter project root: $project_root"
   finish
 fi
 
-direnv_output="$(direnv export bash 2>/dev/null || true)"
-if [[ -z "$direnv_output" ]]; then
-  log "direnv export failed for $project_root"
-  finish
-fi
+source_env_if_exists() {
+  local path="$1"
+  [[ -f "$path" ]] || return 0
+  # shellcheck disable=SC1090
+  source "$path"
+}
 
-eval "$direnv_output"
+source_env_if_exists "$project_root/.envrc"
 
 allowlist_file="$project_root/.claude/env-allowlist"
 if [[ -f "$allowlist_file" ]]; then
@@ -63,4 +59,3 @@ if [[ -f "$allowlist_file" ]]; then
 else
   log "loaded project env from $project_root"
 fi
-

--- a/claude/settings.json.template
+++ b/claude/settings.json.template
@@ -2,6 +2,11 @@
   "model": "sonnet",
   "effortLevel": "high",
   "theme": "dark",
+  "statusLine": {
+    "type": "command",
+    "command": "{{HOME}}/.claude/statusline-command.sh",
+    "padding": 0
+  },
   "permissions": {
     "defaultMode": "auto",
     "allow": [],

--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# Tide-styled Claude Code status line — 4-line layout
+# Colors derived from ~/.config/fish/fish_variables (Tide v6 theme)
+# Lines 1+2: match Claude Code shipped defaults; lines 3+4: extended info
+
+# Ensure common tool paths are available regardless of Claude Code's PATH
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
+input=$(cat)
+
+# Bail-safe: if jq is not available, emit a minimal status line and exit
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "$(pwd) | status line (jq not found)"
+  exit 0
+fi
+
+# --- Extract JSON fields ---
+cwd=$(echo "$input"           | jq -r '.workspace.current_dir // .cwd // empty')
+model=$(echo "$input"         | jq -r '.model.display_name // empty')
+model_id=$(echo "$input"      | jq -r '.model.id // empty')
+used=$(echo "$input"          | jq -r '.context_window.used_percentage // empty')
+remaining=$(echo "$input"     | jq -r '.context_window.remaining_percentage // empty')
+ctx_total=$(echo "$input"     | jq -r '.context_window.context_window_size // empty')
+in_tokens=$(echo "$input"     | jq -r '.context_window.total_input_tokens // empty')
+out_tokens=$(echo "$input"    | jq -r '.context_window.total_output_tokens // empty')
+cache_write=$(echo "$input"   | jq -r '.context_window.current_usage.cache_creation_input_tokens // empty')
+cache_read=$(echo "$input"    | jq -r '.context_window.current_usage.cache_read_input_tokens // empty')
+version=$(echo "$input"       | jq -r '.version // empty')
+vim_mode=$(echo "$input"      | jq -r '.vim.mode // empty')
+effort=$(echo "$input"        | jq -r '.effort.level // empty')
+thinking=$(echo "$input"      | jq -r '.thinking.enabled // empty')
+worktree_name=$(echo "$input" | jq -r '.workspace.git_worktree // empty')
+session=$(echo "$input"       | jq -r '.session_name // empty')
+session_id=$(echo "$input"    | jq -r '.session_id // empty')
+five_h=$(echo "$input"        | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_h_reset=$(echo "$input"  | jq -r '.rate_limits.five_hour.resets_at // empty')
+seven_d=$(echo "$input"       | jq -r '.rate_limits.seven_day.used_percentage // empty')
+seven_d_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+transcript=$(echo "$input"    | jq -r '.transcript_path // empty')
+output_style=$(echo "$input"  | jq -r '.output_style.name // empty')
+added_dirs=$(echo "$input"    | jq -r '.workspace.added_dirs // [] | join(", ")')
+wt_name=$(echo "$input"       | jq -r '.worktree.name // empty')
+wt_branch=$(echo "$input"     | jq -r '.worktree.branch // empty')
+wt_path=$(echo "$input"       | jq -r '.worktree.path // empty')
+agent_name=$(echo "$input"    | jq -r '.agent.name // empty')
+agent_type=$(echo "$input"    | jq -r '.agent.type // empty')
+project_dir=$(echo "$input"   | jq -r '.workspace.project_dir // empty')
+
+[ -z "$cwd" ] && cwd="$(pwd)"
+
+# --- Fish-specific live data (not in JSON input) ---
+# fish_bind_mode universal var is not accessible via --no-config; skip to avoid subprocess timeout
+fish_bind_mode=""
+# VIRTUAL_ENV and DIRENV_DIR are exported by fish into bash's env
+venv_name=""
+[ -n "$VIRTUAL_ENV" ] && venv_name="$(basename "$VIRTUAL_ENV")"
+direnv_active=""
+[ -n "$DIRENV_DIR" ] && direnv_active="$(basename "${DIRENV_DIR#-}")"
+
+# --- ANSI helpers ---
+R='\033[0m'
+pill() {
+  # pill <bg_hex> <fg_hex> <text>
+  local bh="${1}" fh="${2}" txt="${3}"
+  local br gr bb fr fg_g fb
+  br=$((16#${bh:0:2})); bg=$((16#${bh:2:2})); bb=$((16#${bh:4:2}))
+  fr=$((16#${fh:0:2})); fg_g=$((16#${fh:2:2})); fb=$((16#${fh:4:2}))
+  printf '\033[38;2;%d;%d;%dm\033[48;2;%d;%d;%dm %s \033[0m' \
+    "$fr" "$fg_g" "$fb" "$br" "$bg" "$bb" "$txt"
+}
+
+# Tide palette (hex, no #)
+PWD_BG="3465A4";     PWD_FG="E4E4E4"
+GIT_BG="4E9A06";     GIT_FG="000000"
+GIT_DIRTY_BG="C4A000"; GIT_DIRTY_FG="000000"
+GIT_URGENT_BG="CC0000"; GIT_URGENT_FG="000000"
+CTX_BG="444444";     CTX_FG="D7AF87"
+TIME_BG="D3D7CF";    TIME_FG="000000"
+RATE_BG="C4A000";    RATE_FG="000000"
+VIM_INS_BG="87AFAF"; VIM_NRM_BG="949494"; VIM_VIS_BG="FF8700"; VIM_RPL_BG="87AF87"; VIM_FG="000000"
+VENV_BG="444444";   VENV_FG="00AFAF"
+DIRENV_BG="D7AF00"; DIRENV_FG="000000"
+EFF_BG="800080";     EFF_FG="FFFFFF"
+WT_BG="613583";      WT_FG="FFFFFF"
+OS_BG="D4D4D4";      OS_FG_HEX="E95420"
+FRAME="808080"
+DIM='\033[2m'
+BOLD='\033[1m'
+
+# ── git state helper ──────────────────────────────────────────────────────────
+git_info() {
+  local dir="$1"
+  timeout 2s git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || return
+  local branch
+  branch=$(timeout 2s git -C "$dir" -c core.fsmonitor=false symbolic-ref --short HEAD 2>/dev/null \
+           || timeout 2s git -C "$dir" -c core.fsmonitor=false rev-parse --short HEAD 2>/dev/null)
+  local gs staged unstaged untracked conflicts
+  gs=$(timeout 2s git -C "$dir" -c core.fsmonitor=false status --porcelain 2>/dev/null)
+  staged=$(echo "$gs"    | grep -c '^[MADRCU]' 2>/dev/null || echo 0)
+  unstaged=$(echo "$gs"  | grep -c '^.[MD]'    2>/dev/null || echo 0)
+  untracked=$(echo "$gs" | grep -c '^??'       2>/dev/null || echo 0)
+  conflicts=$(echo "$gs" | grep -cE '^(UU|AA|DD)' 2>/dev/null || echo 0)
+
+  local gbg gfg
+  if   [ "$conflicts" -gt 0 ]; then gbg="$GIT_URGENT_BG"; gfg="$GIT_URGENT_FG"
+  elif [ "$staged" -gt 0 ] || [ "$unstaged" -gt 0 ] || [ "$untracked" -gt 0 ]; then
+    gbg="$GIT_DIRTY_BG"; gfg="$GIT_DIRTY_FG"
+  else
+    gbg="$GIT_BG"; gfg="$GIT_FG"
+  fi
+
+  local dirt=""
+  [ "$staged"    -gt 0 ] && dirt+=" *${staged}"
+  [ "$unstaged"  -gt 0 ] && dirt+=" ~${unstaged}"
+  [ "$untracked" -gt 0 ] && dirt+=" ?${untracked}"
+
+  local label=" $branch"
+  [ -n "$worktree_name" ] && label+=" (wt)"
+  pill "$gbg" "$gfg" "${label}${dirt}"
+}
+
+# ── context bar (matches Claude Code default line-2 bar) ──────────────────────
+ctx_bar() {
+  local used_pct="$1"
+  local used_int bar_filled bar_empty bar_fg
+  used_int=$(printf '%.0f' "$used_pct")
+  local bar_width=20
+  bar_filled=$(( used_int * bar_width / 100 ))
+  bar_empty=$(( bar_width - bar_filled ))
+
+  if   [ "$used_int" -ge 80 ]; then bar_fg='\033[38;2;204;0;0m'
+  elif [ "$used_int" -ge 50 ]; then bar_fg='\033[38;2;196;160;0m'
+  else                               bar_fg='\033[38;2;78;154;6m'
+  fi
+
+  printf '%b' "$bar_fg"
+  printf '%0.s█' $(seq 1 "$bar_filled") 2>/dev/null || printf '%0.s█' $(seq 1 $bar_filled)
+  printf '\033[38;2;68;68;68m'
+  printf '%0.s░' $(seq 1 "$bar_empty") 2>/dev/null || printf '%0.s░' $(seq 1 $bar_empty)
+  printf '%b' "$R"
+}
+
+# ── time-until helper for rate limit resets ───────────────────────────────────
+time_until() {
+  local epoch="$1"
+  [ -z "$epoch" ] && return
+  local now delta
+  now=$(date +%s)
+  delta=$(( epoch - now ))
+  [ "$delta" -le 0 ] && echo "now" && return
+  local h m
+  h=$(( delta / 3600 ))
+  m=$(( (delta % 3600) / 60 ))
+  if [ "$h" -gt 0 ]; then printf '%dh%dm' "$h" "$m"
+  else printf '%dm' "$m"
+  fi
+}
+
+# =============================================================================
+# LINE 1 — matches Claude Code default line 1:  cwd  |  model  v<version>
+# =============================================================================
+line1=""
+
+# CWD segment (Tide pwd style)
+dir_display="${cwd/#$HOME/\~}"
+line1+="$(pill "$PWD_BG" "$PWD_FG" " $dir_display")"
+
+# git
+git_seg="$(git_info "$cwd")"
+[ -n "$git_seg" ] && line1+="$git_seg"
+
+# model
+[ -n "$model" ] && line1+=" $(pill "$CTX_BG" "$CTX_FG" " $model")"
+
+# version (dim, as Claude Code default)
+[ -n "$version" ] && line1+=" ${DIM}\033[38;2;128;128;128mv${version}${R}"
+
+# =============================================================================
+# LINE 2 — matches Claude Code default line 2, always dynamic
+# Must never be blank: shows context bar + % + at least one live datum
+# =============================================================================
+line2=""
+
+# No pre-usage time pill here; the always-present time pill at line 238 covers it.
+
+# Rate limits — dynamic, only present from claude.ai subscription
+if [ -n "$five_h" ] || [ -n "$seven_d" ]; then
+  line2+="  "
+  if [ -n "$five_h" ]; then
+    pct=$(printf '%.0f' "$five_h")
+    until=$(time_until "$five_h_reset")
+    label="5h:${pct}%"
+    [ -n "$until" ] && label+=" (resets ${until})"
+    line2+="$(pill "$RATE_BG" "$RATE_FG" "$label")"
+  fi
+  if [ -n "$seven_d" ]; then
+    pct=$(printf '%.0f' "$seven_d")
+    until=$(time_until "$seven_d_reset")
+    label="7d:${pct}%"
+    [ -n "$until" ] && label+=" (resets ${until})"
+    line2+=" $(pill "$RATE_BG" "$RATE_FG" "$label")"
+  fi
+fi
+
+# Vim mode — always dynamic (changes as you type)
+if [ -n "$vim_mode" ]; then
+  case "$vim_mode" in
+    INSERT)  vm_bg="$VIM_INS_BG" ;;
+    NORMAL)  vm_bg="$VIM_NRM_BG" ;;
+    VISUAL*) vm_bg="$VIM_VIS_BG" ;;
+    *)       vm_bg="$VIM_NRM_BG" ;;
+  esac
+  line2+=" $(pill "$vm_bg" "$VIM_FG" "$vim_mode")"
+fi
+
+# Fish bind mode (vi mode in the parent fish shell; only show when not default insert)
+if [ -n "$fish_bind_mode" ] && [ "$fish_bind_mode" != "insert" ]; then
+  case "$fish_bind_mode" in
+    default) fb_bg="$VIM_NRM_BG"; fb_label="FISH:N" ;;
+    replace) fb_bg="$VIM_RPL_BG"; fb_label="FISH:R" ;;
+    visual)  fb_bg="$VIM_VIS_BG"; fb_label="FISH:V" ;;
+    *)       fb_bg="$VIM_NRM_BG"; fb_label="FISH:${fish_bind_mode}" ;;
+  esac
+  line2+=" $(pill "$fb_bg" "$VIM_FG" "$fb_label")"
+fi
+
+# Effort / thinking — changes per-session
+eff_label=""
+[ -n "$effort" ] && eff_label="effort:$effort"
+[ "$thinking" = "true" ] && { [ -n "$eff_label" ] && eff_label+=" "; eff_label+="thinking:on"; }
+[ -n "$eff_label" ] && line2+=" $(pill "$EFF_BG" "$EFF_FG" "$eff_label")"
+
+# Current time — always live; ensures line 2 is never static
+line2+="  $(pill "$TIME_BG" "$TIME_FG" " $(date +%H:%M:%S)")"
+
+# =============================================================================
+# LINE 3 — extended info: cache tokens, total tokens, transcript, added dirs,
+#           output style, worktree details
+# =============================================================================
+line3=""
+sep='\033[38;2;128;128;128m · \033[0m'
+
+# Token counts
+if [ -n "$in_tokens" ] && [ "$in_tokens" != "0" ]; then
+  line3+="${DIM}in:${in_tokens}${R}"
+fi
+if [ -n "$out_tokens" ] && [ "$out_tokens" != "0" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="${DIM}out:${out_tokens}${R}"
+fi
+if [ -n "$cache_write" ] && [ "$cache_write" != "0" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="${DIM}cache-w:${cache_write}${R}"
+fi
+if [ -n "$cache_read" ] && [ "$cache_read" != "0" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="${DIM}cache-r:${cache_read}${R}"
+fi
+
+# Context window size
+if [ -n "$ctx_total" ] && [ "$ctx_total" != "0" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="${DIM}ctx-size:${ctx_total}${R}"
+fi
+
+# Transcript path (truncated)
+if [ -n "$transcript" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  short_transcript="...$(echo "$transcript" | rev | cut -c1-30 | rev)"
+  line3+="${DIM}transcript:${short_transcript}${R}"
+fi
+
+# Python virtual environment
+if [ -n "$venv_name" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="$(pill "$VENV_BG" "$VENV_FG" "venv:$venv_name")"
+fi
+
+# Direnv (active when DIRENV_DIR is set)
+if [ -n "$direnv_active" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="$(pill "$DIRENV_BG" "$DIRENV_FG" "direnv:$direnv_active")"
+fi
+
+# Output style moved to line 4 (always shown)
+
+# Worktree (from workspace.git_worktree or worktree object)
+if [ -n "$wt_name" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  wt_label="wt:$wt_name"
+  [ -n "$wt_branch" ] && wt_label+=" ($wt_branch)"
+  line3+="$(pill "$WT_BG" "$WT_FG" "$wt_label")"
+elif [ -n "$worktree_name" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="$(pill "$WT_BG" "$WT_FG" "wt:$worktree_name")"
+fi
+
+# Added dirs
+if [ -n "$added_dirs" ]; then
+  [ -n "$line3" ] && line3+="$sep"
+  line3+="${DIM}+dirs: $added_dirs${R}"
+fi
+
+# =============================================================================
+# LINE 4 — remaining dynamic data: agent info, session, project dir, worktree
+#           original branch, session ID (short)
+# =============================================================================
+line4=""
+
+# Agent info (only present with --agent flag)
+if [ -n "$agent_name" ]; then
+  agent_label="agent:$agent_name"
+  [ -n "$agent_type" ] && agent_label+=" ($agent_type)"
+  line4+="$(pill "$EFF_BG" "$EFF_FG" "$agent_label")"
+fi
+
+# Session name (when renamed via /rename)
+if [ -n "$session" ]; then
+  [ -n "$line4" ] && line4+=" "
+  line4+="$(pill "$CTX_BG" "$CTX_FG" "\"$session\"")"
+fi
+
+# Project dir (when different from cwd)
+if [ -n "$project_dir" ] && [ "$project_dir" != "$cwd" ]; then
+  [ -n "$line4" ] && line4+="$sep"
+  proj_display="${project_dir/#$HOME/\~}"
+  line4+="${DIM}project:${proj_display}${R}"
+fi
+
+# Worktree original branch (when in a worktree session)
+if [ -n "$wt_path" ]; then
+  [ -n "$line4" ] && line4+="$sep"
+  wt_orig=$(echo "$input" | jq -r '.worktree.original_branch // empty')
+  wt_orig_cwd=$(echo "$input" | jq -r '.worktree.original_cwd // empty')
+  wt_extra="wt-path:${wt_path/#$HOME/\~}"
+  [ -n "$wt_orig" ] && wt_extra+=" from:$wt_orig"
+  line4+="${DIM}${wt_extra}${R}"
+fi
+
+# Session ID (short — last 8 chars)
+if [ -n "$session_id" ]; then
+  short_id="${session_id: -8}"
+  [ -n "$line4" ] && line4+="$sep"
+  line4+="${DIM}sid:${short_id}${R}"
+fi
+
+# Output style (always shown on line 4)
+if [ -n "$output_style" ]; then
+  [ -n "$line4" ] && line4+="$sep"
+  line4+="${DIM}style:${output_style}${R}"
+fi
+
+# =============================================================================
+# LINE 5 — full-width context window bar
+#   Format: "Context Window usage   18% used  [████░░░░░░░░░░░░░░░░]  82% left"
+#   Bar expands to fill terminal width; falls back to 40 cols if tput unavailable.
+# =============================================================================
+line5=""
+if [ -n "$used" ]; then
+  used_int=$(printf '%.0f' "$used")
+  rem_int=0
+  [ -n "$remaining" ] && rem_int=$(printf '%.0f' "$remaining")
+
+  label_left="Context Window usage"
+  label_used="${used_int}% used"
+  label_right="${rem_int}% left"
+
+  # Fixed-width text portions (no ANSI): "Context Window usage   18% used  [" + "]  82% left"
+  # bracket open "[" + bracket close "]" = 2; "   " between label and used = 3; "  " before bracket = 2; "  " after bracket = 2
+  fixed_len=$(( ${#label_left} + 3 + ${#label_used} + 2 + 1 + 1 + 2 + ${#label_right} ))
+  # fixed_len = len("Context Window usage") + 3 + len("18% used") + 2 + 1("[") + 1("]") + 2 + len("82% left")
+
+  term_cols=$(tput cols 2>/dev/null || echo 80)
+  bar_width=$(( term_cols - fixed_len ))
+  [ "$bar_width" -lt 4 ] && bar_width=4
+
+  bar_filled=$(( used_int * bar_width / 100 ))
+  bar_empty=$(( bar_width - bar_filled ))
+
+  # Color: green filled, grey empty
+  GREEN='\033[38;2;78;154;6m'
+  GREY='\033[38;2;100;100;100m'
+
+  bar_str=""
+  if [ "$bar_filled" -gt 0 ]; then
+    bar_str+="${GREEN}"
+    bar_str+=$(printf '%0.s█' $(seq 1 "$bar_filled"))
+  fi
+  if [ "$bar_empty" -gt 0 ]; then
+    bar_str+="${GREY}"
+    bar_str+=$(printf '%0.s░' $(seq 1 "$bar_empty"))
+  fi
+  bar_str+="${R}"
+
+  line5="${label_left}   ${label_used}  [${bar_str}]  ${label_right}"
+fi
+
+# =============================================================================
+# Emit — multi-line output, one line per logical section.
+# Claude Code statusLine renders all newline-delimited lines from the command.
+# =============================================================================
+if [ -z "$line1" ] && [ -z "$line2" ]; then
+  printf '%s\n' "$(pwd)"
+  exit 0
+fi
+
+printf '%b\n' "$line1"
+[ -n "$line2" ] && printf '%b\n' "$line2"
+[ -n "$line3" ] && printf '%b\n' "$line3"
+[ -n "$line4" ] && printf '%b\n' "$line4"
+[ -n "$line5" ] && printf '%b\n' "$line5"

--- a/docs/codacy-branch-protection.md
+++ b/docs/codacy-branch-protection.md
@@ -126,13 +126,13 @@ For the account-token pattern used by this repo, the workflow shape is:
 
 ```yaml
 env:
-  CODACY_COVERAGE_API_TOKEN: ${{ secrets.CODACY_COVERAGE_API_TOKEN }}
+  CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
 
 - name: Upload coverage to Codacy
-  if: ${{ env.CODACY_COVERAGE_API_TOKEN != '' }}
+  if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
   uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
   with:
-    api-token: ${{ secrets.CODACY_COVERAGE_API_TOKEN }}
+    api-token: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
     coverage-reports: coverage.xml
 ```
 

--- a/docs/codacy-coverage-rollout.md
+++ b/docs/codacy-coverage-rollout.md
@@ -15,10 +15,10 @@ Use this document as the checklist for applying the same pattern to other repos.
 4. Added `.github/workflows/dotfiles-validation.yml`.
    - Runs the unit tests with `coverage.py`.
    - Generates `coverage.xml`.
-   - Uploads `coverage.xml` to Codacy on push events only when `CODACY_PROJECT_TOKEN` is configured.
-5. Added the GitHub Actions secret `CODACY_PROJECT_TOKEN`.
-6. Updated the workflow to use Codacy's repository-token input:
-   - `project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}`
+   - Uploads `coverage.xml` to Codacy on push events only when `CODACY_ACCOUNT_TOKEN` is configured.
+5. Added the GitHub Actions secret `CODACY_ACCOUNT_TOKEN`.
+6. Updated the workflow to use Codacy's account-token input:
+   - `api-token: ${{ secrets.CODACY_ACCOUNT_TOKEN }}`
 7. Verified the workflow on `main`.
    - Run: `https://github.com/kairin/000-dotfiles/actions/runs/25203399909`
    - Commit: `29f7529c100b6b2c6ae7aa9fcc6aa1ea1b60a5e8`
@@ -148,8 +148,8 @@ Use this document as the checklist for applying the same pattern to other repos.
 1. Apply this same workflow pattern repo by repo.
    - Each target repo needs its own test command and workflow name adjusted.
 2. Decide whether to use repo-specific Codacy project tokens or one shared account token.
-   - This repo uses a repository token stored as `CODACY_PROJECT_TOKEN`.
-   - If a repo uses a Codacy account token instead, the action input should be `api-token`, not `project-token`.
+   - This repo uses a Codacy account token stored as `CODACY_ACCOUNT_TOKEN` for CI coverage upload.
+   - If a repo uses a Codacy project token instead, the action input should be `project-token`, not `api-token`.
 3. Enable strict coverage gates only after coverage upload is stable.
    - First confirm a few PRs upload coverage consistently.
    - Then set a reasonable threshold in Codacy.
@@ -159,4 +159,4 @@ Use this document as the checklist for applying the same pattern to other repos.
    - This repo runs validation on both `push` and `pull_request`, but uploads coverage on `push` only to avoid duplicate reports for the same commit.
 5. Keep static analysis and coverage separate.
    - Codacy static analysis is handled by the Codacy GitHub app/check.
-   - Coverage upload is handled by the GitHub Actions workflow and `CODACY_PROJECT_TOKEN`.
+   - Coverage upload is handled by the GitHub Actions workflow and `CODACY_ACCOUNT_TOKEN`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,40 +52,62 @@ cd ~/000-dotfiles
 ./setup
 ```
 
-You'll see a summary of your machine state and a 5-option menu:
+You'll see a summary of your machine state and a 6-option menu:
 
 ```
 1. Install / update developer tools        [recommended]
-2. Apply safe non-protected dotfiles
+2. Apply safe non-protected dotfiles.
 3. Show full technical details
 4. Show tool and sign-in guidance
-5. Exit without writing
+5. Configure / verify API tokens
+6. Exit without writing
 ```
 
 Since tools are missing on a fresh machine, **option 1 is highlighted**. Choose it.
 
 ```
-Choose [1-5]: 1
+Choose [1-6]: 1
 ```
 
-### Step 3: Preview and confirm
+### Step 3: Pick a tool phase
 
-You'll see a preview of all tools that will be installed:
-
-```
-Already installed (will be updated where possible):
-  - Git: git version 2.x → apt --only-upgrade
-  - GitHub CLI: gh version 2.x → apt --only-upgrade
-  ... etc ...
-```
-
-Review the list and confirm:
+Option 1 opens a submenu so you can isolate the slow step before you write
+anything:
 
 ```
-Apply tool install/update actions? [y/N]: y
+Developer tool phases:
+1. Preview dev-base packages.
+2. Apply dev-base packages.
+3. Preview individual tool installers.
+4. Apply individual tool installers.
+5. Split post-install verification and guidance.
+6. Back to main menu.
 ```
 
-The installer will run for 2–5 minutes. Once done, you'll see a summary with sign-in commands to run:
+Choose the phase you want to inspect or apply. For example, start with the
+dev-base package preview:
+
+```
+Choose [1-6]: 1
+```
+
+You'll see the dev-base package preview:
+
+```
+Preparing dev-base package preview...
+```
+
+Then confirm the apply step if you want to write the dev-base changes:
+
+```
+Choose [1-6]: 2
+Apply dev-base packages actions? [y/N]: y
+```
+
+If you want the tool installers instead, choose option 3 or 4. After the
+selected phase finishes, you can run option 5 for a second submenu that splits
+post-install verification, auto actions, and manual guidance. Once the relevant
+phase completes, you'll see a summary with sign-in commands to run:
 
 ```
 Auth/setup guidance:
@@ -116,37 +138,28 @@ The menu is now back. Option 2 is now highlighted:
 
 ```
 1. Install / update developer tools
-2. Apply safe non-protected dotfiles        [recommended]
+2. Apply safe non-protected dotfiles.       [recommended]
 3. Show full technical details
 4. Show tool and sign-in guidance
-5. Exit without writing
-Choose [1-5]: 2
+5. Configure / verify API tokens
+6. Exit without writing
+Choose [1-6]: 2
 ```
 
-Choose option 2:
+Choose option 2 to open the safe-changes submenu:
 
 ```
-Choose [1-5]: 2
+Safe setup changes:
+1. Dotfiles and config files.
+2. Fonts and terminal setup.
+3. Apply all safe changes now.
+4. Back to main menu.
 ```
 
-You'll see a preview of config files and fonts to install:
+Choose `1` to review dotfiles or `2` to review fonts, then `3` to apply:
 
 ```
-Update existing files with backups:
-  - ~/.claude/settings.json
-  - ~/.codex/config.toml
-  - (other config templates)
-
-Fonts:
-  - JetBrainsMono Nerd Font
-  - FiraCode Nerd Font
-  - ... etc ...
-```
-
-Confirm to apply:
-
-```
-Apply these changes? [y/N]: y
+Choose [1-4]: 3
 ```
 
 Configs and fonts are now installed.
@@ -217,13 +230,15 @@ Machine setup summary
   - Configs: 2 drifted, 8 current
 
 1. Install / update developer tools
-2. Apply safe non-protected dotfiles        [recommended]
+2. Apply safe non-protected dotfiles.       [recommended]
 3. Show full technical details
 4. Show tool and sign-in guidance
-5. Exit without writing
+5. Configure / verify API tokens
+6. Exit without writing
 ```
 
-Option 2 is highlighted because configs have drifted. Choose it to review and apply the changes.
+Option 2 is highlighted because configs have drifted. Choose it to review the dotfiles/fonts
+split and then apply the changes.
 
 ### Update tools
 
@@ -231,12 +246,12 @@ To upgrade installed tools:
 
 ```bash
 ~/000-dotfiles/setup
-Choose [1-5]: 1
+Choose [1-6]: 1
 ```
 
 This runs:
 - `apt --only-upgrade` for OS packages (git, gh, fish, direnv)
-- `npm update -g` for globally-installed npm tools (codex, gemini, copilot)
+- `npm update -g --prefix ~/.local` for user-local npm tools (codex, gemini, copilot)
 - Self-update for curl installers (claude)
 - `uv tool upgrade` for uv-managed tools (specify)
 
@@ -245,7 +260,7 @@ This runs:
 If you want to inspect cache paths, font versions, or the full operation plan without applying:
 
 ```bash
-Choose [1-5]: 3
+Choose [1-6]: 3
 ```
 
 Shows raw cache state, package versions, and all pending operations.
@@ -380,7 +395,7 @@ Most tools install via `apt`, `npm`, or `uv`. If one fails:
 
 1. Check the error message (scroll back in your terminal)
 2. Run the tool doctor to see state: `./setup doctor`
-3. Try the install command manually, e.g. `apt install git` or `npm install -g @github/copilot`
+3. Try the install command manually, e.g. `apt install git` or `npm install -g --prefix ~/.local @github/copilot`
 4. Re-run `./setup`
 
 ### `Config drift: file X differs`

--- a/docs/issues/menu-renumbering.md
+++ b/docs/issues/menu-renumbering.md
@@ -1,6 +1,6 @@
 # Issue: menu option numbers change between first and subsequent runs
 
-**Status:** Fixed in PR #82 — stable 5-option menu with [recommended] tag
+**Status:** Fixed in PR #82 — stable 6-option menu with [recommended] tag
 **Affects:** Users who run setup more than once
 
 ## Problem
@@ -17,17 +17,21 @@ options will shift after a successful install.
 
 ## Fix applied
 
-Implemented stable 5-option menu regardless of machine state:
+Implemented stable 6-option menu regardless of machine state:
 
 ```
 1. Install / update developer tools  [recommended when tools missing]
 2. Apply safe non-protected dotfiles  [recommended when tools present]
 3. Show full technical details
 4. Show tool and sign-in guidance
-5. Exit without writing
+5. Configure / verify API tokens
+6. Exit without writing
 ```
 
 Option numbers are fixed on every run. The `[recommended]` tag moves to indicate
 the best action for the current state (option 1 when tools are missing, option 2
-when tools are present and configs have drifted). A user who ran option 1 on
-first run finds option 1 in the same position on every subsequent run.
+when tools are present and configs have drifted). Option 1 now opens a phased
+submenu so the tool install/update work can be split into dev-base packages,
+tool installers, and post-install verification without changing the top-level
+menu numbers. Option 5 now opens a second submenu so verification-only,
+auto post-install actions, and manual guidance can be inspected separately.

--- a/dotfiles-manifest.json
+++ b/dotfiles-manifest.json
@@ -41,7 +41,7 @@
       "protected": false,
       "user_customizable": true,
       "parse": "json",
-      "placeholders": "none"
+      "placeholders": "allowed_examples"
     },
     {
       "id": "claude.keybindings",
@@ -52,6 +52,16 @@
       "protected": false,
       "user_customizable": true,
       "parse": "json",
+      "placeholders": "none"
+    },
+    {
+      "id": "claude.statusline-command",
+      "source": "claude/statusline-command.sh.template",
+      "target": ".claude/statusline-command.sh",
+      "kind": "template",
+      "profiles": ["machine"],
+      "protected": false,
+      "user_customizable": true,
       "placeholders": "none"
     },
     {

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -416,19 +416,36 @@ def _auth_check_verify_file(
     verify_json_paths: tuple[tuple[str, ...], ...] | None,
     signed_in_detail: str | None,
 ) -> dict[str, Any]:
-    # Resolve ~ against the audited home, not the process home.
-    p = home / verify_file.lstrip("~/") if verify_file.startswith("~/") else Path(verify_file)
-    if not p.exists():
-        return {**base, "state": "available"}
+    path = _resolve_auth_verify_file(home, verify_file)
     if verify_json_paths:
-        try:
-            data = json.loads(p.read_text())
-        except (OSError, json.JSONDecodeError):
-            return {**base, "state": "available"}
-        if _json_paths_present(data, verify_json_paths):
-            return {**base, "state": "signed_in", "signed_in_detail": signed_in_detail or "cached credentials present"}
+        return _auth_check_verify_json_file(base, path, verify_json_paths, signed_in_detail)
+    return _auth_check_verify_text_file(base, path, signed_in_detail)
+
+
+def _resolve_auth_verify_file(home: Path, verify_file: str) -> Path:
+    # Resolve ~ against the audited home, not the process home.
+    return home / verify_file.lstrip("~/") if verify_file.startswith("~/") else Path(verify_file)
+
+
+def _auth_check_verify_json_file(
+    base: dict[str, Any],
+    path: Path,
+    verify_json_paths: tuple[tuple[str, ...], ...],
+    signed_in_detail: str | None,
+) -> dict[str, Any]:
+    if not path.exists():
         return {**base, "state": "available"}
-    if p.read_text().strip():
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {**base, "state": "available"}
+    if _json_paths_present(data, verify_json_paths):
+        return {**base, "state": "signed_in", "signed_in_detail": signed_in_detail or "cached credentials present"}
+    return {**base, "state": "available"}
+
+
+def _auth_check_verify_text_file(base: dict[str, Any], path: Path, signed_in_detail: str | None) -> dict[str, Any]:
+    if path.exists() and path.read_text().strip():
         return {**base, "state": "signed_in", "signed_in_detail": signed_in_detail or "cached credentials present"}
     return {**base, "state": "available"}
 

--- a/dotfiles_tools/baseline.py
+++ b/dotfiles_tools/baseline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess  # nosec B404
@@ -116,8 +117,8 @@ TOOL_BASELINE = (
         "bootstrap": True,
         "install_method": "npm",
         "install_args": {"package": "@openai/codex"},
-        "requires_sudo": True,
-        "install_hint": "Installed by the setup tool-install menu option (npm install -g @openai/codex).",
+        "requires_sudo": False,
+        "install_hint": "Installed by the setup tool-install menu option (npm install -g --prefix ~/.local @openai/codex).",
         "post_install": (
             {
                 "kind": "guidance",
@@ -154,8 +155,8 @@ TOOL_BASELINE = (
         "bootstrap": True,
         "install_method": "npm",
         "install_args": {"package": "@google/gemini-cli"},
-        "requires_sudo": True,
-        "install_hint": "Installed by the setup tool-install menu option (npm install -g @google/gemini-cli).",
+        "requires_sudo": False,
+        "install_hint": "Installed by the setup tool-install menu option (npm install -g --prefix ~/.local @google/gemini-cli).",
         "post_install": (
             {
                 "kind": "guidance",
@@ -171,8 +172,8 @@ TOOL_BASELINE = (
         "bootstrap": True,
         "install_method": "npm",
         "install_args": {"package": "@github/copilot"},
-        "requires_sudo": True,
-        "install_hint": "Installed by the setup tool-install menu option (npm install -g @github/copilot).",
+        "requires_sudo": False,
+        "install_hint": "Installed by the setup tool-install menu option (npm install -g --prefix ~/.local @github/copilot).",
         "post_install": (
             {
                 "kind": "guidance",
@@ -271,18 +272,25 @@ AUTH_GUIDANCE = (
         "tool": "codex",
         "command": "codex auth",
         "guidance": "Run when Codex CLI is installed and needs user authentication.",
+        "verify_file": "~/.codex/auth.json",
+        "verify_json_paths": (("tokens", "access_token"), ("tokens", "refresh_token")),
+        "signed_in_detail": "cached credentials present",
     },
     {
         "id": "claude",
         "tool": "claude",
         "command": "claude login",
         "guidance": "Run when Claude Code CLI is installed and needs user authentication.",
+        "verify": ("claude", "auth", "status"),
     },
     {
         "id": "gemini",
         "tool": "gemini",
         "command": "gemini",
         "guidance": "Start Gemini CLI and complete its login/setup prompt if needed.",
+        "verify_file": "~/.gemini/oauth_creds.json",
+        "verify_json_paths": (("access_token",), ("refresh_token",)),
+        "signed_in_detail": "cached OAuth credentials present",
     },
     {
         "id": "copilot",
@@ -337,20 +345,28 @@ def _extend_auth_status(lines: list[str], auth_items: list[dict[str, Any]]) -> N
     if not visible:
         return
     lines.append("")
-    lines.append("Sign-in status:")
-    all_ok = all(item["state"] == "signed_in" for item in visible)
-    for item in visible:
-        state = item["state"]
-        if state == "signed_in":
-            marker = "[+]"
+    signed_in = [item for item in visible if item["state"] == "signed_in"]
+    pending = [item for item in visible if item["state"] == "available"]
+
+    if signed_in:
+        lines.append("Verified sign-ins:")
+        for item in signed_in:
             detail = item.get("signed_in_detail") or "signed in"
-        else:
-            marker = "[ ]"
-            detail = item["guidance"]
-        lines.append(f"  {marker} {item['command']}: {detail}")
-    if all_ok:
+            lines.append(f"  [+] {item['command']}: {detail}")
+        if not pending:
+            lines.append("")
+            lines.append("  All verifiable sign-ins confirmed.")
+
+    if pending:
+        if signed_in:
+            lines.append("")
+        lines.append("Pending sign-ins:")
+        for item in pending:
+            lines.append(f"  [ ] {item['command']}: {item['guidance']}")
+
+    if not signed_in and not pending:
         lines.append("")
-        lines.append("  All verifiable sign-ins confirmed.")
+        lines.append("  No auth guidance items applicable.")
 
 
 def _tool_check(item: dict[str, Any], search_path: str) -> dict[str, Any]:
@@ -380,7 +396,7 @@ def _auth_check(item: dict[str, str], search_path: str, home: Path) -> dict[str,
 
     verify_file = item.get("verify_file")
     if verify_file:
-        return _auth_check_verify_file(base, verify_file, home)
+        return _auth_check_verify_file(base, verify_file, home, item.get("verify_json_paths"), item.get("signed_in_detail"))
 
     verify = item.get("verify")
     if verify:
@@ -393,11 +409,27 @@ def _auth_tool_present(tool: str | None, search_path: str) -> bool:
     return bool(shutil.which(tool, path=search_path)) if tool else True
 
 
-def _auth_check_verify_file(base: dict[str, Any], verify_file: str, home: Path) -> dict[str, Any]:
+def _auth_check_verify_file(
+    base: dict[str, Any],
+    verify_file: str,
+    home: Path,
+    verify_json_paths: tuple[tuple[str, ...], ...] | None,
+    signed_in_detail: str | None,
+) -> dict[str, Any]:
     # Resolve ~ against the audited home, not the process home.
     p = home / verify_file.lstrip("~/") if verify_file.startswith("~/") else Path(verify_file)
-    if p.exists() and p.read_text().strip():
-        return {**base, "state": "signed_in", "signed_in_detail": f"token present at {verify_file}"}
+    if not p.exists():
+        return {**base, "state": "available"}
+    if verify_json_paths:
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {**base, "state": "available"}
+        if _json_paths_present(data, verify_json_paths):
+            return {**base, "state": "signed_in", "signed_in_detail": signed_in_detail or "cached credentials present"}
+        return {**base, "state": "available"}
+    if p.read_text().strip():
+        return {**base, "state": "signed_in", "signed_in_detail": signed_in_detail or "cached credentials present"}
     return {**base, "state": "available"}
 
 
@@ -425,7 +457,35 @@ def _auth_check_verify_command(
     return {**base, "state": "available"}
 
 
+def _json_paths_present(data: Any, paths: tuple[tuple[str, ...], ...]) -> bool:
+    for path in paths:
+        node = data
+        for key in path:
+            if not isinstance(node, dict) or key not in node:
+                return False
+            node = node[key]
+        if node in (None, "", [], {}):
+            return False
+    return True
+
+
 def _extract_signed_in_detail(output: str) -> str:
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        data = None
+    if isinstance(data, dict) and data.get("loggedIn") is True:
+        email = data.get("email")
+        org_name = data.get("orgName")
+        auth_method = data.get("authMethod")
+        if email and org_name:
+            return f"{email} ({org_name})"
+        if email:
+            return str(email)
+        if org_name:
+            return str(org_name)
+        if auth_method:
+            return str(auth_method)
     for line in output.splitlines():
         line = line.strip()
         if "logged in" in line.lower() or "account" in line.lower():

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -9,10 +9,9 @@ from .installer import build_plan, execute_manifest_operation
 from .reports import Report
 from .tool_installer import (
     TOOL_CACHE_REL,
+    collect_post_install_summary,
     build_tool_install_plan,
     execute_tool_install_operation,
-    run_post_install_actions,
-    verify_installed_tools,
 )
 
 
@@ -159,7 +158,20 @@ def apply_tool_installs(
         return plan
     report = _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
     if phase == "all":
-        _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner, backup_path)
+        summary = collect_post_install_summary(
+            home_path,
+            mode="all",
+            yes=yes,
+            runner=runner,
+            env=env,
+            repo_path=repo_path,
+            backup_dir=backup_path,
+        )
+        report.extra["verification"] = summary["verification"]
+        report.extra["post_install_actions"] = summary["post_install_actions"]
+        report.backups.extend(summary["backups"])
+        if summary["status"] == "warning":
+            report.status = "warning"
     return report
 
 
@@ -185,55 +197,23 @@ def run_tool_install_post_install(
         home=str(home_path),
         profile="machine",
     )
-    if mode == "verify":
-        verification = verify_installed_tools(home_path, runner=runner, env=env)
-        report.extra["verification"] = verification
-        if any(not item["verified"] for item in verification):
-            report.status = "warning"
-        return report
-
-    verification = verify_installed_tools(home_path, runner=runner, env=env) if mode == "all" else []
-    actions = run_post_install_actions(
+    summary = collect_post_install_summary(
         home_path,
-        yes=yes if mode == "all" else mode == "auto",
+        mode=mode,
+        yes=yes,
         runner=runner,
         env=env,
         repo_path=repo_path,
         backup_dir=backup_path,
     )
-    actions = _filter_post_install_actions(actions, mode)
-    if verification:
-        report.extra["verification"] = verification
-    report.extra["post_install_actions"] = actions
-    report.backups.extend(_collect_post_install_backups(actions))
-    if mode == "all" and any(not item["verified"] for item in verification):
-        report.status = "warning"
-    if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
+    if summary["verification"]:
+        report.extra["verification"] = summary["verification"]
+    if summary["post_install_actions"]:
+        report.extra["post_install_actions"] = summary["post_install_actions"]
+    report.backups.extend(summary["backups"])
+    if summary["status"] == "warning":
         report.status = "warning"
     return report
-
-
-def _attach_verification_and_post_install(
-    report: Report,
-    repo_path: Path,
-    home_path: Path,
-    yes: bool,
-    env: Mapping[str, str] | None,
-    runner: CommandRunner | None,
-    backup_dir: Path,
-) -> None:
-    if report.status == "failed":
-        return
-    verification = verify_installed_tools(home_path, runner=runner, env=env)
-    actions = run_post_install_actions(
-        home_path, yes=yes, runner=runner, env=env,
-        repo_path=repo_path, backup_dir=backup_dir,
-    )
-    report.extra["verification"] = verification
-    report.extra["post_install_actions"] = actions
-    report.backups.extend(_collect_post_install_backups(actions))
-    if any(not item["verified"] for item in verification):
-        report.status = "warning"
 
 
 def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -241,14 +221,6 @@ def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[st
     for action in actions:
         collected.extend(action.get("backups") or [])
     return collected
-
-
-def _filter_post_install_actions(actions: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:
-    if mode == "auto":
-        return [action for action in actions if action.get("kind") == "auto"]
-    if mode == "guidance":
-        return [action for action in actions if action.get("kind") == "guidance"]
-    return actions
 
 
 def _execute_bootstrap_operations(

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -18,6 +18,8 @@ from .tool_installer import (
 
 WARNING_STATES = {"missing", "drifted", "protected", "manual", "unsupported", "needs_update"}
 FAILED_STATES = {"invalid", "blocked"}
+TOOL_INSTALL_PHASES = {"all", "dev-base", "tools"}
+TOOL_POST_INSTALL_MODES = {"all", "verify", "auto", "guidance"}
 
 
 def build_bootstrap_plan(
@@ -104,12 +106,13 @@ def build_tool_install_subplan(
     repo: Path | str,
     home: Path | str,
     *,
+    phase: str = "all",
     env: Mapping[str, str] | None = None,
     runner: CommandRunner | None = None,
 ) -> Report:
     repo_path = Path(repo).resolve()
     home_path = Path(home).resolve()
-    tool_plan = build_tool_install_plan(home_path, env=env, runner=runner)
+    tool_plan = build_tool_install_plan(home_path, phase=phase, env=env, runner=runner)
     operations = list(tool_plan["operations"])
     _renumber_operations(operations)
     entries = list(tool_plan["entries"])
@@ -130,6 +133,7 @@ def apply_tool_installs(
     repo: Path | str,
     home: Path | str,
     *,
+    phase: str = "all",
     backup_dir: Path | str | None = None,
     yes: bool = False,
     env: Mapping[str, str] | None = None,
@@ -148,13 +152,64 @@ def apply_tool_installs(
             errors=[{"message": "bootstrap-install-tools requires --yes before writing"}],
         )
 
-    plan = build_tool_install_subplan(repo_path, home_path, env=env, runner=runner)
+    plan = build_tool_install_subplan(repo_path, home_path, phase=phase, env=env, runner=runner)
     plan.command = "bootstrap-install-tools"
     if plan.errors or any(entry.get("state") in FAILED_STATES for entry in plan.entries):
         plan.status = "failed"
         return plan
     report = _execute_bootstrap_operations(plan, repo_path, backup_path, runner)
-    _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner, backup_path)
+    if phase == "all":
+        _attach_verification_and_post_install(report, repo_path, home_path, yes, env, runner, backup_path)
+    return report
+
+
+def run_tool_install_post_install(
+    repo: Path | str,
+    home: Path | str,
+    *,
+    mode: str = "all",
+    yes: bool = False,
+    env: Mapping[str, str] | None = None,
+    runner: CommandRunner | None = None,
+    backup_dir: Path | str | None = None,
+) -> Report:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    if mode not in TOOL_POST_INSTALL_MODES:
+        raise ValueError(f"unknown tool post-install mode: {mode}")
+    report = Report(
+        "bootstrap-install-tools-verify" if mode == "verify" else "bootstrap-install-tools-post",
+        "ok",
+        str(repo_path),
+        home=str(home_path),
+        profile="machine",
+    )
+    if mode == "verify":
+        verification = verify_installed_tools(home_path, runner=runner, env=env)
+        report.extra["verification"] = verification
+        if any(not item["verified"] for item in verification):
+            report.status = "warning"
+        return report
+
+    verification = verify_installed_tools(home_path, runner=runner, env=env) if mode == "all" else []
+    actions = run_post_install_actions(
+        home_path,
+        yes=yes if mode == "all" else mode == "auto",
+        runner=runner,
+        env=env,
+        repo_path=repo_path,
+        backup_dir=backup_path,
+    )
+    actions = _filter_post_install_actions(actions, mode)
+    if verification:
+        report.extra["verification"] = verification
+    report.extra["post_install_actions"] = actions
+    report.backups.extend(_collect_post_install_backups(actions))
+    if mode == "all" and any(not item["verified"] for item in verification):
+        report.status = "warning"
+    if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
+        report.status = "warning"
     return report
 
 
@@ -186,6 +241,14 @@ def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[st
     for action in actions:
         collected.extend(action.get("backups") or [])
     return collected
+
+
+def _filter_post_install_actions(actions: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:
+    if mode == "auto":
+        return [action for action in actions if action.get("kind") == "auto"]
+    if mode == "guidance":
+        return [action for action in actions if action.get("kind") == "guidance"]
+    return actions
 
 
 def _execute_bootstrap_operations(

--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -167,11 +167,7 @@ def apply_tool_installs(
             repo_path=repo_path,
             backup_dir=backup_path,
         )
-        report.extra["verification"] = summary["verification"]
-        report.extra["post_install_actions"] = summary["post_install_actions"]
-        report.backups.extend(summary["backups"])
-        if summary["status"] == "warning":
-            report.status = "warning"
+        _attach_post_install_summary(report, summary)
     return report
 
 
@@ -206,13 +202,7 @@ def run_tool_install_post_install(
         repo_path=repo_path,
         backup_dir=backup_path,
     )
-    if summary["verification"]:
-        report.extra["verification"] = summary["verification"]
-    if summary["post_install_actions"]:
-        report.extra["post_install_actions"] = summary["post_install_actions"]
-    report.backups.extend(summary["backups"])
-    if summary["status"] == "warning":
-        report.status = "warning"
+    _attach_post_install_summary(report, summary)
     return report
 
 
@@ -221,6 +211,16 @@ def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[st
     for action in actions:
         collected.extend(action.get("backups") or [])
     return collected
+
+
+def _attach_post_install_summary(report: Report, summary: dict[str, Any]) -> None:
+    if summary["verification"]:
+        report.extra["verification"] = summary["verification"]
+    if summary["post_install_actions"]:
+        report.extra["post_install_actions"] = summary["post_install_actions"]
+    report.backups.extend(summary["backups"])
+    if summary["status"] == "warning":
+        report.status = "warning"
 
 
 def _execute_bootstrap_operations(

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -9,6 +9,7 @@ from .bootstrap import (
     apply_tool_installs,
     build_bootstrap_plan,
     build_tool_install_subplan,
+    run_tool_install_post_install,
 )
 from .doctor import run_doctor
 from .installer import apply_plan, build_plan
@@ -65,6 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _common(install_tools_plan)
     install_tools_plan.add_argument("--home", required=True)
+    install_tools_plan.add_argument("--phase", choices=("all", "dev-base", "tools"), default="all")
 
     install_tools_apply = subparsers.add_parser(
         "bootstrap-install-tools",
@@ -74,6 +76,17 @@ def build_parser() -> argparse.ArgumentParser:
     install_tools_apply.add_argument("--home", required=True)
     install_tools_apply.add_argument("--backup-dir")
     install_tools_apply.add_argument("--yes", action="store_true")
+    install_tools_apply.add_argument("--phase", choices=("all", "dev-base", "tools"), default="all")
+
+    install_tools_post = subparsers.add_parser(
+        "bootstrap-install-tools-post",
+        help="Run tool verification and post-install actions",
+    )
+    _common(install_tools_post)
+    install_tools_post.add_argument("--home", required=True)
+    install_tools_post.add_argument("--backup-dir")
+    install_tools_post.add_argument("--yes", action="store_true")
+    install_tools_post.add_argument("--mode", choices=("all", "verify", "auto", "guidance"), default="all")
 
     project = subparsers.add_parser("init-project", help="Initialize project-level agent docs")
     _common(project)
@@ -137,9 +150,15 @@ def _dispatch_bootstrap(args: argparse.Namespace, repo: Path):
             yes=args.yes, include_protected=args.include_protected,
         )
     elif cmd == "bootstrap-install-tools-plan":
-        report = build_tool_install_subplan(repo, args.home)
+        report = build_tool_install_subplan(repo, args.home, phase=args.phase)
     elif cmd == "bootstrap-install-tools":
-        report = apply_tool_installs(repo, args.home, backup_dir=args.backup_dir, yes=args.yes)
+        report = apply_tool_installs(
+            repo, args.home, phase=args.phase, backup_dir=args.backup_dir, yes=args.yes
+        )
+    elif cmd == "bootstrap-install-tools-post":
+        report = run_tool_install_post_install(
+            repo, args.home, mode=args.mode, backup_dir=args.backup_dir, yes=args.yes
+        )
     else:
         raise SystemExit(f"unknown command: {cmd}")
     return report

--- a/dotfiles_tools/font_runner.py
+++ b/dotfiles_tools/font_runner.py
@@ -17,7 +17,14 @@ class CommandRunner:
     def which(self, command: str) -> str | None:
         return shutil.which(command, path=self.path)
 
-    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(
+        self,
+        args: list[str],
+        *,
+        capture_output: bool = False,
+        check: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = dict(self.env)
         env["PATH"] = self.path
         # codacy-disable-next-line
@@ -27,6 +34,7 @@ class CommandRunner:
             capture_output=capture_output,
             text=True,
             env=env,
+            timeout=timeout,
             shell=False,
         )
 

--- a/dotfiles_tools/machine_summary.py
+++ b/dotfiles_tools/machine_summary.py
@@ -240,8 +240,8 @@ def _extend_auth_guidance_context(lines: list[str], doctor: Report) -> None:
     pending = [item for item in auth_guidance if item.get("state") == "available"]
     signed_in = [item for item in auth_guidance if item.get("state") == "signed_in"]
     if signed_in:
-        names = ", ".join(str(item.get("id")) for item in signed_in)
-        lines.append(f"  - Already signed in: {names}.")
+        identities = ", ".join(_auth_identity_label(item) for item in signed_in)
+        lines.append(f"  - Verified sign-ins: {identities}.")
     if pending:
         commands = ", ".join(str(item.get("command")) for item in pending)
         lines.append(f"  - Pending sign-ins: {commands}.")
@@ -475,13 +475,20 @@ def _extend_auth_summary_line(lines: list[str], auth_guidance: list[dict[str, An
     pending = [item for item in auth_guidance if item.get("state") == "available"]
     signed_in = [item for item in auth_guidance if item.get("state") == "signed_in"]
     if signed_in:
-        names = ", ".join(str(item.get("id")) for item in signed_in)
-        lines.append(f"  - Verified sign-ins: {names}.")
+        identities = ", ".join(_auth_identity_label(item) for item in signed_in)
+        lines.append(f"  - Verified sign-ins: {identities}.")
     if pending:
         commands = ", ".join(str(item.get("command")) for item in pending)
         lines.append(f"  - Auth checks are manual: {commands}.")
     elif not signed_in:
         lines.append("  - No auth guidance items applicable.")
+
+
+def _auth_identity_label(item: dict[str, Any]) -> str:
+    detail = item.get("signed_in_detail")
+    if detail:
+        return f"{item.get('id')}={detail}"
+    return str(item.get("id"))
 
 
 def _target_label(entry: dict[str, Any], manifest_entries: dict[str, ManifestEntry]) -> str:

--- a/dotfiles_tools/reports.py
+++ b/dotfiles_tools/reports.py
@@ -246,7 +246,7 @@ def _tool_installed_line(item: dict[str, Any]) -> str:
         "apt": "apt --only-upgrade",
         "apt_keyring": "apt --only-upgrade (keyring repo)",
         "curl_installer": "re-run installer (self-update)",
-        "npm": "npm update -g",
+        "npm": "npm update -g --prefix ~/.local",
     }.get(method, "skip")
     label = item.get("label") or item.get("command") or item.get("entry_id")
     path = item.get("current_path") or ""
@@ -261,7 +261,7 @@ def _tool_missing_line(item: dict[str, Any]) -> str:
         "apt": "apt (sudo)",
         "apt_keyring": "apt + keyring repo (sudo)",
         "curl_installer": "curl installer (no sudo)",
-        "npm": "npm install -g (sudo)",
+        "npm": "npm install -g --prefix ~/.local",
     }.get(method, method or "manual")
     label = item.get("label") or item.get("command") or item.get("entry_id")
     return f"    - {label}: {method_label}"

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import shutil
+import subprocess  # nosec B404
 import sys
 from typing import Any, Mapping
 
@@ -32,6 +33,7 @@ __all__ = (
 def build_tool_install_plan(
     home: Path | str,
     *,
+    phase: str = "all",
     env: Mapping[str, str] | None = None,
     path: str | None = None,
     runner: CommandRunner | None = None,
@@ -44,13 +46,17 @@ def build_tool_install_plan(
 
     if not _is_linux(effective_env):
         return _unsupported_plan(effective_runner)
+    if phase not in {"all", "dev-base", "tools"}:
+        raise ValueError(f"unknown tool install phase: {phase}")
 
     entries: list[dict[str, Any]] = []
     operations: list[dict[str, Any]] = []
     tools: list[dict[str, Any]] = []
 
-    _extend_dev_base_plan(effective_runner, cache_dir, entries, operations, tools)
-    _extend_tool_baseline_plan(effective_runner, cache_dir, entries, operations, tools)
+    if phase in {"all", "dev-base"}:
+        _extend_dev_base_plan(effective_runner, cache_dir, entries, operations, tools)
+    if phase in {"all", "tools"}:
+        _extend_tool_baseline_plan(effective_runner, cache_dir, home_path, entries, operations, tools)
 
     return {"entries": entries, "operations": operations, "tools": tools}
 
@@ -228,6 +234,7 @@ def _dev_base_operations(
 def _extend_tool_baseline_plan(
     runner: CommandRunner,
     cache_dir: Path,
+    home: Path,
     entries: list[dict[str, Any]],
     operations: list[dict[str, Any]],
     tools: list[dict[str, Any]],
@@ -235,7 +242,7 @@ def _extend_tool_baseline_plan(
     for item in TOOL_BASELINE:
         if not item.get("bootstrap") or item["install_method"] == "manual":
             continue
-        entry, ops = _plan_tool_entry(item, runner, cache_dir)
+        entry, ops = _plan_tool_entry(item, runner, cache_dir, home)
         entries.append(entry)
         tools.append(entry)
         operations.extend(ops)
@@ -245,6 +252,7 @@ def _plan_tool_entry(
     item: Mapping[str, Any],
     runner: CommandRunner,
     cache_dir: Path,
+    home: Path,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     method = item["install_method"]
     found_path = runner.which(item["command"])
@@ -257,21 +265,28 @@ def _plan_tool_entry(
         "requires_sudo": item.get("requires_sudo", False),
     }
     if found_path:
+        current_version = _current_version_for_tool(item["command"], found_path, runner)
         base_entry.update(
             {
                 "state": "installed",
                 "current_path": found_path,
-                "current_version": _detect_version(item["command"], found_path, runner),
+                "current_version": current_version,
                 "action": "upgrade",
             }
         )
     else:
         base_entry.update({"state": "missing", "action": "install"})
-    ops = _tool_operations(item, cache_dir, mode="upgrade" if found_path else "install")
+    ops = _tool_operations(item, cache_dir, home, mode="upgrade" if found_path else "install")
     return base_entry, ops
 
 
-def _tool_operations(item: Mapping[str, Any], cache_dir: Path, *, mode: str) -> list[dict[str, Any]]:
+def _tool_operations(
+    item: Mapping[str, Any],
+    cache_dir: Path,
+    home: Path,
+    *,
+    mode: str,
+) -> list[dict[str, Any]]:
     method = item["install_method"]
     iargs = dict(item.get("install_args", {}))
     entry_id = f"tools.{item['id']}"
@@ -291,7 +306,7 @@ def _tool_operations(item: Mapping[str, Any], cache_dir: Path, *, mode: str) -> 
     if method == "curl_installer":
         return [_curl_op(entry_id, item, iargs, cache_dir, mode=mode)]
     if method == "npm":
-        return [_npm_op(entry_id, item, iargs, cache_dir, mode=mode)]
+        return [_npm_op(entry_id, item, iargs, cache_dir, home, mode=mode)]
     if method == "uv_tool":
         return [_uv_tool_op(entry_id, item, iargs, cache_dir, mode=mode)]
     return []
@@ -380,21 +395,24 @@ def _npm_op(
     item: Mapping[str, Any],
     args: Mapping[str, Any],
     cache_dir: Path,
+    home: Path,
     *,
     mode: str,
 ) -> dict[str, Any]:
     op_type = "tool_install_npm" if mode == "install" else "tool_install_npm_upgrade"
+    prefix = home / ".local"
     return {
         "entry_id": entry_id,
         "recipe": "tool_installs",
         "type": op_type,
         "mode": mode,
         "package": args["package"],
-        "requires_sudo": item.get("requires_sudo", True),
+        "prefix": str(prefix),
+        "requires_sudo": item.get("requires_sudo", False),
         "requires_network": True,
         "requires_approval": True,
         "cache_dir": str(cache_dir),
-        "reason": f"{mode} {item['label']} via npm",
+        "reason": f"{mode} {item['label']} via npm in {prefix}",
     }
 
 
@@ -445,12 +463,33 @@ def _dpkg_installed(runner: CommandRunner, package: str) -> bool:
 
 
 def _detect_version(command: str, found_path: str, runner: CommandRunner) -> str:
+    if command == "codacy-cli":
+        return _detect_codacy_cli_version(found_path)
     try:
-        result = runner.run([found_path, "--version"], capture_output=True, check=False)
-    except (OSError, RuntimeError):
+        result = runner.run([found_path, "--version"], capture_output=True, check=False, timeout=5)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired):
         return ""
     output = (result.stdout or "").strip().splitlines()
     return output[0] if output else ""
+
+
+def _current_version_for_tool(command: str, found_path: str, runner: CommandRunner) -> str:
+    return _detect_version(command, found_path, runner)
+
+
+def _detect_codacy_cli_version(found_path: str) -> str:
+    version_file = Path(found_path).expanduser().resolve().parent.parent / "version.yaml"
+    try:
+        text = version_file.read_text()
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("version:"):
+            _, _, raw_value = line.partition(":")
+            version = raw_value.strip().strip('"')
+            return version
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -552,11 +591,12 @@ def _execute_npm(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int
     if not npm:
         op["result"] = "npm not found; install Node first or re-run option 1 after dev-base completes"
         return 0
+    prefix_dir = str(op.get("prefix") or (Path.home() / ".local"))
     prefix = _sudo_prefix() if op.get("requires_sudo", True) else []
     if mode == "upgrade":
-        runner.run([*prefix, npm, "update", "-g", package])
+        runner.run([*prefix, npm, "update", "-g", "--prefix", prefix_dir, package])
     else:
-        runner.run([*prefix, npm, "install", "-g", package])
+        runner.run([*prefix, npm, "install", "-g", "--prefix", prefix_dir, package])
     return 1
 
 

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -678,11 +678,13 @@ def collect_post_install_summary(
     if mode not in {"all", "verify", "auto", "guidance"}:
         raise ValueError(f"unknown tool post-install mode: {mode}")
 
-    effective_env = dict(os.environ if env is None else env)
-    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
-    repo = Path(repo_path).resolve() if repo_path else None
-    home_path = Path(home).expanduser().resolve()
-    backup = Path(backup_dir).expanduser().resolve() if backup_dir else None
+    effective_env, effective_runner, repo, home_path, backup = _post_install_context(
+        home,
+        env=env,
+        runner=runner,
+        repo_path=repo_path,
+        backup_dir=backup_dir,
+    )
 
     summary: dict[str, Any] = {"verification": [], "post_install_actions": [], "backups": [], "status": "ok"}
     if mode == "verify":
@@ -710,6 +712,22 @@ def collect_post_install_summary(
     if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
         summary["status"] = "warning"
     return summary
+
+
+def _post_install_context(
+    home: Path | str,
+    *,
+    env: Mapping[str, str] | None,
+    runner: CommandRunner | None,
+    repo_path: Path | str | None,
+    backup_dir: Path | str | None,
+) -> tuple[dict[str, str], CommandRunner, Path | None, Path, Path | None]:
+    effective_env = dict(os.environ if env is None else env)
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
+    repo = Path(repo_path).resolve() if repo_path else None
+    home_path = Path(home).expanduser().resolve()
+    backup = Path(backup_dir).expanduser().resolve() if backup_dir else None
+    return effective_env, effective_runner, repo, home_path, backup
 
 
 def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -727,25 +727,14 @@ def _collect_post_install_action_summary(
         repo_path=repo_path,
         backup_dir=backup_dir,
     )
-    summary: dict[str, Any] = {"verification": [], "post_install_actions": [], "backups": [], "status": "ok"}
-    verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env) if mode == "all" else []
-    actions = run_post_install_actions(
-        home_path,
-        yes=yes if mode == "all" else mode == "auto",
-        runner=effective_runner,
-        env=effective_env,
-        repo_path=repo,
-        backup_dir=backup,
-    )
-    actions = _filter_post_install_actions(actions, mode)
-    summary["verification"] = verification
-    summary["post_install_actions"] = actions
-    summary["backups"] = _collect_post_install_backups(actions)
-    if mode == "all" and any(not item["verified"] for item in verification):
-        summary["status"] = "warning"
-    if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
-        summary["status"] = "warning"
-    return summary
+    verification = _collect_post_install_verification(mode, home_path, effective_env, effective_runner)
+    actions = _collect_post_install_actions(mode, yes, home_path, effective_env, effective_runner, repo, backup)
+    return {
+        "verification": verification,
+        "post_install_actions": actions,
+        "backups": _collect_post_install_backups(actions),
+        "status": _post_install_summary_status(mode, verification, actions),
+    }
 
 
 def _post_install_context(
@@ -769,6 +758,49 @@ def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[st
     for action in actions:
         collected.extend(action.get("backups") or [])
     return collected
+
+
+def _collect_post_install_verification(
+    mode: str,
+    home_path: Path,
+    env: Mapping[str, str],
+    runner: CommandRunner,
+) -> list[dict[str, Any]]:
+    if mode != "all":
+        return []
+    return verify_installed_tools(home_path, runner=runner, env=env)
+
+
+def _collect_post_install_actions(
+    mode: str,
+    yes: bool,
+    home_path: Path,
+    env: Mapping[str, str],
+    runner: CommandRunner,
+    repo: Path | None,
+    backup: Path | None,
+) -> list[dict[str, Any]]:
+    actions = run_post_install_actions(
+        home_path,
+        yes=yes if mode == "all" else mode == "auto",
+        runner=runner,
+        env=env,
+        repo_path=repo,
+        backup_dir=backup,
+    )
+    return _filter_post_install_actions(actions, mode)
+
+
+def _post_install_summary_status(
+    mode: str,
+    verification: list[dict[str, Any]],
+    actions: list[dict[str, Any]],
+) -> str:
+    if mode == "all" and any(not item["verified"] for item in verification):
+        return "warning"
+    if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
+        return "warning"
+    return "ok"
 
 
 def _filter_post_install_actions(actions: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -24,6 +24,7 @@ __all__ = (
     "build_tool_install_plan",
     "execute_tool_install_operation",
     "verify_installed_tools",
+    "collect_post_install_summary",
     "run_post_install_actions",
     "TOOL_CACHE_REL",
     "DEV_BASE_ENTRY_ID",
@@ -662,6 +663,68 @@ def verify_installed_tools(
             "version": version,
         })
     return results
+
+
+def collect_post_install_summary(
+    home: Path | str,
+    *,
+    mode: str = "all",
+    yes: bool = False,
+    runner: CommandRunner | None = None,
+    env: Mapping[str, str] | None = None,
+    repo_path: Path | str | None = None,
+    backup_dir: Path | str | None = None,
+) -> dict[str, Any]:
+    if mode not in {"all", "verify", "auto", "guidance"}:
+        raise ValueError(f"unknown tool post-install mode: {mode}")
+
+    effective_env = dict(os.environ if env is None else env)
+    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
+    repo = Path(repo_path).resolve() if repo_path else None
+    home_path = Path(home).expanduser().resolve()
+    backup = Path(backup_dir).expanduser().resolve() if backup_dir else None
+
+    summary: dict[str, Any] = {"verification": [], "post_install_actions": [], "backups": [], "status": "ok"}
+    if mode == "verify":
+        verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env)
+        summary["verification"] = verification
+        if any(not item["verified"] for item in verification):
+            summary["status"] = "warning"
+        return summary
+
+    verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env) if mode == "all" else []
+    actions = run_post_install_actions(
+        home_path,
+        yes=yes if mode == "all" else mode == "auto",
+        runner=effective_runner,
+        env=effective_env,
+        repo_path=repo,
+        backup_dir=backup,
+    )
+    actions = _filter_post_install_actions(actions, mode)
+    summary["verification"] = verification
+    summary["post_install_actions"] = actions
+    summary["backups"] = _collect_post_install_backups(actions)
+    if mode == "all" and any(not item["verified"] for item in verification):
+        summary["status"] = "warning"
+    if mode in {"auto", "all"} and any(item.get("status") == "failed" for item in actions):
+        summary["status"] = "warning"
+    return summary
+
+
+def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    collected: list[dict[str, Any]] = []
+    for action in actions:
+        collected.extend(action.get("backups") or [])
+    return collected
+
+
+def _filter_post_install_actions(actions: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:
+    if mode == "auto":
+        return [action for action in actions if action.get("kind") == "auto"]
+    if mode == "guidance":
+        return [action for action in actions if action.get("kind") == "guidance"]
+    return actions
 
 
 def run_post_install_actions(

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -678,6 +678,48 @@ def collect_post_install_summary(
     if mode not in {"all", "verify", "auto", "guidance"}:
         raise ValueError(f"unknown tool post-install mode: {mode}")
 
+    if mode == "verify":
+        return _collect_post_install_verify_summary(home, env=env, runner=runner)
+
+    return _collect_post_install_action_summary(
+        home,
+        mode=mode,
+        yes=yes,
+        env=env,
+        runner=runner,
+        repo_path=repo_path,
+        backup_dir=backup_dir,
+    )
+
+
+def _collect_post_install_verify_summary(
+    home: Path | str,
+    *,
+    env: Mapping[str, str] | None,
+    runner: CommandRunner | None,
+) -> dict[str, Any]:
+    effective_env, effective_runner, _, home_path, _ = _post_install_context(
+        home,
+        env=env,
+        runner=runner,
+        repo_path=None,
+        backup_dir=None,
+    )
+    verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env)
+    status = "warning" if any(not item["verified"] for item in verification) else "ok"
+    return {"verification": verification, "post_install_actions": [], "backups": [], "status": status}
+
+
+def _collect_post_install_action_summary(
+    home: Path | str,
+    *,
+    mode: str,
+    yes: bool,
+    env: Mapping[str, str] | None,
+    runner: CommandRunner | None,
+    repo_path: Path | str | None,
+    backup_dir: Path | str | None,
+) -> dict[str, Any]:
     effective_env, effective_runner, repo, home_path, backup = _post_install_context(
         home,
         env=env,
@@ -685,15 +727,7 @@ def collect_post_install_summary(
         repo_path=repo_path,
         backup_dir=backup_dir,
     )
-
     summary: dict[str, Any] = {"verification": [], "post_install_actions": [], "backups": [], "status": "ok"}
-    if mode == "verify":
-        verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env)
-        summary["verification"] = verification
-        if any(not item["verified"] for item in verification):
-            summary["status"] = "warning"
-        return summary
-
     verification = verify_installed_tools(home_path, runner=effective_runner, env=effective_env) if mode == "all" else []
     actions = run_post_install_actions(
         home_path,

--- a/fish/functions/direnv.fish
+++ b/fish/functions/direnv.fish
@@ -1,13 +1,3 @@
-function direnv --description "direnv wrapper that locks .envrc after allow"
-    if test "$argv[1]" = "allow"
-        command direnv allow $argv[2..]
-        if test -f .envrc
-            chmod 444 .envrc
-            and sudo chattr +i .envrc
-            and echo "direnv: .envrc locked (chmod 444 + chattr +i)"
-            or echo "direnv: .envrc chmod 444 applied (chattr +i requires sudo)"
-        end
-    else
-        command direnv $argv
-    end
+function direnv --description "pass-through wrapper for direnv"
+    command direnv $argv
 end

--- a/setup
+++ b/setup
@@ -354,7 +354,7 @@ check_api_credentials() {
 
   # Check gh CLI
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    echo "  GitHub (gh)          ✓ Authenticated"
+    echo "  GitHub (gh)          ✓ verified: $(gh_identity_summary)"
   else
     echo "  GitHub (gh)          ✗ Not configured"
   fi
@@ -367,34 +367,98 @@ check_api_credentials() {
   fi
 
   # Check Codacy account token — prefer env var, fall back to file
-  local codacy_token="${CODACY_ACCOUNT_TOKEN:-}"
-  if [[ -z "$codacy_token" && -f "$HOME/.codacy/account-token" ]]; then
-    codacy_token="$(cat "$HOME/.codacy/account-token")"
-  fi
-  if [[ -n "$codacy_token" ]] && command -v curl >/dev/null 2>&1; then
-    local codacy_response codacy_name
-    codacy_response="$(curl -sf --max-time 5 \
-      -H "api-token: $codacy_token" \
-      "https://app.codacy.com/api/v3/user" 2>/dev/null || true)"
-    if [[ -n "$codacy_response" ]]; then
-      if command -v jq >/dev/null 2>&1; then
-        codacy_name="$(printf '%s' "$codacy_response" | jq -r '.data.name // empty' 2>/dev/null || true)"
-      else
-        codacy_name="$(printf '%s' "$codacy_response" | python3 -c \
-          'import json,sys; d=json.load(sys.stdin); print(d["data"]["name"])' 2>/dev/null || true)"
-      fi
-      if [[ -n "$codacy_name" ]]; then
-        echo "  Codacy               ✓ Authenticated as $codacy_name"
-      else
-        echo "  Codacy               ✗ Token invalid (API call failed)"
-      fi
-    else
-      echo "  Codacy               ✗ Token invalid (no response from API)"
-    fi
-  elif [[ -n "$codacy_token" ]]; then
-    echo "  Codacy               ✓ Token found (curl unavailable, skipping live check)"
+  local codacy_details
+  codacy_details="$(codacy_account_details "$PWD")"
+  if [[ -n "$codacy_details" ]]; then
+    echo "  Codacy               ✓ $codacy_details"
   else
     echo "  Codacy               ✗ Not configured"
+  fi
+}
+
+gh_identity_summary() {
+  local response login name
+  response="$(gh api user --jq '{login: .login, name: .name}' 2>/dev/null || true)"
+  if [[ -z "$response" ]]; then
+    echo "Authenticated"
+    return 0
+  fi
+  login="$(printf '%s' "$response" | jq -r '.login // empty' 2>/dev/null || true)"
+  name="$(printf '%s' "$response" | jq -r '.name // empty' 2>/dev/null || true)"
+  if [[ -n "$login" && -n "$name" ]]; then
+    printf '%s (%s)' "$login" "$name"
+  elif [[ -n "$login" ]]; then
+    printf '%s' "$login"
+  else
+    echo "authenticated"
+  fi
+}
+
+codacy_account_token_value() {
+  local token="${CODACY_ACCOUNT_TOKEN:-}"
+  if [[ -z "$token" && -f "$HOME/.codacy/account-token" ]]; then
+    token="$(cat "$HOME/.codacy/account-token")"
+  fi
+  printf '%s' "$token"
+}
+
+codacy_account_identity() {
+  local token="$1" codacy_response codacy_name
+  [[ -n "$token" ]] || return 1
+  command -v curl >/dev/null 2>&1 || return 1
+  codacy_response="$(curl -sf --max-time 5 \
+    -H "api-token: $token" \
+    "https://app.codacy.com/api/v3/user" 2>/dev/null || true)"
+  [[ -n "$codacy_response" ]] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    codacy_name="$(printf '%s' "$codacy_response" | jq -r '.data.name // .data.username // empty' 2>/dev/null || true)"
+  else
+    codacy_name="$(printf '%s' "$codacy_response" | python3 -c \
+      'import json,sys; d=json.load(sys.stdin); print(d["data"].get("name") or d["data"].get("username") or "")' 2>/dev/null || true)"
+  fi
+  [[ -n "$codacy_name" ]] || return 1
+  printf '%s' "$codacy_name"
+}
+
+codacy_project_scope() {
+  local project="$1" identity owner repo project_token_file
+  identity="$(detect_github_identity "$project" 2>/dev/null || true)"
+  [[ -n "$identity" ]] || return 1
+  local -a identity_lines=()
+  mapfile -t identity_lines <<<"$identity"
+  owner="${identity_lines[0]:-}"
+  repo="${identity_lines[1]:-}"
+  [[ -n "$owner" && -n "$repo" ]] || return 1
+  project_token_file="$HOME/.codacy/$(codacy_safe_name "$owner")-$(codacy_safe_name "$repo").project-token"
+  [[ -f "$project_token_file" ]] || return 1
+  printf '%s/%s' "$owner" "$repo"
+}
+
+codacy_account_details() {
+  local project="$1" token account_name project_scope details=()
+  token="$(codacy_account_token_value)"
+  if [[ -n "$token" ]]; then
+    account_name="$(codacy_account_identity "$token" || true)"
+    [[ -n "$account_name" ]] && details+=("account=$account_name")
+  fi
+  project_scope="$(codacy_project_scope "$project" || true)"
+  [[ -n "$project_scope" ]] && details+=("project=$project_scope")
+  if [[ ${#details[@]} -gt 0 ]]; then
+    printf '%s' "${details[0]}"
+    local i
+    for ((i = 1; i < ${#details[@]}; i++)); do
+      printf ', %s' "${details[i]}"
+    done
+  fi
+}
+
+codacy_account_status() {
+  local details
+  details="$(codacy_account_details "$1")"
+  if [[ -n "$details" ]]; then
+    printf 'verified: %s' "$details"
+  else
+    printf 'needs setup'
   fi
 }
 
@@ -948,33 +1012,189 @@ run_machine_apply() {
 }
 
 run_machine_install_tools_preview() {
+  local phase="${1:-all}"
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools-plan \
     --repo "$DOTFILES_REPO" \
-    --home "$HOME")
+    --home "$HOME" \
+    --phase "$phase")
 }
 
 run_machine_install_tools_apply() {
+  local phase="${1:-all}"
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools \
     --repo "$DOTFILES_REPO" \
     --home "$HOME" \
     --backup-dir "$HOME/.dotfiles-backups" \
+    --phase "$phase" \
     --yes)
 }
 
-run_machine_install_tools_with_confirm() {
+run_machine_install_tools_post_install_verify() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools-post \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --backup-dir "$HOME/.dotfiles-backups" \
+    --mode verify)
+}
+
+run_machine_install_tools_post_install_auto() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools-post \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --backup-dir "$HOME/.dotfiles-backups" \
+    --mode auto \
+    --yes)
+}
+
+run_machine_install_tools_post_install_guidance() {
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools bootstrap-install-tools-post \
+    --repo "$DOTFILES_REPO" \
+    --home "$HOME" \
+    --backup-dir "$HOME/.dotfiles-backups" \
+    --mode guidance)
+}
+
+run_machine_install_tools_phase_with_confirm() {
+  local phase="$1"
+  local label="$2"
   echo
-  run_machine_install_tools_preview
+  echo "Preparing ${label} preview..."
+  run_machine_install_tools_preview "$phase"
   echo
-  printf 'Apply tool install/update actions? [y/N]: '
+  echo "Preview complete."
+  printf 'Apply %s actions? [y/N]: ' "$label"
   local confirm
   if read -r -e confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
     echo
-    run_machine_install_tools_apply || return $?
+    run_machine_install_tools_apply "$phase" || return $?
     return 2
   else
     echo "No tool changes applied."
     return 2
   fi
+}
+
+run_machine_install_tools_apply_with_confirm() {
+  local phase="$1"
+  local label="$2"
+  echo
+  echo "Preparing ${label} for apply..."
+  run_machine_install_tools_preview "$phase"
+  echo
+  echo "Preview complete."
+  printf 'Apply %s actions? [y/N]: ' "$label"
+  local confirm
+  if read -r -e confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
+    echo
+    run_machine_install_tools_apply "$phase" || return $?
+    return 2
+  else
+    echo "No tool changes applied."
+    return 2
+  fi
+}
+
+run_machine_install_tools_post_install_verify_only() {
+  echo
+  echo "Verifying installed tools only..."
+  run_machine_install_tools_post_install_verify || return $?
+  return 2
+}
+
+run_machine_install_tools_post_install_auto_with_confirm() {
+  echo
+  echo "Preparing auto post-install actions..."
+  printf 'Run auto post-install actions? [y/N]: '
+  local confirm
+  if read -r -e confirm && [[ "$confirm" =~ ^[Yy]$ ]]; then
+    echo
+    run_machine_install_tools_post_install_auto || return $?
+    return 2
+  else
+    echo "No tool changes applied."
+    return 2
+  fi
+}
+
+run_machine_install_tools_post_install_guidance_only() {
+  echo
+  echo "Manual post-install guidance:"
+  run_machine_install_tools_post_install_guidance || return $?
+  return 2
+}
+
+tool_install_phase_menu_loop() {
+  while true; do
+    echo
+    echo "Developer tool phases:"
+    cat <<EOF
+  1. Preview dev-base packages.
+  2. Apply dev-base packages.
+  3. Preview individual tool installers.
+  4. Apply individual tool installers.
+  5. Split post-install verification and guidance.
+  6. Back to main menu.
+EOF
+    printf 'Choose [1-6]: '
+    local choice
+    if ! read -r -e choice; then
+      echo
+      return 0
+    fi
+    case "$choice" in
+      1)
+        echo
+        echo "Preparing dev-base package preview..."
+        run_machine_install_tools_preview dev-base || { echo "Dev-base preview failed." >&2; continue; }
+        echo
+        echo "Preview complete."
+        ;;
+      2)
+        run_machine_install_tools_phase_with_confirm dev-base "dev-base packages" || return $?
+        ;;
+      3)
+        echo
+        echo "Preparing individual tool installer preview..."
+        run_machine_install_tools_preview tools || { echo "Tool installer preview failed." >&2; continue; }
+        echo
+        echo "Preview complete."
+        ;;
+      4)
+        run_machine_install_tools_apply_with_confirm tools "individual tool installers" || return $?
+      ;;
+      5)
+        while true; do
+          echo
+          echo "Post-install phases:"
+          cat <<EOF
+  1. Verify installed tools only.
+  2. Run auto post-install actions.
+  3. Show manual post-install guidance.
+  4. Back to main menu.
+EOF
+          printf 'Choose [1-4]: '
+          local post_choice
+          if ! read -r -e post_choice; then
+            echo
+            return 0
+          fi
+          case "$post_choice" in
+            1) run_machine_install_tools_post_install_verify_only || return $? ;;
+            2) run_machine_install_tools_post_install_auto_with_confirm || return $? ;;
+            3) run_machine_install_tools_post_install_guidance_only || return $? ;;
+            4|"") return 0 ;;
+            *) echo "Unknown choice: $post_choice" >&2 ;;
+          esac
+        done
+        ;;
+      6|"")
+        return 0
+        ;;
+      *)
+        echo "Unknown choice: $choice" >&2
+        ;;
+    esac
+  done
 }
 
 ensure_project_envrc_local() {
@@ -1044,12 +1264,68 @@ show_tool_auth_commands() {
   (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools.baseline)
 }
 
+print_summary_section() {
+  local summary_text="$1"
+  local section_title="$2"
+  printf '%s\n' "$summary_text" | awk -v title="$section_title" '
+    $0 == title ":" { printing = 1; print; next }
+    printing && /^[^ ]/ { exit }
+    printing { print }
+  '
+}
+
+show_safe_changes_preview() {
+  local summary_text="$1"
+  local preview_kind="$2"
+  case "$preview_kind" in
+    dotfiles)
+      echo "Dotfiles and config files:"
+      print_summary_section "$summary_text" "Update existing files with backups"
+      print_summary_section "$summary_text" "Create missing files"
+      print_summary_section "$summary_text" "Protected/manual files"
+      print_summary_section "$summary_text" "Needs attention before apply"
+      ;;
+    fonts)
+      echo "Fonts and terminal setup:"
+      print_summary_section "$summary_text" "Fonts"
+      ;;
+  esac
+}
+
+safe_changes_menu_loop() {
+  local summary_text="$1"
+  while true; do
+    echo
+    echo "Safe setup changes:"
+    cat <<EOF
+  1. Preview dotfiles and config files.
+  2. Preview fonts and terminal setup.
+  3. Apply all safe changes now.
+  4. Back to main menu.
+EOF
+    printf 'Choose [1-4]: '
+    local choice
+    if ! read -r -e choice; then
+      echo
+      return 0
+    fi
+    case "$choice" in
+      1) echo; show_safe_changes_preview "$summary_text" dotfiles; echo; echo "Preview complete; returning to main menu."; return 2 ;;
+      2) echo; show_safe_changes_preview "$summary_text" fonts; echo; echo "Preview complete; returning to main menu."; return 2 ;;
+      3) run_machine_apply_with_message; return $? ;;
+      4|"") return 0 ;;
+      *) echo "Unknown choice: $choice" >&2 ;;
+    esac
+  done
+}
+
 machine_menu_loop() {
   local recommendation_body="$1"
   local rec_opt="$2"
+  local summary_text="$3"
   while true; do
-    local opt1="  1. Install / update developer tools (preview, then apply)."
-    local opt2="  2. Apply safe non-protected dotfiles and approved install/update recipes."
+    local opt1="  1. Install / update developer tools (phased submenu, preview, then apply)."
+    local opt2="  2. Apply safe non-protected dotfiles."
     local opt3="  3. Show full technical details."
     local opt4="  4. Show tool and sign-in guidance."
     local opt5="  5. Configure / verify API tokens (GitHub, HuggingFace, Codacy)."
@@ -1078,8 +1354,14 @@ EOF
       return 0
     fi
     case "$choice" in
-      1) run_machine_install_tools_with_confirm; return $? ;;
-      2) run_machine_apply_with_message; return $? ;;
+      1)
+        tool_install_phase_menu_loop
+        [[ $? -eq 2 ]] && return 2
+        ;;
+      2)
+        safe_changes_menu_loop "$summary_text"
+        [[ $? -eq 2 ]] && return 2
+        ;;
       3) echo; run_machine_details ;;
       4) echo; show_tool_auth_commands ;;
       5) echo; configure_machine_api_tokens ;;
@@ -1092,7 +1374,8 @@ EOF
 machine_menu() {
   local recommendation_body="${1:-5. Exit without writing - Setup is current and no write action is needed.}"
   local rec_opt="${2:-5}"
-  machine_menu_loop "$recommendation_body" "$rec_opt"
+  local summary_text="${3:-}"
+  machine_menu_loop "$recommendation_body" "$rec_opt" "$summary_text"
 }
 
 cmd_machine_setup() {
@@ -1106,7 +1389,7 @@ cmd_machine_setup() {
     recommendation_body="$(extract_machine_recommendation "$summary_output")"
     rec_opt="${recommendation_body%%.*}"
     [[ "$rec_opt" =~ ^[1-5]$ ]] || rec_opt="5"
-    if machine_menu "$recommendation_body" "$rec_opt"; then
+    if machine_menu "$recommendation_body" "$rec_opt" "$summary_output"; then
       menu_status=0
     else
       menu_status=$?
@@ -1715,27 +1998,26 @@ cmd_repair_codacy_env() {
 }
 
 configure_machine_api_tokens() {
+  local project="${1:-$PWD}"
   while true; do
     echo
-    echo "Machine-level API Authentication:"
+    echo "Tool and sign-in guidance:"
     local gh_status="needs setup" hf_status="needs setup" codacy_status="needs setup"
 
     # Check status for display
     if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-      gh_status="verified"
+      gh_status="verified: $(gh_identity_summary)"
     fi
     if [[ -f "$HOME/.cache/huggingface/token" ]]; then
       hf_status="verified"
     fi
-    if [[ -f "$HOME/.codacy/account-token" ]] || ls "$HOME/.codacy"/*.project-token >/dev/null 2>&1; then
-      codacy_status="verified"
-    fi
+    codacy_status="$(codacy_account_status "$project")"
 
     cat <<EOF
-  1. GitHub (gh) authentication [$gh_status]
-  2. HuggingFace Hub access [$hf_status]
-  3. Codacy API access (account token + project token) [$codacy_status]
-  4. Back to main menu
+  1. GitHub (gh) authentication. [$gh_status]
+  2. HuggingFace Hub access. [$hf_status]
+  3. Codacy API access (account token + project token). [$codacy_status]
+  4. Back to main menu.
 EOF
 
     printf "Choose [1-4]: "
@@ -1748,7 +2030,7 @@ EOF
     case "$choice" in
       1) configure_gh_auth ;;
       2) configure_huggingface_global ;;
-      3) configure_codacy_env "$(pwd)" ;;
+      3) configure_codacy_env "$project" ;;
       4|"") return 0 ;;
       *) echo "Unknown choice: $choice" >&2 ;;
     esac

--- a/specs/002-setup-menu-recommendation/contracts/setup-menu.md
+++ b/specs/002-setup-menu-recommendation/contracts/setup-menu.md
@@ -12,7 +12,8 @@ The machine setup menu must expose these option numbers:
 2. Apply safe non-protected dotfiles
 3. Show full technical details
 4. Show tool and sign-in guidance
-5. Exit without writing
+5. Configure / verify API tokens (GitHub, HuggingFace, Codacy)
+6. Exit without writing
 ```
 
 Labels may include short clarifying suffixes, but the option purpose and number
@@ -44,22 +45,32 @@ The recommendation must remain visible in plain captured output without color.
 | Tools are present and safe dotfile or font actions are pending | 2 | Explain that safe non-protected setup changes are pending |
 | Only manual sign-in guidance is pending | 4 | Explain that sign-in guidance is the useful next step |
 | Only protected/manual items are pending | 3 | Explain that manual items need inspection and are not applied automatically |
-| No useful setup action is pending | 5 | Explain that setup is current and no write action is needed |
+| No useful setup action is pending | 6 | Explain that setup is current and no write action is needed |
 
 ## Fresh-Machine Session Contract
 
 When option 1 is selected:
 
-1. The tool install/update preview is shown.
-2. The user is asked for confirmation before writes.
-3. If the user confirms, the action runs and reports the result.
+1. A phase submenu is shown that separates dev-base packages, individual tool
+   installers, and post-install verification.
+2. Each preview item shows only its own phase.
+3. Each apply item asks for confirmation before writes.
 4. If the user declines, no tool changes are applied.
-5. In both cases, `./setup` re-runs the machine summary and renders a fresh
-   recommendation unless the process cannot continue.
+5. After a phase completes or is declined, `./setup` returns to the submenu or
+   main menu so the next slow phase can be isolated.
+
+When option 5 is selected:
+
+1. A post-install submenu is shown that separates verification-only, auto
+   post-install actions, and manual guidance.
+2. Verification-only must not run post-install commands.
+3. Auto actions must prompt before executing writes or shell commands.
+4. Manual guidance must not execute commands.
 
 ## Safety Contract
 
-- Option 2 still requires explicit apply confirmation before writes.
+- Option 2 opens a safe-changes submenu that separates dotfiles/config files
+  from fonts and still requires explicit apply confirmation before writes.
 - Protected/manual files remain untouched unless separately and explicitly
   included by protected entry ID outside the safe menu path.
 - Backups remain required before replacing differing files.

--- a/tests/test_apply_failures.py
+++ b/tests/test_apply_failures.py
@@ -16,7 +16,7 @@ class _NoDownloadRunner:
     def which(self, command: str) -> str | None:
         return "/bin/bash" if command == "bash" else None
 
-    def run(self, args, *, capture_output: bool = False, check: bool = True):  # pragma: no cover
+    def run(self, args, *, capture_output: bool = False, check: bool = True, timeout: float | None = None):  # pragma: no cover
         self.commands.append(list(args))
         raise AssertionError("runner.run should not be invoked when download fails")
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -17,6 +17,7 @@ from dotfiles_tools.bootstrap import (
     apply_bootstrap,
     build_tool_install_subplan,
     apply_tool_installs,
+    run_tool_install_post_install,
 )
 from dotfiles_tools.reports import Report
 from tests.helpers import DotfilesTestCase, REPO_ROOT
@@ -55,6 +56,7 @@ class FakeRunner:
         *,
         capture_output: bool = False,
         check: bool = True,
+        timeout: float | None = None,
     ) -> subprocess.CompletedProcess[str]:
         command = Path(args[0]).name if args else ""
         if command == "dpkg-query":
@@ -244,6 +246,18 @@ class BuildToolInstallSubplanTests(DotfilesTestCase):
         expected = [f"op-{i:03d}" for i in range(1, len(ids) + 1)]
         self.assertEqual(ids, expected)
 
+    def test_dev_base_phase_only_includes_dev_base(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home, phase="dev-base")
+        self.assertTrue(report.operations)
+        self.assertEqual({entry["entry_id"] for entry in report.entries}, {"tools.dev_base"})
+
+    def test_tools_phase_skips_dev_base(self):
+        home = self.make_home()
+        report = build_tool_install_subplan(REPO_ROOT, home, phase="tools")
+        self.assertTrue(report.operations)
+        self.assertNotIn("tools.dev_base", {entry["entry_id"] for entry in report.entries})
+
 
 class ApplyToolInstallsTests(DotfilesTestCase):
     def test_requires_yes_flag(self):
@@ -262,3 +276,40 @@ class ApplyToolInstallsTests(DotfilesTestCase):
             runner=runner,
         )
         self.assertEqual(report.command, "bootstrap-install-tools")
+
+    def test_post_install_report_command(self):
+        home = self.make_home()
+        runner = FakeRunner()
+        report = run_tool_install_post_install(
+            REPO_ROOT, home,
+            backup_dir=home / ".dotfiles-backups",
+            yes=True,
+            runner=runner,
+        )
+        self.assertEqual(report.command, "bootstrap-install-tools-post")
+
+    def test_post_install_verify_mode_skips_actions(self):
+        home = self.make_home()
+        runner = FakeRunner()
+        report = run_tool_install_post_install(
+            REPO_ROOT, home,
+            mode="verify",
+            backup_dir=home / ".dotfiles-backups",
+            runner=runner,
+        )
+        self.assertEqual(report.command, "bootstrap-install-tools-verify")
+        self.assertIn("verification", report.extra)
+        self.assertNotIn("post_install_actions", report.extra)
+
+    def test_post_install_guidance_mode_omits_verification(self):
+        home = self.make_home()
+        runner = FakeRunner(which={"gh": "/usr/bin/gh"})
+        report = run_tool_install_post_install(
+            REPO_ROOT, home,
+            mode="guidance",
+            backup_dir=home / ".dotfiles-backups",
+            runner=runner,
+        )
+        self.assertEqual(report.command, "bootstrap-install-tools-post")
+        self.assertNotIn("verification", report.extra)
+        self.assertTrue(report.extra["post_install_actions"])

--- a/tests/test_codacy_cli_bootstrap.py
+++ b/tests/test_codacy_cli_bootstrap.py
@@ -107,6 +107,24 @@ class CodacyCliPlanTests(DotfilesTestCase):
         ops = [op for op in plan["operations"] if op.get("entry_id") == CODACY_ENTRY_ID]
         self.assertFalse(ops[0]["requires_sudo"])
 
+    def test_plan_reads_codacy_version_from_cache_without_execing_binary(self) -> None:
+        home = self.make_home()
+        version_dir = home / ".cache" / "codacy" / "codacy-cli-v2" / "1.0.0-main.376.sha.799aab5"
+        version_dir.mkdir(parents=True)
+        (home / ".cache" / "codacy" / "codacy-cli-v2" / "version.yaml").write_text(
+            'version: "1.0.0-main.376.sha.799aab5"\n'
+        )
+        codacy_bin = version_dir / "codacy-cli-v2"
+        codacy_bin.write_text("#!/usr/bin/env bash\nexit 0\n")
+        codacy_bin.chmod(0o755)
+        runner = FakeRunner(
+            which={"dpkg-query": "/usr/bin/dpkg-query", "codacy-cli": str(codacy_bin)},
+            run_failures={"codacy-cli": AssertionError("codacy-cli should not be executed for version lookup")},
+        )
+        plan = build_tool_install_plan(home, runner=runner)
+        entry = next(e for e in plan["entries"] if e.get("entry_id") == CODACY_ENTRY_ID)
+        self.assertEqual(entry["current_version"], "1.0.0-main.376.sha.799aab5")
+
 
 class CodacyCliExecuteTests(DotfilesTestCase):
     def setUp(self) -> None:

--- a/tests/test_doctor_reports.py
+++ b/tests/test_doctor_reports.py
@@ -1,10 +1,16 @@
 import json
+import os
+from unittest import mock
 
 from dotfiles_tools.doctor import _missing_json_keys, run_doctor
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
 
 class DoctorReportTests(DotfilesTestCase):
+    def write_executable(self, path, text):
+        path.write_text(text)
+        path.chmod(0o755)
+
     def test_json_report_contains_target_states(self):
         home = self.make_home()
         target = home / ".claude" / ".mcp.json"
@@ -29,6 +35,116 @@ class DoctorReportTests(DotfilesTestCase):
         self.assertGreaterEqual(tool_ids, {"uv", "git", "gh", "fish", "direnv", "codex", "claude", "gemini", "copilot", "specify"})
         auth_commands = {item["command"] for item in data["auth_guidance"]}
         self.assertIn("gh auth status", auth_commands)
+
+    def test_machine_doctor_marks_logged_in_tools(self):
+        home = self.make_home()
+        bin_dir = home / "bin"
+        bin_dir.mkdir()
+
+        self.write_executable(
+            bin_dir / "gh",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  echo "Logged in to github.com account kairin (keyring)"
+  exit 0
+fi
+exit 64
+""",
+        )
+        self.write_executable(
+            bin_dir / "hf",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  [[ -f "$HOME/.cache/huggingface/token" ]]
+  exit $?
+fi
+exit 64
+""",
+        )
+        self.write_executable(
+            bin_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  cat <<'JSON'
+{"loggedIn":true,"email":"kairin@gmail.com","orgName":"Kairin"}
+JSON
+  exit 0
+fi
+exit 64
+""",
+        )
+        self.write_executable(
+            bin_dir / "codex",
+            """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+        )
+        self.write_executable(
+            bin_dir / "gemini",
+            """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+        )
+        self.write_executable(
+            bin_dir / "copilot",
+            """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+        )
+        (home / ".codex").mkdir()
+        (home / ".codex" / "auth.json").write_text(
+            json.dumps(
+                {
+                    "OPENAI_API_KEY": "sk-test",
+                    "auth_mode": "oauth",
+                    "last_refresh": "2026-05-09T00:00:00Z",
+                    "tokens": {
+                        "access_token": "access",
+                        "refresh_token": "refresh",
+                        "account_id": "acct_123",
+                    },
+                }
+            )
+        )
+        (home / ".gemini").mkdir()
+        (home / ".gemini" / "oauth_creds.json").write_text(
+            json.dumps(
+                {
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                    "id_token": "id",
+                    "expiry_date": "2026-06-01T00:00:00Z",
+                    "scope": "scope",
+                    "token_type": "Bearer",
+                }
+            )
+        )
+        (home / ".cache" / "huggingface").mkdir(parents=True)
+        (home / ".cache" / "huggingface" / "token").write_text("hf_token\n")
+
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env["HOME"] = str(home)
+        with mock.patch.dict(os.environ, env, clear=True):
+            report = run_doctor(REPO_ROOT, home)
+
+        data = json.loads(report.to_json())
+        auth = {item["id"]: item for item in data["auth_guidance"]}
+        self.assertEqual(auth["gh"]["state"], "signed_in")
+        self.assertEqual(auth["claude"]["state"], "signed_in")
+        self.assertEqual(auth["codex"]["state"], "signed_in")
+        self.assertEqual(auth["gemini"]["state"], "signed_in")
+        self.assertEqual(auth["huggingface"]["state"], "signed_in")
+        self.assertEqual(auth["copilot"]["state"], "available")
+        self.assertIn("kairin@gmail.com", auth["claude"]["signed_in_detail"])
+        self.assertIn("cached credentials present", auth["codex"]["signed_in_detail"])
+        self.assertIn("cached OAuth credentials present", auth["gemini"]["signed_in_detail"])
 
     def test_stale_mcp_target_without_env_blocks_is_flagged(self):
         home = self.make_home()

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -71,7 +71,14 @@ class FakeRunner:
         item = next(item for item in NERD_FONT_CATALOG if item.asset_name == asset_name)
         write_font_zip(target, item.expected_regular)
 
-    def run(self, args: list[str], *, capture_output: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run(
+        self,
+        args: list[str],
+        *,
+        capture_output: bool = False,
+        check: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         self.commands.append(args)
         command = Path(args[0]).name
         if command == "fc-match":

--- a/tests/test_machine_summary.py
+++ b/tests/test_machine_summary.py
@@ -204,6 +204,21 @@ class MachineSummaryTests(DotfilesTestCase):
         self.assertIn("Recommended next step: 4. Show tool and sign-in guidance - Sign-in guidance is the useful next step.", text)
         self.assertIn("Pending sign-ins: gh auth status.", text)
 
+    def test_auth_guidance_lists_verified_sign_in_identities(self) -> None:
+        home = self.make_home()
+        plan_report = plan(home)
+        doctor_report = doctor(
+            home,
+            auth_guidance=[
+                {"id": "gh", "command": "gh auth status", "state": "signed_in", "signed_in_detail": "kairin (keyring)"},
+                {"id": "claude", "command": "claude login", "state": "signed_in", "signed_in_detail": "kairin@gmail.com (Kairin)"},
+            ],
+        )
+
+        text = self.render(plan_report, doctor_report=doctor_report)
+
+        self.assertIn("Verified sign-ins: gh=kairin (keyring), claude=kairin@gmail.com (Kairin).", text)
+
     def test_current_setup_recommends_exit(self) -> None:
         home = self.make_home()
         plan_report = plan(home)

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -80,7 +80,7 @@ class SetupScriptTests(DotfilesTestCase):
         if not (bin_dir / "gh").exists():
             self.write_executable(
                 bin_dir / "gh",
-                "#!/usr/bin/env bash\nset -euo pipefail\ncase \"${1:-}\" in\n  auth)\n    if [[ \"${2:-}\" == status ]]; then\n      exit 0\n    fi\n    if [[ \"${2:-}\" == token ]]; then\n      echo \"gho_fake_token\"\n      exit 0\n    fi\n    if [[ \"${2:-}\" == login ]]; then\n      exit 0\n    fi\n    ;;\nesac\nexit 1\n",
+                "#!/usr/bin/env bash\nset -euo pipefail\ncase \"${1:-}\" in\n  auth)\n    if [[ \"${2:-}\" == status ]]; then\n      exit 0\n    fi\n    if [[ \"${2:-}\" == token ]]; then\n      echo \"gho_fake_token\"\n      exit 0\n    fi\n    if [[ \"${2:-}\" == login ]]; then\n      exit 0\n    fi\n    ;;\n  api)\n    if [[ \"${2:-}\" == user ]]; then\n      printf '{\"login\":\"kairin\",\"name\":\"Mister K\"}\\n'\n      exit 0\n    fi\n    ;;\nesac\nexit 1\n",
             )
         if not (bin_dir / "direnv").exists():
             self.write_executable(
@@ -538,7 +538,7 @@ exit 64
         self.assertIn("Create missing files:", result.stdout)
         self.assertIn("1. Install / update developer tools", result.stdout)
         self.assertIn("3. Show full technical details.", result.stdout)
-        self.assertIn("1. Install / update developer tools (preview, then apply). [recommended]", result.stdout)
+        self.assertIn("1. Install / update developer tools (phased submenu, preview, then apply). [recommended]", result.stdout)
         self.assertNotRegex(result.stdout, r"2\..*\[recommended\]")
         self.assertNotIn("entries:", result.stdout)
         self.assertNotIn("operations:", result.stdout)
@@ -599,12 +599,31 @@ exit 64
 
         env = self.env_for(bin_dir, home)
         env["DOTFILES_PLATFORM"] = "pixel-avf"
-        result = run_setup(env=env, input_text="2\n")
+        result = run_setup(env=env, input_text="2\n3\n")
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Safe setup changes:", result.stdout)
+        self.assertIn("1. Preview dotfiles and config files.", result.stdout)
+        self.assertIn("2. Preview fonts and terminal setup.", result.stdout)
+        self.assertIn("3. Apply all safe changes now.", result.stdout)
+        self.assertIn("Applying safe non-protected machine dotfiles and approved install/update recipes...", result.stdout)
         self.assertTrue((home / ".config" / "fish" / "functions" / "direnv.fish").exists())
         self.assertFalse((home / ".config" / "git" / "config").exists())
         self.assertTrue((home / ".config" / "fish" / "conf.d" / "000-dotfiles-pixel-avf-prompt.fish").exists())
+
+    def test_no_arg_safe_changes_fonts_preview_shows_scope(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        env = self.env_for(bin_dir, home)
+        env["DOTFILES_PLATFORM"] = "pixel-avf"
+        result = run_setup(env=env, input_text="2\n2\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Safe setup changes:", result.stdout)
+        self.assertIn("Preview fonts and terminal setup.", result.stdout)
+        self.assertIn("Preview complete; returning to main menu.", result.stdout)
 
     def test_no_arg_tool_guidance_choice_prints_status(self) -> None:
         home = self.make_home()
@@ -624,7 +643,7 @@ exit 64
         self.assertIn("4. Show tool and sign-in guidance. [recommended]", result.stdout)
         self.assertIn("Tool status:", result.stdout)
         self.assertIn("Missing tools:", result.stdout)
-        self.assertIn("Sign-in status:", result.stdout)
+        self.assertIn("Verified sign-ins:", result.stdout)
         self.assertNotIn("Missing tool install/auth commands:", result.stdout)
 
     def test_no_arg_details_choice_prints_full_diagnostics(self) -> None:
@@ -662,12 +681,51 @@ exit 64
             "    - gh: install gh",
         )
 
-        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="1\nn\n5\n")
+        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="1\n2\nn\n6\n")
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertGreaterEqual(result.stdout.count("Machine setup summary"), 2)
         self.assertGreaterEqual(result.stdout.count("Recommended next step: 1. Install / update developer tools - Developer tools should be installed or updated first."), 2)
-        self.assertGreaterEqual(result.stdout.count("1. Install / update developer tools (preview, then apply). [recommended]"), 2)
+        self.assertGreaterEqual(result.stdout.count("1. Install / update developer tools (phased submenu, preview, then apply). [recommended]"), 2)
+        self.assertIn("Developer tool phases:", result.stdout)
+        self.assertIn("1. Preview dev-base packages.", result.stdout)
+        self.assertIn("2. Apply dev-base packages.", result.stdout)
+        self.assertIn("Preparing dev-base packages preview...", result.stdout)
+        self.assertIn("Apply dev-base packages actions? [y/N]:", result.stdout)
+        self.assertGreaterEqual(result.stdout.count("Preview complete."), 1)
+        self.assertIn("No tool changes applied.", result.stdout)
+
+    def test_no_arg_post_install_verify_choice_shows_verification_only(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="1\n5\n1\n6\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Post-install phases:", result.stdout)
+        self.assertIn("1. Verify installed tools only.", result.stdout)
+        self.assertIn("Verifying installed tools only...", result.stdout)
+        self.assertIn("verification:", result.stdout)
+        self.assertNotIn("post-install actions (auto-run, --yes):", result.stdout)
+
+    def test_no_arg_install_apply_choice_uses_apply_wording(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+        summary = self.machine_summary_output(
+            1,
+            "Install / update developer tools",
+            "Developer tools should be installed or updated first.",
+            "  - 2 developer tools are missing or unverified.",
+            "    - gh: install gh",
+        )
+
+        result = run_setup(env=self.env_for(bin_dir, home, machine_summary_output=summary), input_text="1\n4\nn\n6\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Preparing individual tool installers for apply...", result.stdout)
+        self.assertIn("Apply individual tool installers actions? [y/N]:", result.stdout)
         self.assertIn("No tool changes applied.", result.stdout)
 
     def test_help_subcommand(self) -> None:
@@ -1080,7 +1138,8 @@ exit 64
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("✓ GitHub authentication configured", result.stdout)
         self.assertIn("✓ GitHub authentication verified", result.stdout)
-        self.assertIn("GitHub (gh) authentication [verified]", result.stdout)
+        self.assertIn("Tool and sign-in guidance:", result.stdout)
+        self.assertIn("GitHub (gh) authentication. [verified: kairin (Mister K)]", result.stdout)
 
     def test_machine_api_huggingface_auth_prints_explicit_verification(self) -> None:
         home = self.make_home()
@@ -1092,7 +1151,35 @@ exit 64
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("✓ HuggingFace token configured", result.stdout)
         self.assertIn("✓ HuggingFace Hub authentication verified", result.stdout)
-        self.assertIn("HuggingFace Hub access [verified]", result.stdout)
+        self.assertIn("Tool and sign-in guidance:", result.stdout)
+        self.assertIn("HuggingFace Hub access. [verified]", result.stdout)
+
+    def test_machine_api_codacy_auth_prints_resolved_identity(self) -> None:
+        home = self.make_home()
+        bin_dir = self.make_command_path()
+        self.write_fake_uv(bin_dir, home / "uv.log")
+        self.write_executable(
+            bin_dir / "curl",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
+""",
+        )
+        codacy_dir = home / ".codacy"
+        codacy_dir.mkdir(parents=True)
+        (codacy_dir / "account-token").write_text("account-token\n")
+        (codacy_dir / "account-token").chmod(0o600)
+        (codacy_dir / "kairin-000-dotfiles.project-token").write_text("project-token\n")
+        (codacy_dir / "kairin-000-dotfiles.project-token").chmod(0o600)
+
+        result = run_setup(env=self.env_for(bin_dir, home), input_text="5\n4\n6\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Tool and sign-in guidance:", result.stdout)
+        self.assertIn(
+            "Codacy API access (account token + project token). [verified: account=Mister K, project=kairin/000-dotfiles]",
+            result.stdout,
+        )
 
     def test_ship_help_and_extra_args(self) -> None:
         help_result = run_setup("ship", "--help")

--- a/tests/test_tool_installer.py
+++ b/tests/test_tool_installer.py
@@ -40,6 +40,7 @@ class FakeRunner:
         *,
         capture_output: bool = False,
         check: bool = True,
+        timeout: float | None = None,
     ) -> subprocess.CompletedProcess[str]:
         self.commands.append(list(args))
         if args and Path(args[0]).name in self.run_failures:
@@ -91,6 +92,44 @@ class ToolInstallPlanTests(DotfilesTestCase):
         op = dev_base_ops[0]
         self.assertEqual(op["type"], "tool_install_apt")
         self.assertEqual(set(op["packages"]), set(DEV_BASE_PACKAGES))
+
+    def test_dev_base_phase_excludes_tool_baseline(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, phase="dev-base", runner=runner)
+        self.assertTrue(plan["operations"])
+        self.assertEqual({entry["entry_id"] for entry in plan["entries"]}, {DEV_BASE_ENTRY_ID})
+        self.assertEqual({op["entry_id"] for op in plan["operations"]}, {DEV_BASE_ENTRY_ID})
+
+    def test_tool_phase_excludes_dev_base_bundle(self) -> None:
+        home = self.make_home()
+        runner = FakeRunner(which={"dpkg-query": "/usr/bin/dpkg-query"})
+        plan = build_tool_install_plan(home, phase="tools", runner=runner)
+        self.assertTrue(plan["operations"])
+        self.assertNotIn(DEV_BASE_ENTRY_ID, {entry["entry_id"] for entry in plan["entries"]})
+        self.assertNotIn(DEV_BASE_ENTRY_ID, {op["entry_id"] for op in plan["operations"]})
+
+    def test_codacy_cli_version_timeout_does_not_block_preview(self) -> None:
+        home = self.make_home()
+
+        class TimeoutRunner(FakeRunner):
+            def run(
+                self,
+                args: list[str],
+                *,
+                capture_output: bool = False,
+                check: bool = True,
+                timeout: float | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                if args and Path(args[0]).name == "codacy-cli" and "--version" in args:
+                    raise subprocess.TimeoutExpired(args, timeout or 5)
+                return super().run(args, capture_output=capture_output, check=check, timeout=timeout)
+
+        runner = TimeoutRunner(which={"dpkg-query": "/usr/bin/dpkg-query", "codacy-cli": "/usr/local/bin/codacy-cli"})
+        plan = build_tool_install_plan(home, phase="tools", runner=runner)
+        codacy_entry = next(entry for entry in plan["entries"] if entry.get("entry_id") == "tools.codacy-cli")
+        self.assertEqual(codacy_entry["state"], "installed")
+        self.assertEqual(codacy_entry["current_version"], "")
 
     def test_dev_base_partial_install(self) -> None:
         home = self.make_home()
@@ -178,6 +217,7 @@ class ToolInstallPlanTests(DotfilesTestCase):
         copilot_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.copilot"]
         self.assertEqual(codex_ops[0]["type"], "tool_install_npm")
         self.assertEqual(codex_ops[0]["package"], "@openai/codex")
+        self.assertEqual(codex_ops[0]["prefix"], str(home / ".local"))
         self.assertEqual(gemini_ops[0]["package"], "@google/gemini-cli")
         self.assertEqual(copilot_ops[0]["type"], "tool_install_npm")
         self.assertEqual(copilot_ops[0]["package"], "@github/copilot")
@@ -203,6 +243,7 @@ class ToolInstallPlanTests(DotfilesTestCase):
         plan = build_tool_install_plan(home, runner=runner)
         codex_ops = [op for op in plan["operations"] if op.get("entry_id") == "tools.codex"]
         self.assertEqual(codex_ops[0]["type"], "tool_install_npm_upgrade")
+        self.assertEqual(codex_ops[0]["prefix"], str(home / ".local"))
 
     def test_entries_include_installed_for_preview(self) -> None:
         home = self.make_home()
@@ -399,8 +440,9 @@ class ToolInstallExecuteTests(DotfilesTestCase):
             "recipe": "tool_installs",
             "type": "tool_install_npm",
             "package": "@openai/codex",
+            "prefix": str(home / ".local"),
             "cache_dir": str(home / ".cache"),
-            "requires_sudo": True,
+            "requires_sudo": False,
         }
         result = execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
         self.assertEqual(result, 0)
@@ -414,13 +456,14 @@ class ToolInstallExecuteTests(DotfilesTestCase):
             "recipe": "tool_installs",
             "type": "tool_install_npm",
             "package": "@openai/codex",
+            "prefix": str(home / ".local"),
             "cache_dir": str(home / ".cache"),
-            "requires_sudo": True,
+            "requires_sudo": False,
         }
         execute_tool_install_operation(op, runner=runner, cache_dir=Path(op["cache_dir"]))
         self.assertEqual(
             runner.commands[0],
-            ["sudo", "/usr/bin/npm", "install", "-g", "@openai/codex"],
+            ["/usr/bin/npm", "install", "-g", "--prefix", str(home / ".local"), "@openai/codex"],
         )
 
     def test_uv_tool_missing_skips(self) -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -30,7 +30,7 @@ class WorkflowTests(DotfilesTestCase):
         self.assertIn("name: Dotfiles Validation", workflow)
         # job name must stay codacy-safety-net — required by branch protection ruleset
         self.assertIn("codacy-safety-net:", workflow)
-        self.assertIn("CODACY_PROJECT_TOKEN", workflow)
+        self.assertIn("CODACY_ACCOUNT_TOKEN", workflow)
         self.assertIn("concurrency:", workflow)
         self.assertIn("coverage run -m unittest discover -s tests", workflow)
         self.assertIn("coverage xml", workflow)


### PR DESCRIPTION
## What changed
- Split the setup menu into smaller phases so tool install, safe file changes, and post-install actions can be isolated.
- Added real sign-in verification for supported tools in the machine guidance output.
- Updated the guidance text to show verified identities directly instead of only tool names.
- Added the Claude statusline helper template and synced the supporting docs/specs/tests.

## Why
The previous menu bundled too many unrelated actions into a single option, which made it hard to tell which step was slow or hanging. The sign-in guidance also reported only tool presence or generic state for some CLIs, which was not enough to tell whether the tool was actually logged in.

## Impact
- Option 1 now breaks the developer-tool workflow into separate preview/apply/post-install phases.
- Option 5 now splits verification, auto post-install actions, and manual guidance.
- Tool/sign-in guidance now shows verified identities where safe probes exist.
- `claude`, `codex`, and `gemini` auth checks no longer rely on interactive login flows.

## Validation
- `bash -n setup`
- `uv run python -m unittest tests.test_machine_summary tests.test_setup_script tests.test_doctor_reports`
- `uv run python -m unittest discover -s tests`

## Notes
- `copilot` remains manual because there is no safe, stable non-interactive status probe wired in yet.
