### PR TITLE
Add OpenAI skills catalog table

### DIFF
--- a/openai-skills-table.md
+++ b/openai-skills-table.md
@@ -1,0 +1,69 @@
+# OpenAI Skills Catalog Table
+
+Source note: the repository at `openai/skills` is maintained by OpenAI, but the table below classifies the *target ecosystem* each skill depends on.
+
+Paid note: this column is a practical estimate, not a license audit. "Paid" means a separate paid subscription or billed usage is typically involved. "Free tier" means a free account is usually enough to start.
+
+## Curated Skills
+
+| Skill | Target ecosystem | Dependency type | Paid? |
+|---|---|---|---|
+| `aspnet-core` | Microsoft ASP.NET Core | Third-party software | No |
+| `chatgpt-apps` | OpenAI / ChatGPT | OpenAI product | OpenAI usage/account required |
+| `cli-creator` | Generic local CLI tooling | Generic / local | No |
+| `cloudflare-deploy` | Cloudflare | Third-party SaaS | Free tier usually enough |
+| `figma` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-code-connect-components` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-create-design-system-rules` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-create-new-file` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-generate-design` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-generate-library` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-implement-design` | Figma | Third-party SaaS | Free tier usually enough |
+| `figma-use` | Figma | Third-party SaaS | Free tier usually enough |
+| `gh-address-comments` | GitHub | Third-party SaaS | Free tier usually enough |
+| `gh-fix-ci` | GitHub | Third-party SaaS | Free tier usually enough |
+| `hatch-pet` | OpenAI skill / local workflow | Generic / local | No |
+| `jupyter-notebook` | Jupyter / Python notebooks | Third-party software | No |
+| `linear` | Linear | Third-party SaaS | Free tier usually enough |
+| `migrate-to-codex` | OpenAI / Codex | OpenAI product | No separate subscription for the skill |
+| `netlify-deploy` | Netlify | Third-party SaaS | Free tier usually enough |
+| `notion-knowledge-capture` | Notion | Third-party SaaS | Free tier usually enough |
+| `notion-meeting-intelligence` | Notion | Third-party SaaS | Free tier usually enough |
+| `notion-research-documentation` | Notion | Third-party SaaS | Free tier usually enough |
+| `notion-spec-to-implementation` | Notion | Third-party SaaS | Free tier usually enough |
+| `openai-docs` | OpenAI | OpenAI docs / API | No separate subscription for the skill |
+| `pdf` | PDF files / local tooling | Generic / local | No |
+| `playwright` | Playwright | Third-party software | No |
+| `playwright-interactive` | Playwright | Third-party software | No |
+| `render-deploy` | Render | Third-party SaaS | Free tier usually enough |
+| `screenshot` | Local screen capture / files | Generic / local | No |
+| `security-best-practices` | Generic security workflow | Generic / local | No |
+| `security-ownership-map` | Generic security workflow | Generic / local | No |
+| `security-threat-model` | Generic security workflow | Generic / local | No |
+| `sentry` | Sentry | Third-party SaaS | Free tier usually enough |
+| `speech` | OpenAI speech tooling | OpenAI product | OpenAI usage/account required |
+| `transcribe` | OpenAI transcription tooling | OpenAI product | OpenAI usage/account required |
+| `vercel-deploy` | Vercel | Third-party SaaS | Free tier usually enough |
+| `winui-app` | Microsoft WinUI / Windows App SDK | Third-party software | No |
+| `yeet` | GitHub | Third-party SaaS | Free tier usually enough |
+
+## Experimental History
+
+The current `.experimental` tree is empty in the live listing, but GitHub history shows these experimental skills previously existed there:
+
+| Skill | Evidence in repo history | Target ecosystem | Dependency type | Paid? |
+|---|---|---|---|---|
+| `frontend-design` | Pull request #49 added `skills/.experimental/frontend-design` | Generic frontend workflow | Generic / local | No |
+| `olostep-web-research` | Pull request #323 added it as an experimental skill | Olostep | Third-party API / SaaS | Likely paid API |
+| `causal-halting` | Pull request #380 added `skills/.experimental/causal-halting` | Research / formal verification workflow | Generic / local | No |
+| `ExecFence` | Pull request #385 added `skills/.experimental/execfence` | ExecFence CLI | Third-party software | No separate paid subscription indicated |
+
+## Sources
+
+- [openai/skills repository](https://github.com/openai/skills)
+- [Curated skill listing via skill-installer](https://github.com/openai/skills/tree/main/skills/.curated)
+- [Skill installer docs](https://github.com/openai/skills/blob/main/skills/.system/skill-installer/SKILL.md)
+- [Experimental `frontend-design` PR #49](https://github.com/openai/skills/pull/49)
+- [Experimental `olostep-web-research` PR #323](https://github.com/openai/skills/pull/323)
+- [Experimental `causal-halting` PR #380](https://github.com/openai/skills/pull/380)
+- [Experimental `ExecFence` PR #385](https://github.com/openai/skills/pull/385)


### PR DESCRIPTION
Adds a root-level markdown table summarizing the curated skills in `openai/skills` and the historical experimental entries recovered from repo history.

Includes source links and a note that the paid/subscription column is an estimate, not a license audit.