### PR TITLE
Refine statusline and add OpenAI skills catalog

### DIFF
--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -110,7 +110,7 @@ git_info() {
     gbg="$GIT_BG"; gfg="$GIT_FG"
   fi
 
-  local label="  $branch"
+  local label="  $branch"
   [ "$ahead" -gt 0 ] && label+=" ⇡${ahead}"
   [ "$behind" -gt 0 ] && label+=" ⇣${behind}"
   [ "$untracked" -gt 0 ] && label+=" ?${untracked}"

--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -110,7 +110,7 @@ git_info() {
     gbg="$GIT_BG"; gfg="$GIT_FG"
   fi
 
-  local label=" $branch"
+  local label="  $branch"
   [ "$ahead" -gt 0 ] && label+=" ⇡${ahead}"
   [ "$behind" -gt 0 ] && label+=" ⇣${behind}"
   [ "$untracked" -gt 0 ] && label+=" ?${untracked}"

--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -166,7 +166,7 @@ line1+="$(pill "$PWD_BG" "$PWD_FG" "󰉋 $dir_display")"
 
 # git
 git_seg="$(git_info "$cwd")"
-[ -n "$git_seg" ] && line1+="$git_seg"
+[ -n "$git_seg" ] && line1+=" $git_seg"
 
 # model
 [ -n "$model" ] && line1+=" $(pill "$CTX_BG" "$CTX_FG" " $model")"

--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -94,29 +94,28 @@ git_info() {
   local branch
   branch=$(timeout 2s git -C "$dir" -c core.fsmonitor=false symbolic-ref --short HEAD 2>/dev/null \
            || timeout 2s git -C "$dir" -c core.fsmonitor=false rev-parse --short HEAD 2>/dev/null)
-  local gs staged unstaged untracked conflicts
+  local gs untracked
   gs=$(timeout 2s git -C "$dir" -c core.fsmonitor=false status --porcelain 2>/dev/null)
-  staged=$(echo "$gs"    | grep -c '^[MADRCU]' 2>/dev/null || echo 0)
-  unstaged=$(echo "$gs"  | grep -c '^.[MD]'    2>/dev/null || echo 0)
-  untracked=$(echo "$gs" | grep -c '^??'       2>/dev/null || echo 0)
-  conflicts=$(echo "$gs" | grep -cE '^(UU|AA|DD)' 2>/dev/null || echo 0)
+  untracked=$(echo "$gs" | grep -c '^??' 2>/dev/null || echo 0)
+
+  # Detect commits ahead/behind
+  local ahead behind
+  ahead=$(timeout 2s git -C "$dir" rev-list --count @{u}..HEAD 2>/dev/null || echo 0)
+  behind=$(timeout 2s git -C "$dir" rev-list --count HEAD..@{u} 2>/dev/null || echo 0)
 
   local gbg gfg
-  if   [ "$conflicts" -gt 0 ]; then gbg="$GIT_URGENT_BG"; gfg="$GIT_URGENT_FG"
-  elif [ "$staged" -gt 0 ] || [ "$unstaged" -gt 0 ] || [ "$untracked" -gt 0 ]; then
+  if [ "$untracked" -gt 0 ] || [ -n "$(echo "$gs" | grep -v '^??')" ]; then
     gbg="$GIT_DIRTY_BG"; gfg="$GIT_DIRTY_FG"
   else
     gbg="$GIT_BG"; gfg="$GIT_FG"
   fi
 
-  local dirt=""
-  [ "$staged"    -gt 0 ] && dirt+=" *${staged}"
-  [ "$unstaged"  -gt 0 ] && dirt+=" ~${unstaged}"
-  [ "$untracked" -gt 0 ] && dirt+=" ?${untracked}"
-
   local label=" $branch"
+  [ "$ahead" -gt 0 ] && label+=" ⇡${ahead}"
+  [ "$behind" -gt 0 ] && label+=" ⇣${behind}"
+  [ "$untracked" -gt 0 ] && label+=" ?${untracked}"
   [ -n "$worktree_name" ] && label+=" (wt)"
-  pill "$gbg" "$gfg" "${label}${dirt}"
+  pill "$gbg" "$gfg" "$label"
 }
 
 # ── context bar (matches Claude Code default line-2 bar) ──────────────────────
@@ -163,7 +162,7 @@ line1=""
 
 # CWD segment (Tide pwd style)
 dir_display="${cwd/#$HOME/\~}"
-line1+="$(pill "$PWD_BG" "$PWD_FG" " $dir_display")"
+line1+="$(pill "$PWD_BG" "$PWD_FG" "󰉋 $dir_display")"
 
 # git
 git_seg="$(git_info "$cwd")"
@@ -224,10 +223,13 @@ if [ -n "$fish_bind_mode" ] && [ "$fish_bind_mode" != "insert" ]; then
   line2+=" $(pill "$fb_bg" "$VIM_FG" "$fb_label")"
 fi
 
-# Effort / thinking — changes per-session
+# Effort / thinking — only show thinking for models that support it (opus, sonnet)
 eff_label=""
 [ -n "$effort" ] && eff_label="effort:$effort"
-[ "$thinking" = "true" ] && { [ -n "$eff_label" ] && eff_label+=" "; eff_label+="thinking:on"; }
+if [ "$thinking" = "true" ] && [[ "$model_id" =~ (opus|sonnet) ]]; then
+  [ -n "$eff_label" ] && eff_label+=" "
+  eff_label+="thinking:on"
+fi
 [ -n "$eff_label" ] && line2+=" $(pill "$EFF_BG" "$EFF_FG" "$eff_label")"
 
 # Current time — always live; ensures line 2 is never static
@@ -263,12 +265,6 @@ if [ -n "$ctx_total" ] && [ "$ctx_total" != "0" ]; then
   line3+="${DIM}ctx-size:${ctx_total}${R}"
 fi
 
-# Transcript path (truncated)
-if [ -n "$transcript" ]; then
-  [ -n "$line3" ] && line3+="$sep"
-  short_transcript="...$(echo "$transcript" | rev | cut -c1-30 | rev)"
-  line3+="${DIM}transcript:${short_transcript}${R}"
-fi
 
 # Python virtual environment
 if [ -n "$venv_name" ]; then
@@ -314,11 +310,6 @@ if [ -n "$agent_name" ]; then
   line4+="$(pill "$EFF_BG" "$EFF_FG" "$agent_label")"
 fi
 
-# Session name (when renamed via /rename)
-if [ -n "$session" ]; then
-  [ -n "$line4" ] && line4+=" "
-  line4+="$(pill "$CTX_BG" "$CTX_FG" "\"$session\"")"
-fi
 
 # Project dir (when different from cwd)
 if [ -n "$project_dir" ] && [ "$project_dir" != "$cwd" ]; then
@@ -337,12 +328,6 @@ if [ -n "$wt_path" ]; then
   line4+="${DIM}${wt_extra}${R}"
 fi
 
-# Session ID (short — last 8 chars)
-if [ -n "$session_id" ]; then
-  short_id="${session_id: -8}"
-  [ -n "$line4" ] && line4+="$sep"
-  line4+="${DIM}sid:${short_id}${R}"
-fi
 
 # Output style (always shown on line 4)
 if [ -n "$output_style" ]; then

--- a/claude/statusline-command.sh.template
+++ b/claude/statusline-command.sh.template
@@ -259,11 +259,6 @@ if [ -n "$cache_read" ] && [ "$cache_read" != "0" ]; then
   line3+="${DIM}cache-r:${cache_read}${R}"
 fi
 
-# Context window size
-if [ -n "$ctx_total" ] && [ "$ctx_total" != "0" ]; then
-  [ -n "$line3" ] && line3+="$sep"
-  line3+="${DIM}ctx-size:${ctx_total}${R}"
-fi
 
 
 # Python virtual environment
@@ -329,16 +324,10 @@ if [ -n "$wt_path" ]; then
 fi
 
 
-# Output style (always shown on line 4)
-if [ -n "$output_style" ]; then
-  [ -n "$line4" ] && line4+="$sep"
-  line4+="${DIM}style:${output_style}${R}"
-fi
 
 # =============================================================================
-# LINE 5 — full-width context window bar
-#   Format: "Context Window usage   18% used  [████░░░░░░░░░░░░░░░░]  82% left"
-#   Bar expands to fill terminal width; falls back to 40 cols if tput unavailable.
+# LINE 5 — context window bar with total size prefix + output style
+#   Format: "󰯃 200000  󰯃 ctx  67%  [████░░░░]  33% 󰄾   style:default"
 # =============================================================================
 line5=""
 if [ -n "$used" ]; then
@@ -346,18 +335,19 @@ if [ -n "$used" ]; then
   rem_int=0
   [ -n "$remaining" ] && rem_int=$(printf '%.0f' "$remaining")
 
-  label_left="Context Window usage"
-  label_used="${used_int}% used"
-  label_right="${rem_int}% left"
+  # Prefix with total context window size
+  prefix=""
+  [ -n "$ctx_total" ] && prefix="󰯃 ${ctx_total}  "
 
-  # Fixed-width text portions (no ANSI): "Context Window usage   18% used  [" + "]  82% left"
-  # bracket open "[" + bracket close "]" = 2; "   " between label and used = 3; "  " before bracket = 2; "  " after bracket = 2
-  fixed_len=$(( ${#label_left} + 3 + ${#label_used} + 2 + 1 + 1 + 2 + ${#label_right} ))
-  # fixed_len = len("Context Window usage") + 3 + len("18% used") + 2 + 1("[") + 1("]") + 2 + len("82% left")
+  label_left="󰯃 ctx"
+  label_used="${used_int}%"
+  label_right="${rem_int}% 󰄾"
 
+  # Fixed-width calc with prefix, reduced bar (60% of available width)
+  fixed_len=$(( ${#prefix} + ${#label_left} + 3 + ${#label_used} + 2 + 1 + 1 + 2 + ${#label_right} ))
   term_cols=$(tput cols 2>/dev/null || echo 80)
-  bar_width=$(( term_cols - fixed_len ))
-  [ "$bar_width" -lt 4 ] && bar_width=4
+  bar_width=$(( (term_cols - fixed_len) * 60 / 100 ))
+  [ "$bar_width" -lt 6 ] && bar_width=6
 
   bar_filled=$(( used_int * bar_width / 100 ))
   bar_empty=$(( bar_width - bar_filled ))
@@ -377,7 +367,10 @@ if [ -n "$used" ]; then
   fi
   bar_str+="${R}"
 
-  line5="${label_left}   ${label_used}  [${bar_str}]  ${label_right}"
+  line5="${prefix}${label_left}   ${label_used}  ${bar_str}  ${label_right}"
+
+  # Add output style at the end
+  [ -n "$output_style" ] && line5+="   ${DIM}style:${output_style}${R}"
 fi
 
 # =============================================================================

--- a/docs/codacy-handling-git-commit-to-merge2.md
+++ b/docs/codacy-handling-git-commit-to-merge2.md
@@ -1,0 +1,335 @@
+• I’m pulling the live GitHub tree and history now so the markdown file reflects the repo, not memory. After that I’ll add the
+  file at the repo root and commit it.
+
+• Searching the web
+
+• Searched site:github.com/openai/skills/tree/main/skills/.curated openai skills curated GitHub
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I’ve got the authoritative skill list paths now. Next I’m extracting the current curated and experimental entries so the
+  document can reflect the repo’s actual contents.
+
+• Ran python3 /home/kkk/.codex/skills/.system/skill-installer/scripts/list-skills.py --repo openai/skills --path
+  │ skills/.experimental
+  └ Error: Skills path not found: https://github.com/openai/skills/tree/main/skills/.experimental
+
+• Ran python3 /home/kkk/.codex/skills/.system/skill-installer/scripts/list-skills.py --repo openai/skills
+  └ 1. aspnet-core
+    2. chatgpt-apps
+    … +34 lines (ctrl + t to view transcript)
+    37. winui-app
+    38. yeet
+
+• Searching the web
+
+• Searched site:github.com/openai/skills "skills/.experimental" "github.com/openai/skills"
+
+• Searching the web
+
+• Searched site:github.com/openai/skills/pull "experimental skill" "openai/skills"
+
+• Searching the web
+
+• Searched https://github.com/openai/skills/pulls
+
+• Searching the web
+
+• Searched site:github.com/openai/skills/pull/342 openai/skills
+
+• Searching the web
+
+• Searched https://github.com/openai/skills/pull/385
+
+• Searching the web
+
+• Searched 'Summary' in https://github.com/openai/skills/pull/380
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I’ve narrowed it down to a repo doc, so I’m checking the brainstorming guidance before I write the table. Then I’ll patch the
+  file and run a quick verification pass.
+
+• Explored
+  └ Read SKILL.md (superpowers:brainstorming skill)
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I have enough to write the doc now. I’m choosing a single root-level markdown file with two tables: current curated skills,
+  and experimental entries recovered from GitHub history. After that I’ll verify the file, commit it, and attempt the push.
+
+• Added openai-skills-table.md (+69 -0)
+     1 +# OpenAI Skills Catalog Table
+     2 +
+     3 +Source note: the repository at `openai/skills` is maintained by OpenAI, but the table below classifies the *target ecos
+        ystem* each skill depends on.
+     4 +
+     5 +Paid note: this column is a practical estimate, not a license audit. "Paid" means a separate paid subscription or bille
+        d usage is typically involved. "Free tier" means a free account is usually enough to start.
+     6 +
+     7 +## Curated Skills
+     8 +
+     9 +| Skill | Target ecosystem | Dependency type | Paid? |
+    10 +|---|---|---|---|
+    11 +| `aspnet-core` | Microsoft ASP.NET Core | Third-party software | No |
+    12 +| `chatgpt-apps` | OpenAI / ChatGPT | OpenAI product | OpenAI usage/account required |
+    13 +| `cli-creator` | Generic local CLI tooling | Generic / local | No |
+    14 +| `cloudflare-deploy` | Cloudflare | Third-party SaaS | Free tier usually enough |
+    15 +| `figma` | Figma | Third-party SaaS | Free tier usually enough |
+    16 +| `figma-code-connect-components` | Figma | Third-party SaaS | Free tier usually enough |
+    17 +| `figma-create-design-system-rules` | Figma | Third-party SaaS | Free tier usually enough |
+    18 +| `figma-create-new-file` | Figma | Third-party SaaS | Free tier usually enough |
+    19 +| `figma-generate-design` | Figma | Third-party SaaS | Free tier usually enough |
+    20 +| `figma-generate-library` | Figma | Third-party SaaS | Free tier usually enough |
+    21 +| `figma-implement-design` | Figma | Third-party SaaS | Free tier usually enough |
+    22 +| `figma-use` | Figma | Third-party SaaS | Free tier usually enough |
+    23 +| `gh-address-comments` | GitHub | Third-party SaaS | Free tier usually enough |
+    24 +| `gh-fix-ci` | GitHub | Third-party SaaS | Free tier usually enough |
+    25 +| `hatch-pet` | OpenAI skill / local workflow | Generic / local | No |
+    26 +| `jupyter-notebook` | Jupyter / Python notebooks | Third-party software | No |
+    27 +| `linear` | Linear | Third-party SaaS | Free tier usually enough |
+    28 +| `migrate-to-codex` | OpenAI / Codex | OpenAI product | No separate subscription for the skill |
+    29 +| `netlify-deploy` | Netlify | Third-party SaaS | Free tier usually enough |
+    30 +| `notion-knowledge-capture` | Notion | Third-party SaaS | Free tier usually enough |
+    31 +| `notion-meeting-intelligence` | Notion | Third-party SaaS | Free tier usually enough |
+    32 +| `notion-research-documentation` | Notion | Third-party SaaS | Free tier usually enough |
+    33 +| `notion-spec-to-implementation` | Notion | Third-party SaaS | Free tier usually enough |
+    34 +| `openai-docs` | OpenAI | OpenAI docs / API | No separate subscription for the skill |
+    35 +| `pdf` | PDF files / local tooling | Generic / local | No |
+    36 +| `playwright` | Playwright | Third-party software | No |
+    37 +| `playwright-interactive` | Playwright | Third-party software | No |
+    38 +| `render-deploy` | Render | Third-party SaaS | Free tier usually enough |
+    39 +| `screenshot` | Local screen capture / files | Generic / local | No |
+    40 +| `security-best-practices` | Generic security workflow | Generic / local | No |
+    41 +| `security-ownership-map` | Generic security workflow | Generic / local | No |
+    42 +| `security-threat-model` | Generic security workflow | Generic / local | No |
+    43 +| `sentry` | Sentry | Third-party SaaS | Free tier usually enough |
+    44 +| `speech` | OpenAI speech tooling | OpenAI product | OpenAI usage/account required |
+    45 +| `transcribe` | OpenAI transcription tooling | OpenAI product | OpenAI usage/account required |
+    46 +| `vercel-deploy` | Vercel | Third-party SaaS | Free tier usually enough |
+    47 +| `winui-app` | Microsoft WinUI / Windows App SDK | Third-party software | No |
+    48 +| `yeet` | GitHub | Third-party SaaS | Free tier usually enough |
+    49 +
+    50 +## Experimental History
+    51 +
+    52 +The current `.experimental` tree is empty in the live listing, but GitHub history shows these experimental skills previ
+        ously existed there:
+    53 +
+    54 +| Skill | Evidence in repo history | Target ecosystem | Dependency type | Paid? |
+    55 +|---|---|---|---|---|
+    56 +| `frontend-design` | Pull request #49 added `skills/.experimental/frontend-design` | Generic frontend workflow | Gener
+        ic / local | No |
+    57 +| `olostep-web-research` | Pull request #323 added it as an experimental skill | Olostep | Third-party API / SaaS | Lik
+        ely paid API |
+    58 +| `causal-halting` | Pull request #380 added `skills/.experimental/causal-halting` | Research / formal verification wor
+        kflow | Generic / local | No |
+    59 +| `ExecFence` | Pull request #385 added `skills/.experimental/execfence` | ExecFence CLI | Third-party software | No se
+        parate paid subscription indicated |
+    60 +
+    61 +## Sources
+    62 +
+    63 +- [openai/skills repository](https://github.com/openai/skills)
+    64 +- [Curated skill listing via skill-installer](https://github.com/openai/skills/tree/main/skills/.curated)
+    65 +- [Skill installer docs](https://github.com/openai/skills/blob/main/skills/.system/skill-installer/SKILL.md)
+    66 +- [Experimental `frontend-design` PR #49](https://github.com/openai/skills/pull/49)
+    67 +- [Experimental `olostep-web-research` PR #323](https://github.com/openai/skills/pull/323)
+    68 +- [Experimental `causal-halting` PR #380](https://github.com/openai/skills/pull/380)
+    69 +- [Experimental `ExecFence` PR #385](https://github.com/openai/skills/pull/385)
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The file is in place. I’m doing a quick readback and diff check now to catch any wording issues before I commit it.
+
+• Explored
+  └ Read openai-skills-table.md
+
+• Ran git diff --stat && git status --short
+  └ ?? openai-skills-table.md
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The content reads cleanly. I’m staging only the new markdown file now, then I’ll commit and try to push the branch to origin.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I hit a filesystem permission boundary on .git/index.lock, so I need to run the git write operations outside the sandbox. Do
+  you want me to commit openai-skills-table.md and push it to origin/main now?
+
+✔ You approved codex to always run commands that start with git add openai-skills-table.md
+
+• Ran git add openai-skills-table.md && git commit -m "Add OpenAI skills catalog table" && git push origin main
+  └ remote: error: GH013: Repository rule violations found for refs/heads/main.
+    remote: Review all repository rules at https://github.com/kairin/000-dotfiles/rules?ref=refs%2Fheads%2Fmain
+    … +6 lines (ctrl + t to view transcript)
+     ! [remote rejected] main -> main (push declined due to repository rule violations)
+    error: failed to push some refs to 'https://github.com/kairin/000-dotfiles.git'
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The commit landed locally, but the remote blocks direct pushes to main and requires a PR. I’m pushing the same commit to a
+  feature branch now so it’s on the remote in a reviewable form.
+
+✔ You approved codex to always run commands that start with git push
+
+• Ran git push origin HEAD:openai-skills-table
+  └ remote:
+    remote: Create a pull request for 'openai-skills-table' on GitHub by visiting:
+    … +2 lines (ctrl + t to view transcript)
+    To https://github.com/kairin/000-dotfiles.git
+     * [new branch]      HEAD -> openai-skills-table
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The branch is on the remote. I’m doing a final status check so I can give you the exact state and the PR URL the server
+  suggested.
+
+• Ran git status --short --branch && git log --oneline -1
+  └ ## main...origin/main [ahead 1]
+    71bb51e Add OpenAI skills catalog table
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I added the markdown table as openai-skills-table.md at the repo root, committed it as 71bb51e (Add OpenAI skills catalog
+  table), and pushed it to the remote branch openai-skills-table.
+
+  Direct push to main was blocked by repository rules, specifically a required codacy-safety-net check and a PR-only policy.
+  GitHub gave this PR URL for the pushed branch:
+
+  https://github.com/kairin/000-dotfiles/pull/new/openai-skills-table
+
+  The file includes:
+
+  - a curated skills table
+  - a separate experimental-history table recovered from GitHub PR history
+  - source links and a note that the paid/subscription column is an estimate, not a license audit
+
+─ Worked for 3m 53s ───────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+
+› $github commit, push, open pr, merge to main
+
+
+• Using the GitHub workflow here to turn the pushed branch into a PR, then I’ll see whether merge is allowed or whether the
+  repo gates it on checks.
+
+• Called
+  └ codex_apps.github_search_prs({"query":"head:openai-skills-table repo:kairin/000-dotfiles","repo":["kairin/000-
+        dotfiles"],"topn":10})
+    {"issues": []}
+
+• Called codex_apps.github_get_repo_collaborator_permission({"repository_full_name":"kairin/000-dotfiles","username":"kkk"})
+  └ {"permission": "read"}
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• There isn’t an existing PR for that branch, so I’m opening one now from openai-skills-table into main.
+
+• Called
+  └ codex_apps.github_create_pull_request({"repository_full_name":"kairin/000-
+        dotfiles","base_branch":"main","head_branch":"openai-skills-table","title":"Add OpenAI skills catalog
+        table","body":"Adds a root-level markdown table summarizing the curated skills in `openai/skills` and the historical
+        experimental entries recovered from repo history.\n\nIncludes source links and a note that the paid/subscription column
+        is an estimate, not a license audit."})
+    {"url": "https://github.com/kairin/000-dotfiles/pull/239", "number": 239, "state": "open", "merged": false, "mergeable": f
+        alse, "draft": false, "body": "Adds a root-level markdown table summarizing the curated skills in `openai/skills` and
+        the historical experimental entries recovered from repo history.\n\nIncludes source links and a note that the paid/sub
+        scription column is an estimate, not a license audit.", "title": "Add OpenAI skills catalog table", "base": "main", "b
+        ase_sha": "16a8e0b155e88c0a71d87bb4145b7c34bc9a0bcb", "head": "openai-skills-table", "head_sha": "71bb51e75c5b730ab956
+        ede90aea47bda...
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The PR is open. I’m checking its merge state and required checks before attempting the merge, because the repository
+  previously rejected direct pushes.
+
+• Called codex_apps.github_get_pr_info({"pr_number":239,"repository_full_name":"kairin/000-dotfiles"})
+  └ {"url": "https://github.com/kairin/000-dotfiles/pull/239", "number": 239, "state": "open", "merged": false, "mergeable": t
+        rue, "draft": false, "body": "Adds a root-level markdown table summarizing the curated skills in `openai/skills` and t
+        he historical experimental entries recovered from repo history.\n\nIncludes source links and a note that the paid/subs
+        cription column is an estimate, not a license audit.", "title": "Add OpenAI skills catalog table", "base": "main", "ba
+        se_sha": "16a8e0b155e88c0a71d87bb4145b7c34bc9a0bcb", "head": "openai-skills-table", "head_sha": "71bb51e75c5b730ab956e
+        de90aea47bda0...
+
+• Called
+  └ codex_apps.github_get_commit_combined_status({"commit_sha":"71bb51e75c5b730ab956ede90aea47bda05fd6bf","repo_full_name":"kai
+        rin/000-dotfiles"})
+    {"statuses": []}
+
+• Called codex_apps.github_list_pull_request_reviews({"pr_number":239,"repository_full_name":"kairin/000-dotfiles"})
+  └ Error code: INVALID_ARGUMENT; Error: Parameters failed connector schema validation: repo_full_name [required]: Missing
+        required property (does not match constraints configured by your ChatGPT workspace admin. If the issue persists,
+        instruct the user to contact their workspace admin.); repo_full_name [required]: Missing required property (does not
+        match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their
+        workspace admin.)
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The PR is mergeable from GitHub’s side, but there are no status checks reported yet. I’m trying the merge; if the repo blocks
+  it, I’ll tell you exactly which rule stopped it.
+
+• Called
+  └ codex_apps.github_merge_pull_request({"pr_number":239,"repository_full_name":"kairin/000-
+        dotfiles","merge_method":"squash","commit_title":"Add OpenAI skills catalog table","commit_message":"Add a root-level
+        markdown table summarizing curated and historical experimental skills from openai/skills."})
+    Error code: UNKNOWN; Error: GitHub API error 405: {"message":"Repository rule violations found\n\nRequired status check
+        \"codacy-safety-net\" is in progress.\n\n","documentation_url":"https://docs.github.com/rest/pulls/pulls#merge-a-pull-
+        request","status":"405"}
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The merge is blocked on codacy-safety-net still running. I’m polling the PR again after a short wait so I can see whether it
+  finishes or if we need a follow-up nudge.
+
+✔ You approved codex to always run commands that start with sleep
+
+• Running sleep 20; git status --short --branch
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• I’ve got the wait running; once it returns I’ll check whether the repo rule moved from “in progress” to mergeable.
+
+• Waited for background terminal
+
+• Ran sleep 20; git status --short --branch
+  └ ## main...origin/main [ahead 1]
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The wait finished. I’m checking the PR state again before retrying merge.
+
+• Called codex_apps.github_get_pr_info({"pr_number":239,"repository_full_name":"kairin/000-dotfiles"})
+  └ {"url": "https://github.com/kairin/000-dotfiles/pull/239", "number": 239, "state": "open", "merged": false, "mergeable": t
+        rue, "draft": false, "body": "Adds a root-level markdown table summarizing the curated skills in `openai/skills` and t
+        he historical experimental entries recovered from repo history.\n\nIncludes source links and a note that the paid/subs
+        cription column is an estimate, not a license audit.", "title": "Add OpenAI skills catalog table", "base": "main", "ba
+        se_sha": "16a8e0b155e88c0a71d87bb4145b7c34bc9a0bcb", "head": "openai-skills-table", "head_sha": "71bb51e75c5b730ab956e
+        de90aea47bda0...
+
+• Called
+  └ codex_apps.github_get_commit_combined_status({"commit_sha":"71bb51e75c5b730ab956ede90aea47bda05fd6bf","repo_full_name":"kai
+        rin/000-dotfiles"})
+    {"statuses": []}
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• The PR is still mergeable from GitHub’s standpoint, so I’m retrying the merge now.
+
+• Called
+  └ codex_apps.github_merge_pull_request({"pr_number":239,"repository_full_name":"kairin/000-
+        dotfiles","merge_method":"squash","commit_title":"Add OpenAI skills catalog table","commit_message":"Add a root-level
+        markdown table summarizing curated and historical experimental skills from openai/skills."})
+    {"sha": "6a97f3abb08b817a3b4e5663e682eb514b4e28e6", "merged": true, "message": "Pull Request successfully merged"}
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+• Done.
+
+  - Commit: 71bb51e on branch openai-skills-table
+  - PR: https://github.com/kairin/000-dotfiles/pull/239
+  - Merge: completed to main with merge commit 6a97f3abb08b817a3b4e5663e682eb514b4e28e6
+
+  The only blocker was the repo rule that required codacy-safety-net to finish before merge. Once that cleared, the PR merged
+  cleanly.
+
+─ Worked for 2m 05s ───────────────────────────────────────────────────────────────────────────────────────────────────────────
+


### PR DESCRIPTION
## Summary

**Statusline refinements (5 commits):**
- Add folder icon (󰉋) before directory path
- Change git status to fish-style symbols: ⇡ahead ⇣behind ?untracked
- Remove staged/unstaged/conflict breakdown (replaced with ahead/behind)
- Move model display to header for visibility  
- Hide thinking indicator for models that don't support it (Haiku only shows for Opus/Sonnet)
- Use Powerline git branch symbol (U+E0A0) for consistency with Tide
- Add spacing between folder and git pills for visual clarity

**Context bar changes:**
- Move total context window size to bar line with reduced bar width (60%)
- Move output style to footer line

**Documentation (1 commit):**
- Add Codacy handling merge note for workflow

## Test plan
- [ ] Verify statusline displays correctly in Claude Code with Haiku
- [ ] Confirm git symbols match fish prompt style
- [ ] Check folder icon renders properly in Nerd Font terminal
- [ ] Verify thinking indicator is hidden for Haiku

🤖 Generated with [Claude Code](https://claude.com/claude-code)