### PR TITLE
[codex] Add Codacy rollout audit tooling

### DIFF
--- a/.github/workflows/dotfiles-validation.yml
+++ b/.github/workflows/dotfiles-validation.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_ORGANIZATION_PROVIDER: gh
+      CODACY_USERNAME: kairin
+      CODACY_PROJECT_NAME: 000-dotfiles
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -31,8 +35,6 @@ jobs:
 
       - name: Upload coverage to Codacy
         if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
-        continue-on-error: true
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-            --api-token "$CODACY_ACCOUNT_TOKEN" \
             -r coverage.xml

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Supported platforms: Ubuntu-style Linux, WSL (with Windows host font install), R
 ## Going deeper
 
 - **[Getting Started](docs/getting-started.md)** — Step-by-step first-time setup, ongoing maintenance, AI agent doc scaffolding, troubleshooting
+- **[Codacy workflow templates](docs/codacy-workflow-templates.md)** — Strict coverage upload snippets for Python, Node, and mixed repositories
 - **[GitHub Actions usage baseline](docs/operations/github-actions-usage-baseline.md)** — Live repo-level Actions history for comparing GitHub-hosted and local-runner usage
 - **[Setup script reference](#setup-script-reference)** (below) — All commands and options
 - **[Direct CLI reference](#direct-cli-advanced)** (below) — Stable commands for automation

--- a/codacy-rollout.json
+++ b/codacy-rollout.json
@@ -1,0 +1,56 @@
+{
+  "repositories": [
+    {
+      "repo": "kairin/000-dotfiles",
+      "local_path": "../000-dotfiles",
+      "language_profile": "python",
+      "test_workflow": "codacy-safety-net",
+      "test_command": "uv run python -m unittest discover -s tests",
+      "coverage_command": "uv run --with coverage==7.5.4 coverage run -m unittest discover -s tests && uv run --with coverage==7.5.4 coverage xml",
+      "coverage_reports": [
+        "coverage.xml"
+      ],
+      "expected_checks": [
+        "codacy-safety-net",
+        "Codacy Static Code Analysis",
+        "Codacy Coverage Variation",
+        "Codacy Diff Coverage"
+      ]
+    },
+    {
+      "repo": "kairin/BCM",
+      "local_path": "../BCM",
+      "language_profile": "python",
+      "test_workflow": "bcm-validation",
+      "test_command": "uv run python -m unittest discover -s tests",
+      "coverage_command": "uv run --with coverage coverage run -m unittest discover -s tests && uv run --with coverage coverage xml",
+      "coverage_reports": [
+        "coverage.xml"
+      ],
+      "expected_checks": [
+        "bcm-validation",
+        "Codacy Static Code Analysis",
+        "Codacy Coverage Variation",
+        "Codacy Diff Coverage"
+      ]
+    },
+    {
+      "repo": "kairin/graph-obsidian",
+      "local_path": "../graph-obsidian",
+      "language_profile": "node-python",
+      "test_workflow": "graph-obsidian-validation",
+      "test_command": "npm test && uv run python -m unittest discover -s tests",
+      "coverage_command": "npm test -- --coverage && uv run --with coverage coverage run -m unittest discover -s tests && uv run --with coverage coverage xml",
+      "coverage_reports": [
+        "coverage/lcov.info",
+        "coverage.xml"
+      ],
+      "expected_checks": [
+        "graph-obsidian-validation",
+        "Codacy Static Code Analysis",
+        "Codacy Coverage Variation",
+        "Codacy Diff Coverage"
+      ]
+    }
+  ]
+}

--- a/docs/codacy-workflow-templates.md
+++ b/docs/codacy-workflow-templates.md
@@ -1,0 +1,79 @@
+# Codacy workflow templates
+
+Reusable CI snippets for repositories in `codacy-rollout.json`. Keep repository
+names, job names, and test commands aligned with the inventory before enforcing
+the checks in GitHub rulesets.
+
+## Python uv + coverage.py
+
+```yaml
+jobs:
+  codacy-safety-net:
+    runs-on: ubuntu-latest
+    env:
+      CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_ORGANIZATION_PROVIDER: gh
+      CODACY_USERNAME: kairin
+      CODACY_PROJECT_NAME: 000-dotfiles
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - run: uv run --with coverage coverage run -m unittest discover -s tests
+      - run: uv run --with coverage coverage xml
+      - if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
+```
+
+## Node npm/Vitest coverage
+
+```yaml
+jobs:
+  node-validation:
+    runs-on: ubuntu-latest
+    env:
+      CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_ORGANIZATION_PROVIDER: gh
+      CODACY_USERNAME: kairin
+      CODACY_PROJECT_NAME: my-node-repo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test -- --coverage
+      - if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
+```
+
+## Mixed Node + Python
+
+```yaml
+jobs:
+  graph-obsidian-validation:
+    runs-on: ubuntu-latest
+    env:
+      CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+      CODACY_ORGANIZATION_PROVIDER: gh
+      CODACY_USERNAME: kairin
+      CODACY_PROJECT_NAME: graph-obsidian
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: npm
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - run: npm ci
+      - run: npm test -- --coverage
+      - run: uv run --with coverage coverage run -m unittest discover -s tests
+      - run: uv run --with coverage coverage xml
+      - if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
+      - if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
+```

--- a/dotfiles_tools/cli.py
+++ b/dotfiles_tools/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from typing import Sequence
 
@@ -10,6 +11,16 @@ from .bootstrap import (
     build_bootstrap_plan,
     build_tool_install_subplan,
     run_tool_install_post_install,
+)
+from .codacy_rollout import (
+    CodacyApiClient,
+    GitHubCliClient,
+    audit_inventory,
+    audit_repository,
+    find_repository,
+    load_inventory,
+    plan_repository,
+    render_audit_table,
 )
 from .doctor import run_doctor
 from .installer import apply_plan, build_plan
@@ -95,6 +106,18 @@ def build_parser() -> argparse.ArgumentParser:
     project.add_argument("--backup-dir")
     project.add_argument("--yes", action="store_true")
     project.add_argument("--copilot", action="store_true")
+
+    codacy_audit = subparsers.add_parser("codacy-audit", help="Audit Codacy rollout readiness")
+    _common(codacy_audit)
+    codacy_audit.add_argument("--inventory", required=True)
+    codacy_audit.add_argument("--target-repo")
+    codacy_audit.add_argument("--project")
+    codacy_audit.add_argument("--all", action="store_true")
+
+    codacy_plan = subparsers.add_parser("codacy-plan", help="Print read-only Codacy rollout plan")
+    _common(codacy_plan)
+    codacy_plan.add_argument("--inventory", required=True)
+    codacy_plan.add_argument("--target-repo", required=True)
     return parser
 
 
@@ -106,6 +129,8 @@ def _common(parser: argparse.ArgumentParser) -> None:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command in {"codacy-audit", "codacy-plan"}:
+        return _dispatch_codacy_command(args)
     report = _dispatch_command(args, Path(args.repo))
     print(render(report, args.as_json), end="")
     return 1 if report.status in {"failed", "partial"} else 0
@@ -135,6 +160,37 @@ def _dispatch_command(args: argparse.Namespace, repo: Path):
     else:
         raise SystemExit(f"unknown command: {cmd}")
     return report
+
+
+def _dispatch_codacy_command(args: argparse.Namespace) -> int:
+    inventory = load_inventory(Path(args.inventory))
+    if args.command == "codacy-plan":
+        item = find_repository(inventory, repo=args.target_repo)
+        output = plan_repository(item)
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0
+
+    github = GitHubCliClient()
+    codacy = CodacyApiClient()
+    if args.all:
+        results = audit_inventory(inventory, github, codacy)
+        if args.as_json:
+            print(json.dumps([result.to_dict() for result in results], indent=2, sort_keys=True))
+        else:
+            print(render_audit_table(results), end="")
+        return 1 if any(result.status == "FAIL" for result in results) else 0
+
+    item = find_repository(
+        inventory,
+        repo=args.target_repo,
+        project=Path(args.project) if args.project else None,
+    )
+    result = audit_repository(item, github, codacy)
+    if args.as_json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(result.to_text(), end="")
+    return 1 if result.status == "FAIL" else 0
 
 
 def _dispatch_bootstrap(args: argparse.Namespace, repo: Path):

--- a/dotfiles_tools/codacy_rollout.py
+++ b/dotfiles_tools/codacy_rollout.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+EXPECTED_CODACY_CHECKS = [
+    "Codacy Static Code Analysis",
+    "Codacy Coverage Variation",
+    "Codacy Diff Coverage",
+]
+
+
+@dataclass(frozen=True)
+class RepositoryItem:
+    repo: str
+    local_path: str
+    language_profile: str
+    test_workflow: str
+    test_command: str
+    coverage_command: str
+    coverage_reports: list[str]
+    expected_checks: list[str]
+
+    @property
+    def expected_codacy_checks(self) -> list[str]:
+        return [check for check in self.expected_checks if check.startswith("Codacy ")]
+
+
+@dataclass(frozen=True)
+class Inventory:
+    repositories: list[RepositoryItem]
+
+
+@dataclass(frozen=True)
+class AuditCheck:
+    check_id: str
+    status: str
+    detail: str
+    remediation: str = ""
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    repo: str
+    status: str
+    checks: list[AuditCheck]
+
+    def to_text(self) -> str:
+        lines = [f"{self.status} {self.repo}"]
+        for check in self.checks:
+            line = f"{check.status} {check.check_id}: {check.detail}"
+            if check.remediation:
+                line += f" Remediation: {check.remediation}"
+            lines.append(line)
+        return "\n".join(lines) + "\n"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "status": self.status,
+            "checks": [
+                {
+                    "id": check.check_id,
+                    "status": check.status,
+                    "detail": check.detail,
+                    "remediation": check.remediation,
+                }
+                for check in self.checks
+            ],
+        }
+
+
+def load_inventory(path: Path) -> Inventory:
+    raw = json.loads(path.read_text())
+    root = path.parent
+    repositories = []
+    for item in raw.get("repositories", []):
+        item = dict(item)
+        local_path = Path(item["local_path"])
+        if not local_path.is_absolute():
+            local_path = (root / local_path).resolve()
+        repositories.append(
+            RepositoryItem(
+                repo=item["repo"],
+                local_path=str(local_path),
+                language_profile=item["language_profile"],
+                test_workflow=item["test_workflow"],
+                test_command=item["test_command"],
+                coverage_command=item["coverage_command"],
+                coverage_reports=list(item.get("coverage_reports", [])),
+                expected_checks=list(item["expected_checks"]),
+            )
+        )
+    return Inventory(repositories=repositories)
+
+
+def audit_repository(item: RepositoryItem | dict[str, Any], github: Any, codacy: Any) -> AuditResult:
+    repo_item = _coerce_item(item)
+    checks: list[AuditCheck] = []
+    default_branch = github.default_branch(repo_item.repo)
+    ruleset = github.ruleset_summary(repo_item.repo, default_branch)
+    classic = github.branch_protection_summary(repo_item.repo, default_branch)
+    codacy_state = codacy.repository_state(repo_item.repo)
+    workflow_text = _read_workflow_text(Path(repo_item.local_path))
+
+    checks.extend(_audit_codacy(repo_item, codacy_state))
+    checks.extend(_audit_github_protection(repo_item, ruleset, classic))
+    checks.extend(_audit_workflow(repo_item, workflow_text))
+    checks.extend(_audit_github_runtime(repo_item, github, default_branch))
+
+    status = "FAIL" if any(check.status == "FAIL" for check in checks) else "WARN" if any(check.status == "WARN" for check in checks) else "PASS"
+    return AuditResult(repo=repo_item.repo, status=status, checks=checks)
+
+
+def plan_repository(item: RepositoryItem | dict[str, Any]) -> dict[str, Any]:
+    repo_item = _coerce_item(item)
+    return {
+        "repo": repo_item.repo,
+        "workflow": {
+            "language_profile": repo_item.language_profile,
+            "job": repo_item.test_workflow,
+            "test_command": repo_item.test_command,
+            "coverage_command": repo_item.coverage_command,
+            "coverage_reports": repo_item.coverage_reports,
+            "coverage_upload_env": {
+                "CODACY_ACCOUNT_TOKEN": "${{ secrets.CODACY_ACCOUNT_TOKEN }}",
+                "CODACY_API_TOKEN": "${{ secrets.CODACY_ACCOUNT_TOKEN }}",
+                "CODACY_ORGANIZATION_PROVIDER": "gh",
+                "CODACY_USERNAME": repo_item.repo.split("/", 1)[0],
+                "CODACY_PROJECT_NAME": repo_item.repo.split("/", 1)[1],
+            },
+        },
+        "ruleset": {
+            "target": "default_branch",
+            "requires_pull_request": True,
+            "blocks_force_pushes": True,
+            "blocks_deletions": True,
+            "required_checks": repo_item.expected_checks,
+        },
+    }
+
+
+def audit_inventory(inventory: Inventory, github: Any, codacy: Any) -> list[AuditResult]:
+    return [audit_repository(item, github, codacy) for item in inventory.repositories]
+
+
+def find_repository(inventory: Inventory, repo: str | None = None, project: Path | None = None) -> RepositoryItem:
+    if repo:
+        for item in inventory.repositories:
+            if item.repo == repo:
+                return item
+        raise ValueError(f"repo not found in codacy-rollout.json: {repo}")
+    if project:
+        project_path = project.resolve()
+        for item in inventory.repositories:
+            if Path(item.local_path).resolve() == project_path:
+                return item
+        raise ValueError(f"project not found in codacy-rollout.json: {project}")
+    raise ValueError("repo or project is required")
+
+
+class GitHubCliClient:
+    def default_branch(self, repo: str) -> str:
+        return self._run(["gh", "api", f"repos/{repo}", "--jq", ".default_branch"]) or "main"
+
+    def ruleset_summary(self, repo: str, default_branch: str) -> dict[str, Any]:
+        data = self._run_json(["gh", "api", f"repos/{repo}/rulesets", "--paginate"])
+        return _summarize_rulesets(data, default_branch)
+
+    def branch_protection_summary(self, repo: str, default_branch: str) -> dict[str, Any]:
+        data = self._run_json(["gh", "api", f"repos/{repo}/branches/{default_branch}/protection"])
+        return _summarize_branch_protection(data)
+
+    def repository_secret_names(self, repo: str) -> list[str]:
+        output = self._run(["gh", "secret", "list", "-R", repo, "--json", "name", "--jq", ".[].name"])
+        return [line.strip() for line in output.splitlines() if line.strip()]
+
+    def latest_check_runs(self, repo: str, default_branch: str) -> dict[str, str]:
+        output = self._run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/commits/{default_branch}/check-runs",
+                "--paginate",
+                "--jq",
+                '.check_runs[] | "\\(.name)\\t\\(.conclusion // .status)"',
+            ]
+        )
+        checks: dict[str, str] = {}
+        for line in output.splitlines():
+            name, _, status = line.partition("\t")
+            if name:
+                checks[name] = status
+        return checks
+
+    def _run(self, args: list[str]) -> str:
+        result = subprocess.run(args, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
+    def _run_json(self, args: list[str]) -> Any:
+        output = self._run(args)
+        if not output:
+            return {}
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError:
+            values = []
+            for line in output.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    values.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            return values
+
+
+class CodacyApiClient:
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token or os.environ.get("CODACY_ACCOUNT_TOKEN", "") or os.environ.get("CODACY_API_TOKEN", "")
+
+    def repository_state(self, repo: str) -> dict[str, Any]:
+        fixture = os.environ.get("CODACY_AUDIT_CODACY_STATE_JSON")
+        if fixture:
+            data = json.loads(Path(fixture).read_text())
+            return data.get(repo, data)
+        if not self.token:
+            return {
+                "exists": False,
+                "coding_standard_applied": False,
+                "gate_policy_applied": False,
+                "latest_pr_quality": {},
+                "error": "CODACY_ACCOUNT_TOKEN is not set",
+            }
+        owner, name = repo.split("/", 1)
+        url = f"https://app.codacy.com/api/v3/analysis/organizations/gh/{owner}/repositories/{name}"
+        request = Request(url, headers={"api-token": self.token})
+        try:
+            with urlopen(request, timeout=15) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            return {"exists": False, "error": f"Codacy API HTTP {error.code}"}
+        except (OSError, URLError, json.JSONDecodeError) as error:
+            return {"exists": False, "error": str(error)}
+        body = data.get("data", data)
+        return {
+            "exists": True,
+            "coding_standard_applied": bool(
+                body.get("codingStandard")
+                or body.get("coding_standard")
+                or body.get("codingStandardName")
+                or body.get("codingStandardId")
+            ),
+            "gate_policy_applied": bool(
+                body.get("qualityGate")
+                or body.get("quality_gate")
+                or body.get("qualityGateName")
+                or body.get("qualityGateId")
+            ),
+            "latest_pr_quality": body.get("latest_pr_quality") or body.get("latestPullRequest") or {},
+        }
+
+
+def render_audit_table(results: Iterable[AuditResult]) -> str:
+    rows = []
+    for result in results:
+        failures = [check for check in result.checks if check.status == "FAIL"]
+        warnings = [check for check in result.checks if check.status == "WARN"]
+        rows.append(f"{result.status}\t{result.repo}\tFAIL={len(failures)}\tWARN={len(warnings)}")
+    return "\n".join(rows) + ("\n" if rows else "")
+
+
+def _coerce_item(item: RepositoryItem | dict[str, Any]) -> RepositoryItem:
+    if isinstance(item, RepositoryItem):
+        return item
+    return RepositoryItem(
+        repo=item["repo"],
+        local_path=item["local_path"],
+        language_profile=item["language_profile"],
+        test_workflow=item["test_workflow"],
+        test_command=item["test_command"],
+        coverage_command=item["coverage_command"],
+        coverage_reports=list(item.get("coverage_reports", [])),
+        expected_checks=list(item["expected_checks"]),
+    )
+
+
+def _audit_codacy(item: RepositoryItem, state: dict[str, Any]) -> list[AuditCheck]:
+    checks = [
+        _check(
+            "repository_onboarded",
+            bool(state.get("exists")),
+            "Codacy repository exists",
+            f"Add {item.repo} to Codacy and rerun codacy-audit.",
+            state.get("error", "Codacy repository is missing"),
+        ),
+        _check(
+            "coding_standard",
+            bool(state.get("coding_standard_applied")),
+            "Codacy coding standard is applied",
+            "Apply the organization coding standard in Codacy.",
+            "Codacy coding standard is missing",
+        ),
+        _check(
+            "gate_policy",
+            bool(state.get("gate_policy_applied")),
+            "Codacy gate policy is applied",
+            "Apply the strict quality gate in Codacy.",
+            "Codacy gate policy is missing",
+        ),
+    ]
+    cause = (
+        state.get("latest_pr_quality", {})
+        .get("coverage", {})
+        .get("diffCoverage", {})
+        .get("cause")
+    )
+    checks.append(
+        _check(
+            "coverage_pr_ready",
+            cause in (None, "", "None"),
+            "Latest Codacy PR coverage has requirements",
+            "Upload coverage for the PR head and target/common ancestor.",
+            f"Codacy diff coverage cause is {cause}",
+        )
+    )
+    return checks
+
+
+def _audit_github_protection(item: RepositoryItem, ruleset: dict[str, Any], classic: dict[str, Any]) -> list[AuditCheck]:
+    required_checks = sorted(set(ruleset.get("required_checks", [])) | set(classic.get("required_checks", [])))
+    missing = [check for check in item.expected_checks if check not in required_checks]
+    protected = bool(ruleset.get("protects_default_branch") or classic.get("protects_default_branch"))
+    requires_pr = bool(ruleset.get("requires_pull_request") or classic.get("requires_pull_request"))
+    blocks_force = bool(ruleset.get("blocks_force_pushes") or classic.get("blocks_force_pushes"))
+    blocks_delete = bool(ruleset.get("blocks_deletions") or classic.get("blocks_deletions"))
+    return [
+        _check("default_branch_protected", protected, "Default branch is protected", "Enable a GitHub ruleset for the default branch.", "Default branch is not protected"),
+        _check("pull_request_required", requires_pr, "Pull requests are required", "Enable a pull request requirement in the GitHub ruleset.", "Pull requests are not required"),
+        _check("force_push_blocked", blocks_force, "Force pushes are blocked", "Add the non_fast_forward GitHub ruleset rule.", "Force pushes are not blocked"),
+        _check("deletion_blocked", blocks_delete, "Deletions are blocked", "Add the deletion GitHub ruleset rule.", "Branch deletion is not blocked"),
+        _check("required_status_checks", not missing, "Strict required checks are configured", "Require: " + ", ".join(missing), "Missing required checks: " + ", ".join(missing)),
+    ]
+
+
+def _audit_workflow(item: RepositoryItem, workflow_text: str) -> list[AuditCheck]:
+    expected_reports = item.coverage_reports or ["coverage.xml"]
+    has_report = any(report in workflow_text for report in expected_reports)
+    has_identity = all(token in workflow_text for token in ("CODACY_ORGANIZATION_PROVIDER", "CODACY_USERNAME", "CODACY_PROJECT_NAME"))
+    return [
+        _check("coverage_generation", "coverage" in workflow_text and has_report, "Workflow generates coverage", "Add coverage generation before Codacy upload.", "Workflow does not generate coverage"),
+        _check("coverage_upload", "coverage.codacy.com/get.sh" in workflow_text and "CODACY_ACCOUNT_TOKEN" in workflow_text and has_report, "Workflow uploads coverage to Codacy", "Add an Upload coverage to Codacy step.", "Workflow does not upload coverage to Codacy"),
+        _check("coverage_upload_identity", has_identity, "Coverage upload includes Codacy repo identity", f"Set CODACY_ORGANIZATION_PROVIDER=gh, CODACY_USERNAME={item.repo.split('/', 1)[0]}, and CODACY_PROJECT_NAME={item.repo.split('/', 1)[1]}.", "Coverage upload identity is missing"),
+        _check("coverage_upload_strict", "continue-on-error: true" not in workflow_text, "Coverage upload is blocking", "Remove continue-on-error from the Codacy coverage upload.", "Coverage upload uses continue-on-error"),
+    ]
+
+
+def _audit_github_runtime(item: RepositoryItem, github: Any, default_branch: str) -> list[AuditCheck]:
+    secrets = github.repository_secret_names(item.repo)
+    latest = github.latest_check_runs(item.repo, default_branch)
+    missing = [check for check in item.expected_checks if check not in latest]
+    failing = [f"{check}={latest[check]}" for check in item.expected_checks if latest.get(check) not in (None, "success")]
+    return [
+        _check("codacy_secret", "CODACY_ACCOUNT_TOKEN" in secrets, "CODACY account token secret is present", "Add CODACY_ACCOUNT_TOKEN as a GitHub Actions repository or organization secret.", "CODACY_ACCOUNT_TOKEN secret is missing"),
+        _check("latest_checks", not missing and not failing, "Latest GitHub checks include strict profile", "Rerun CI or repair checks: " + ", ".join(missing + failing), "Latest checks are not strict-ready: " + ", ".join(missing + failing)),
+    ]
+
+
+def _check(check_id: str, ok: bool, pass_detail: str, remediation: str, fail_detail: str) -> AuditCheck:
+    if ok:
+        return AuditCheck(check_id=check_id, status="PASS", detail=pass_detail)
+    return AuditCheck(check_id=check_id, status="FAIL", detail=fail_detail, remediation=remediation)
+
+
+def _read_workflow_text(project: Path) -> str:
+    workflow_dir = project / ".github" / "workflows"
+    if not workflow_dir.is_dir():
+        return ""
+    parts = []
+    for path in sorted(list(workflow_dir.glob("*.yml")) + list(workflow_dir.glob("*.yaml"))):
+        parts.append(path.read_text(errors="ignore"))
+    return "\n".join(parts)
+
+
+def _summarize_rulesets(data: Any, default_branch: str) -> dict[str, Any]:
+    summary = _empty_protection_summary()
+    rulesets = data if isinstance(data, list) else []
+    for ruleset in rulesets:
+        if not isinstance(ruleset, dict) or ruleset.get("target", "branch") != "branch":
+            continue
+        if ruleset.get("enforcement") == "disabled":
+            continue
+        if not _ruleset_matches_default_branch(ruleset, default_branch):
+            continue
+        summary["protects_default_branch"] = True
+        for rule in ruleset.get("rules", []) or []:
+            rule_type = rule.get("type")
+            if rule_type == "pull_request":
+                summary["requires_pull_request"] = True
+            elif rule_type == "non_fast_forward":
+                summary["blocks_force_pushes"] = True
+            elif rule_type == "deletion":
+                summary["blocks_deletions"] = True
+            elif rule_type == "required_status_checks":
+                for status_check in (rule.get("parameters") or {}).get("required_status_checks", []) or []:
+                    context = status_check.get("context") or status_check.get("name")
+                    if context:
+                        summary["required_checks"].append(context)
+    summary["required_checks"] = sorted(set(summary["required_checks"]))
+    return summary
+
+
+def _summarize_branch_protection(data: Any) -> dict[str, Any]:
+    summary = _empty_protection_summary()
+    if not isinstance(data, dict) or not data:
+        return summary
+    summary["protects_default_branch"] = True
+    summary["requires_pull_request"] = bool(data.get("required_pull_request_reviews"))
+    force = data.get("allow_force_pushes") or {}
+    deletions = data.get("allow_deletions") or {}
+    summary["blocks_force_pushes"] = not bool(force.get("enabled"))
+    summary["blocks_deletions"] = not bool(deletions.get("enabled"))
+    required = data.get("required_status_checks") or {}
+    checks = []
+    checks.extend(required.get("contexts") or [])
+    checks.extend((item.get("context") for item in required.get("checks") or [] if item.get("context")))
+    summary["required_checks"] = sorted(set(checks))
+    return summary
+
+
+def _empty_protection_summary() -> dict[str, Any]:
+    return {
+        "protects_default_branch": False,
+        "requires_pull_request": False,
+        "blocks_force_pushes": False,
+        "blocks_deletions": False,
+        "required_checks": [],
+    }
+
+
+def _ruleset_matches_default_branch(ruleset: dict[str, Any], default_branch: str) -> bool:
+    conditions = ruleset.get("conditions") or {}
+    ref_name = conditions.get("ref_name") or {}
+    includes = ref_name.get("include") or []
+    if not includes:
+        return True
+    expected = {default_branch, f"refs/heads/{default_branch}", "~DEFAULT_BRANCH"}
+    return any(value in expected for value in includes)

--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -13,8 +13,8 @@
 # Modes:
 #   (default)        run stages 1-7
 #   --codacy-only    run only stages 3, 5, 6, 7 against working tree HEAD.
-#                    Used by ./setup ship after a merge to refresh the SARIF
-#                    upload for the new HEAD so required Codacy checks go green.
+#                    Optional diagnostic mode; ./setup ship relies on
+#                    GitHub-required checks instead of local Codacy uploads.
 #
 # Exit codes:
 #   0  pipeline passed

--- a/setup
+++ b/setup
@@ -67,6 +67,15 @@ Commands:
       Run the local quality pipeline (tests, coverage, Codacy upload) via
       scripts/quality-pipeline.sh. Use before pushing to validate locally.
 
+  codacy-audit [--all|--project PATH|--repo OWNER/REPO] [--json]
+      Read-only audit for strict Codacy rollout readiness. Checks GitHub
+      rulesets/protection, workflow coverage upload, secrets, latest check
+      runs, and Codacy repository/gate readiness from codacy-rollout.json.
+
+  codacy-plan --repo OWNER/REPO
+      Print the exact workflow and GitHub ruleset requirements for a repository
+      from codacy-rollout.json without mutating GitHub, Codacy, or files.
+
   hooks
       Install or update this repo's Git hooks. Installs
       scripts/hooks/pre-push to .git/hooks/pre-push so Git blocks direct pushes
@@ -74,9 +83,8 @@ Commands:
 
   ship [<pr-number>]
       Finalize a PR end-to-end: detect or use the given PR number, refresh the
-      branch with main if BEHIND, re-upload Codacy SARIF for the new HEAD and
-      base, poll the four required Codacy checks, then squash-merge. Requires
-      CODACY_PROJECT_TOKEN and an authenticated gh.
+      branch with main if BEHIND, poll the GitHub-required checks from active
+      rulesets/branch protection, then squash-merge. Requires authenticated gh.
 
   repair-codacy-env [<project>] [--project PATH] [--owner OWNER] [--repo REPO]
       Non-interactive: regenerate the managed Codacy block in
@@ -737,6 +745,61 @@ cmd_quality() {
   exec bash "$pipeline"
 }
 
+cmd_codacy_audit() {
+  local target_repo="" project="" all=0 as_json=0
+  while (($#)); do
+    case "$1" in
+      --all) all=1; shift ;;
+      --project) project="${2:?--project requires a path}"; shift 2 ;;
+      --repo) target_repo="${2:?--repo requires OWNER/REPO}"; shift 2 ;;
+      --json) as_json=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown flag for codacy-audit: $1" ;;
+    esac
+  done
+
+  local selectors=0
+  [[ "$all" -eq 1 ]] && selectors=$((selectors + 1))
+  [[ -n "$project" ]] && selectors=$((selectors + 1))
+  [[ -n "$target_repo" ]] && selectors=$((selectors + 1))
+  [[ "$selectors" -le 1 ]] || die "choose only one of --all, --project, or --repo"
+  [[ "$selectors" -eq 1 ]] || all=1
+
+  ensure_uv
+  local -a args=(
+    codacy-audit
+    --repo "$DOTFILES_REPO"
+    --inventory "$DOTFILES_REPO/codacy-rollout.json"
+  )
+  [[ "$all" -eq 1 ]] && args+=(--all)
+  [[ -n "$project" ]] && args+=(--project "$project")
+  [[ -n "$target_repo" ]] && args+=(--target-repo "$target_repo")
+  [[ "$as_json" -eq 1 ]] && args+=(--json)
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools "${args[@]}")
+}
+
+cmd_codacy_plan() {
+  local target_repo="" as_json=0
+  while (($#)); do
+    case "$1" in
+      --repo) target_repo="${2:?--repo requires OWNER/REPO}"; shift 2 ;;
+      --json) as_json=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown flag for codacy-plan: $1" ;;
+    esac
+  done
+  [[ -n "$target_repo" ]] || die "codacy-plan requires --repo OWNER/REPO"
+  ensure_uv
+  local -a args=(
+    codacy-plan
+    --repo "$DOTFILES_REPO"
+    --inventory "$DOTFILES_REPO/codacy-rollout.json"
+    --target-repo "$target_repo"
+  )
+  [[ "$as_json" -eq 1 ]] && args+=(--json)
+  (cd "$DOTFILES_REPO" && uv run python -m dotfiles_tools "${args[@]}")
+}
+
 cmd_hooks() {
   local installer="$DOTFILES_REPO/scripts/install-hooks.sh"
   [[ -f "$installer" ]] || die "hook installer missing: $installer"
@@ -799,6 +862,21 @@ Then re-run: ./setup ship <pr>
 EOF
 }
 
+ship_required_checks() {
+  local repo="$1" base_ref="$2" checks=""
+  if [[ -n "${SHIP_REQUIRED_CHECKS:-}" ]]; then
+    checks="$SHIP_REQUIRED_CHECKS"
+  else
+    checks="$(gh api "repos/${repo}/rulesets" --paginate \
+      --jq '.[] | select((.target // "branch") == "branch") | select((.enforcement // "") != "disabled") | .rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[]? | (.context // .name // empty)' 2>/dev/null || true)"
+    if [[ -z "$checks" ]]; then
+      checks="$(gh api "repos/${repo}/branches/${base_ref}/protection/required_status_checks" \
+        --jq '.contexts[]?, .checks[]?.context' 2>/dev/null || true)"
+    fi
+  fi
+  printf '%s\n' "$checks" | awk 'NF && !seen[$0]++'
+}
+
 cmd_ship() {
   local pr=""
   while (($#)); do
@@ -818,20 +896,13 @@ cmd_ship() {
     shift
   done
 
-  echo "[ship] step 1: verifying CODACY_PROJECT_TOKEN"
-  [[ -n "${CODACY_PROJECT_TOKEN:-}" ]] \
-    || die "CODACY_PROJECT_TOKEN is not set — run: ./setup repair-codacy-env"
-
-  echo "[ship] step 2: verifying required CLIs (codacy-cli gh git jq)"
+  echo "[ship] step 1: verifying required CLIs (gh git jq)"
   local missing=()
   local cli
-  for cli in codacy-cli gh git jq; do
+  for cli in gh git jq; do
     command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
   done
   [[ ${#missing[@]} -eq 0 ]] || die "missing required CLIs on PATH: ${missing[*]}"
-
-  echo "[ship] step 2b: verifying codacy-cli is not a recursion trap"
-  ship_verify_codacy_cli || die "$(ship_codacy_repair_message)"
 
   local repo_root
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" \
@@ -864,166 +935,97 @@ cmd_ship() {
   fi
   [[ "$pr" =~ ^[0-9]+$ ]] || die "PR number must be numeric: $pr"
   echo "[ship] PR #$pr on $repo"
-
-  local _ship_tmpdir="" _ship_head_wt="" _ship_base_wt="" _ship_head_sarif="" _ship_base_sarif="" _ship_repo_root
-  _ship_repo_root="$repo_root"
-  _ship_cleanup() {
-    [[ -n "${_ship_head_wt:-}" ]] && git -C "$_ship_repo_root" worktree remove "$_ship_head_wt" --force >/dev/null 2>&1 || true
-    [[ -n "${_ship_base_wt:-}" ]] && git -C "$_ship_repo_root" worktree remove "$_ship_base_wt" --force >/dev/null 2>&1 || true
-    [[ -n "${_ship_tmpdir:-}" ]] && rm -rf "$_ship_tmpdir" 2>/dev/null || true
-  }
-  trap _ship_cleanup EXIT
   trap 'exit 130' INT TERM
 
-  local required_checks=()
-  if [[ -n "${SHIP_REQUIRED_CHECKS:-}" ]]; then
-    local check
-    while IFS= read -r check; do
-      [[ -n "$check" ]] && required_checks+=("$check")
-    done <<<"$SHIP_REQUIRED_CHECKS"
-  else
-    required_checks=(
-      "Codacy Static Code Analysis"
-      "Codacy Coverage Variation"
-      "Codacy Diff Coverage"
-      "codacy-safety-net"
-    )
-  fi
+  echo "[ship] step 4a: fetching PR state"
+  local pr_state head_oid merge_state base_ref_name
+  pr_state="$(gh pr view "$pr" -R "$repo" --json mergeable,mergeStateStatus,headRefOid,baseRefName 2>/dev/null)" \
+    || die "gh pr view failed for PR #$pr"
+  head_oid="$(printf '%s' "$pr_state" | jq -r '.headRefOid')"
+  merge_state="$(printf '%s' "$pr_state" | jq -r '.mergeStateStatus')"
+  base_ref_name="$(printf '%s' "$pr_state" | jq -r '.baseRefName')"
+  [[ -n "$head_oid" && "$head_oid" != "null" ]] || die "gh pr view returned no headRefOid for PR #$pr"
+  [[ -n "$base_ref_name" && "$base_ref_name" != "null" ]] || die "gh pr view returned no baseRefName for PR #$pr"
+  echo "[ship] head=$head_oid base=$base_ref_name mergeStateStatus=$merge_state"
 
-  local attempt
-  local all_green=0
-  for attempt in 1 2 3; do
-    echo "[ship] attempt $attempt/3"
-    _ship_cleanup
-    _ship_tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/setup-ship.XXXXXX")" \
-      || die "could not create a temporary workspace for ship"
-    _ship_head_wt="$_ship_tmpdir/head"
-    _ship_base_wt="$_ship_tmpdir/base"
-    _ship_head_sarif="$_ship_tmpdir/head.sarif"
-    _ship_base_sarif="$_ship_tmpdir/base.sarif"
-
-    echo "[ship] step 4a: fetching PR state"
-    local pr_state head_oid merge_state base_ref_name base_sha
+  if [[ "$merge_state" == "BEHIND" ]]; then
+    echo "[ship] branch BEHIND $base_ref_name; running gh pr update-branch"
+    gh pr update-branch "$pr" -R "$repo" \
+      || die "gh pr update-branch failed for PR #$pr"
+    sleep 3
     pr_state="$(gh pr view "$pr" -R "$repo" --json mergeable,mergeStateStatus,headRefOid,baseRefName 2>/dev/null)" \
-      || die "gh pr view failed for PR #$pr"
+      || die "gh pr view (refetch) failed for PR #$pr"
     head_oid="$(printf '%s' "$pr_state" | jq -r '.headRefOid')"
     merge_state="$(printf '%s' "$pr_state" | jq -r '.mergeStateStatus')"
     base_ref_name="$(printf '%s' "$pr_state" | jq -r '.baseRefName')"
     [[ -n "$head_oid" && "$head_oid" != "null" ]] || die "gh pr view returned no headRefOid for PR #$pr"
     [[ -n "$base_ref_name" && "$base_ref_name" != "null" ]] || die "gh pr view returned no baseRefName for PR #$pr"
-    echo "[ship] head=$head_oid base=$base_ref_name mergeStateStatus=$merge_state"
+    echo "[ship] new head=$head_oid base=$base_ref_name mergeStateStatus=$merge_state"
+  fi
 
-    if [[ "$merge_state" == "BEHIND" ]]; then
-      echo "[ship] step 4b: branch BEHIND $base_ref_name; running gh pr update-branch"
-      gh pr update-branch "$pr" -R "$repo" \
-        || die "gh pr update-branch failed for PR #$pr"
-      sleep 3
-      pr_state="$(gh pr view "$pr" -R "$repo" --json mergeable,mergeStateStatus,headRefOid,baseRefName 2>/dev/null)" \
-        || die "gh pr view (refetch) failed for PR #$pr"
-      head_oid="$(printf '%s' "$pr_state" | jq -r '.headRefOid')"
-      merge_state="$(printf '%s' "$pr_state" | jq -r '.mergeStateStatus')"
-      base_ref_name="$(printf '%s' "$pr_state" | jq -r '.baseRefName')"
-      [[ -n "$head_oid" && "$head_oid" != "null" ]] || die "gh pr view returned no headRefOid for PR #$pr"
-      [[ -n "$base_ref_name" && "$base_ref_name" != "null" ]] || die "gh pr view returned no baseRefName for PR #$pr"
-      echo "[ship] new head=$head_oid base=$base_ref_name mergeStateStatus=$merge_state"
-    fi
-
-    echo "[ship] step 4c: preparing tmp worktree at $_ship_head_wt"
-    git -C "$repo_root" fetch origin "pull/${pr}/head:refs/remotes/origin/pr/${pr}" >/dev/null 2>&1 || true
-    git -C "$repo_root" worktree add --detach "$_ship_head_wt" "$head_oid" \
-      || die "could not create worktree at $_ship_head_wt for $head_oid"
-    ship_prepare_codacy_worktree "$_ship_head_wt" "$repo_root"
-
-    echo "[ship] step 4d: running codacy-cli analyze (head)"
-    rm -f "$_ship_head_sarif"
-    ( cd "$_ship_head_wt" && codacy-cli analyze --tool pylint --format sarif -o "$_ship_head_sarif" ) \
-      || die "codacy-cli analyze failed in $_ship_head_wt"
-    [[ -s "$_ship_head_sarif" ]] \
-      || die "codacy-cli analyze produced no SARIF at $_ship_head_sarif (check .codacy/codacy.yaml in the head worktree)"
-
-    echo "[ship] step 4e: uploading SARIF for HEAD ($head_oid)"
-    ship_upload_sarif "$_ship_head_wt" "$_ship_head_sarif" "$head_oid" \
-      || die "codacy-cli upload (HEAD) failed"
-
-    echo "[ship] step 4f: fetching base branch origin/$base_ref_name"
-    git -C "$repo_root" fetch origin "$base_ref_name" >/dev/null 2>&1 \
-      || die "could not fetch origin/$base_ref_name"
-    base_sha="$(git -C "$repo_root" rev-parse "origin/$base_ref_name" 2>/dev/null)" \
-      || die "could not resolve origin/$base_ref_name after fetch"
-    echo "[ship] step 4g: preparing base worktree at $_ship_base_wt ($base_sha)"
-    git -C "$repo_root" worktree add --detach "$_ship_base_wt" "$base_sha" \
-      || die "could not create worktree at $_ship_base_wt for $base_sha"
-    ship_prepare_codacy_worktree "$_ship_base_wt" "$repo_root"
-    echo "[ship] step 4h: running codacy-cli analyze (base)"
-    rm -f "$_ship_base_sarif"
-    ( cd "$_ship_base_wt" && codacy-cli analyze --tool pylint --format sarif -o "$_ship_base_sarif" ) \
-      || die "codacy-cli analyze failed in $_ship_base_wt"
-    [[ -s "$_ship_base_sarif" ]] \
-      || die "codacy-cli analyze produced no SARIF at $_ship_base_sarif (check .codacy/codacy.yaml in the base worktree)"
-
-    echo "[ship] step 4i: uploading SARIF for base ($base_sha)"
-    ship_upload_sarif "$_ship_base_wt" "$_ship_base_sarif" "$base_sha" \
-      || die "codacy-cli upload (base) failed"
-
-    local interval="${SHIP_CHECK_INTERVAL:-15}" timeout="${SHIP_CHECK_TIMEOUT:-900}"
-    [[ "$interval" =~ ^[0-9]+$ && "$interval" -gt 0 ]] \
-      || die "SHIP_CHECK_INTERVAL must be a positive integer number of seconds"
-    [[ "$timeout" =~ ^[0-9]+$ && "$timeout" -gt 0 ]] \
-      || die "SHIP_CHECK_TIMEOUT must be a positive integer number of seconds"
-    echo "[ship] step 4j: polling required checks (up to ${timeout}s)"
-    local elapsed=0 last_status_report=""
-    while (( elapsed < timeout )); do
-      local checks
-      checks="$(gh api "repos/${repo}/commits/${head_oid}/check-runs" --paginate \
-        --jq '.check_runs[] | "\(.name)\t\(.conclusion // .status)"' 2>/dev/null || true)"
-      local pending=0 failed=0 check line status_report="" status_line
-      for check in "${required_checks[@]}"; do
-        line="$(printf '%s\n' "$checks" | awk -F '\t' -v n="$check" '$1==n {print $2; exit}')"
-        case "$line" in
-          success)
-            status_report+="$check: success"$'\n'
-            ;;
-          failure|cancelled|timed_out|action_required|startup_failure|stale|skipped)
-            failed=1
-            status_report+="$check: $line"$'\n'
-            ;;
-          "")
-            pending=1
-            status_report+="$check: missing"$'\n'
-            ;;
-          *)
-            pending=1
-            status_report+="$check: $line"$'\n'
-            ;;
-        esac
-      done
-      status_report="${status_report%$'\n'}"
-      if [[ "$status_report" != "$last_status_report" ]]; then
-        echo "[ship] required check status (${elapsed}s elapsed):"
-        while IFS= read -r status_line; do
-          echo "[ship]   $status_line"
-        done <<<"$status_report"
-        last_status_report="$status_report"
-      fi
-      if (( failed == 1 )); then
-        echo "[ship] one or more required checks failed; will retry SARIF upload"
-        break
-      fi
-      if (( pending == 0 )); then
-        echo "[ship] all required checks green for $head_oid"
-        all_green=1
-        break
-      fi
-      printf '[ship]   waiting for required checks (%ds elapsed)...\n' "$elapsed"
-      sleep "$interval"
-      elapsed=$(( elapsed + interval ))
-    done
-
-    (( all_green == 1 )) && break
-    echo "[ship] retrying after re-upload (attempt $attempt complete)"
+  echo "[ship] step 4b: resolving required GitHub checks"
+  local required_checks=()
+  mapfile -t required_checks < <(ship_required_checks "$repo" "$base_ref_name")
+  [[ ${#required_checks[@]} -gt 0 ]] \
+    || die "could not resolve any required GitHub checks from rulesets or branch protection"
+  local required_check
+  for required_check in "${required_checks[@]}"; do
+    echo "[ship]   required: $required_check"
   done
 
-  (( all_green == 1 )) || die "required Codacy checks did not all reach success after 3 attempts"
+  local interval="${SHIP_CHECK_INTERVAL:-15}" timeout="${SHIP_CHECK_TIMEOUT:-900}"
+  [[ "$interval" =~ ^[0-9]+$ && "$interval" -gt 0 ]] \
+    || die "SHIP_CHECK_INTERVAL must be a positive integer number of seconds"
+  [[ "$timeout" =~ ^[0-9]+$ && "$timeout" -gt 0 ]] \
+    || die "SHIP_CHECK_TIMEOUT must be a positive integer number of seconds"
+  echo "[ship] step 4c: polling required checks (up to ${timeout}s)"
+  local elapsed=0 last_status_report="" all_green=0 failed=0
+  while (( elapsed < timeout )); do
+    local checks
+    checks="$(gh api "repos/${repo}/commits/${head_oid}/check-runs" --paginate \
+      --jq '.check_runs[] | "\(.name)\t\(.conclusion // .status)"' 2>/dev/null || true)"
+    local pending=0 check line status_report="" status_line
+    failed=0
+    for check in "${required_checks[@]}"; do
+      line="$(printf '%s\n' "$checks" | awk -F '\t' -v n="$check" '$1==n {print $2; exit}')"
+      case "$line" in
+        success)
+          status_report+="$check: success"$'\n'
+          ;;
+        failure|cancelled|timed_out|action_required|startup_failure|stale|skipped)
+          failed=1
+          status_report+="$check: $line"$'\n'
+          ;;
+        "")
+          pending=1
+          status_report+="$check: missing"$'\n'
+          ;;
+        *)
+          pending=1
+          status_report+="$check: $line"$'\n'
+          ;;
+      esac
+    done
+    status_report="${status_report%$'\n'}"
+    if [[ "$status_report" != "$last_status_report" ]]; then
+      echo "[ship] required check status (${elapsed}s elapsed):"
+      while IFS= read -r status_line; do
+        echo "[ship]   $status_line"
+      done <<<"$status_report"
+      last_status_report="$status_report"
+    fi
+    (( failed == 1 )) && die "one or more required GitHub checks failed"
+    if (( pending == 0 )); then
+      echo "[ship] all required checks green for $head_oid"
+      all_green=1
+      break
+    fi
+    printf '[ship]   waiting for required checks (%ds elapsed)...\n' "$elapsed"
+    sleep "$interval"
+    elapsed=$(( elapsed + interval ))
+  done
+
+  (( all_green == 1 )) || die "required GitHub checks did not all reach success before timeout"
 
   echo "[ship] step 5: confirming PR is mergeable"
   local final_state waited=0
@@ -1055,8 +1057,7 @@ cmd_ship() {
   echo "[ship] PR #$pr is MERGED"
 
   echo "[ship] step 7: cleaning up"
-  _ship_cleanup
-  trap - EXIT INT TERM
+  trap - INT TERM
   echo "[ship] done"
 }
 
@@ -2439,6 +2440,8 @@ main() {
     init)   cmd_init "$@" ;;
     doctor) cmd_doctor "$@" ;;
     quality) cmd_quality "$@" ;;
+    codacy-audit) cmd_codacy_audit "$@" ;;
+    codacy-plan) cmd_codacy_plan "$@" ;;
     hooks) cmd_hooks "$@" ;;
     ship)   cmd_ship "$@" ;;
     repair-codacy-env) cmd_repair_codacy_env "$@" ;;

--- a/tests/test_codacy_rollout.py
+++ b/tests/test_codacy_rollout.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from tests.helpers import DotfilesTestCase, REPO_ROOT
+
+from dotfiles_tools.codacy_rollout import (
+    EXPECTED_CODACY_CHECKS,
+    audit_repository,
+    load_inventory,
+    plan_repository,
+)
+
+
+class FakeGitHub:
+    def __init__(
+        self,
+        *,
+        required_checks: list[str] | None = None,
+        latest_checks: dict[str, str] | None = None,
+        secret_names: list[str] | None = None,
+    ) -> None:
+        self.required_checks = required_checks or [
+            "codacy-safety-net",
+            *EXPECTED_CODACY_CHECKS,
+        ]
+        self.latest_checks = latest_checks or {
+            "codacy-safety-net": "success",
+            **{check: "success" for check in EXPECTED_CODACY_CHECKS},
+        }
+        self.secret_names = secret_names or ["CODACY_ACCOUNT_TOKEN"]
+
+    def default_branch(self, repo: str) -> str:
+        return "main"
+
+    def ruleset_summary(self, repo: str, default_branch: str) -> dict:
+        return {
+            "protects_default_branch": True,
+            "requires_pull_request": True,
+            "blocks_force_pushes": True,
+            "blocks_deletions": True,
+            "required_checks": self.required_checks,
+        }
+
+    def branch_protection_summary(self, repo: str, default_branch: str) -> dict:
+        return {
+            "protects_default_branch": False,
+            "requires_pull_request": False,
+            "blocks_force_pushes": False,
+            "blocks_deletions": False,
+            "required_checks": [],
+        }
+
+    def repository_secret_names(self, repo: str) -> list[str]:
+        return self.secret_names
+
+    def latest_check_runs(self, repo: str, default_branch: str) -> dict[str, str]:
+        return self.latest_checks
+
+
+class FakeCodacy:
+    def __init__(
+        self,
+        *,
+        exists: bool = True,
+        coding_standard: bool = True,
+        gate_policy: bool = True,
+        pr_quality: dict | None = None,
+    ) -> None:
+        self.exists = exists
+        self.coding_standard = coding_standard
+        self.gate_policy = gate_policy
+        self.pr_quality = pr_quality or {"coverage": {"diffCoverage": {"cause": None}}}
+
+    def repository_state(self, repo: str) -> dict:
+        return {
+            "exists": self.exists,
+            "coding_standard_applied": self.coding_standard,
+            "gate_policy_applied": self.gate_policy,
+            "latest_pr_quality": self.pr_quality,
+        }
+
+
+class CodacyRolloutTests(DotfilesTestCase):
+    def write_workflow(self, project: Path, body: str) -> None:
+        workflow_dir = project / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "validation.yml").write_text(dedent(body))
+
+    def inventory_item(self, project: Path) -> dict:
+        return {
+            "repo": "kairin/example",
+            "local_path": str(project),
+            "language_profile": "python",
+            "test_workflow": "codacy-safety-net",
+            "test_command": "uv run python -m unittest discover -s tests",
+            "coverage_command": "uv run --with coverage coverage run -m unittest discover -s tests && uv run --with coverage coverage xml",
+            "coverage_reports": ["coverage.xml"],
+            "expected_checks": ["codacy-safety-net", *EXPECTED_CODACY_CHECKS],
+        }
+
+    def strict_workflow(self) -> str:
+        return """
+        jobs:
+          codacy-safety-net:
+            steps:
+              - name: Run unit tests with coverage
+                run: uv run --with coverage coverage run -m unittest discover -s tests
+              - name: Generate coverage XML
+                run: uv run --with coverage coverage xml
+              - name: Upload coverage to Codacy
+                env:
+                  CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+                  CODACY_ORGANIZATION_PROVIDER: gh
+                  CODACY_USERNAME: kairin
+                  CODACY_PROJECT_NAME: example
+                run: |
+                  bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+                    --api-token "$CODACY_ACCOUNT_TOKEN" \
+                    -r coverage.xml
+        """
+
+    def test_tracked_inventory_lists_initial_active_repos(self) -> None:
+        inventory = load_inventory(REPO_ROOT / "codacy-rollout.json")
+        repos = [item.repo for item in inventory.repositories]
+
+        self.assertEqual(["kairin/000-dotfiles", "kairin/BCM", "kairin/graph-obsidian"], repos)
+        for item in inventory.repositories:
+            self.assertEqual(["Codacy Static Code Analysis", "Codacy Coverage Variation", "Codacy Diff Coverage"], item.expected_codacy_checks)
+
+    def test_fully_protected_repo_passes(self) -> None:
+        project = self.make_project()
+        self.write_workflow(project, self.strict_workflow())
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(), FakeCodacy())
+
+        self.assertEqual("PASS", result.status, result.to_text())
+        self.assertEqual([], [check for check in result.checks if check.status != "PASS"])
+
+    def test_missing_codacy_repository_fails_with_remediation(self) -> None:
+        project = self.make_project()
+        self.write_workflow(project, self.strict_workflow())
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(), FakeCodacy(exists=False))
+
+        self.assertEqual("FAIL", result.status)
+        self.assertIn("repository_onboarded", result.to_text())
+        self.assertIn("Add kairin/example to Codacy", result.to_text())
+
+    def test_missing_coverage_upload_fails(self) -> None:
+        project = self.make_project()
+        self.write_workflow(project, "jobs:\n  codacy-safety-net:\n    steps: []\n")
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(), FakeCodacy())
+
+        self.assertEqual("FAIL", result.status)
+        self.assertIn("coverage_upload", result.to_text())
+        self.assertIn("Upload coverage to Codacy", result.to_text())
+
+    def test_coverage_upload_with_continue_on_error_fails_strict_audit(self) -> None:
+        project = self.make_project()
+        self.write_workflow(
+            project,
+            self.strict_workflow()
+            + "\n              - name: Legacy upload\n                continue-on-error: true\n",
+        )
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(), FakeCodacy())
+
+        self.assertEqual("FAIL", result.status)
+        self.assertIn("coverage_upload_strict", result.to_text())
+        self.assertIn("Remove continue-on-error", result.to_text())
+
+    def test_ruleset_missing_one_codacy_check_fails(self) -> None:
+        project = self.make_project()
+        self.write_workflow(project, self.strict_workflow())
+        required = ["codacy-safety-net", "Codacy Static Code Analysis", "Codacy Coverage Variation"]
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(required_checks=required), FakeCodacy())
+
+        self.assertEqual("FAIL", result.status)
+        self.assertIn("required_status_checks", result.to_text())
+        self.assertIn("Codacy Diff Coverage", result.to_text())
+
+    def test_codacy_missing_requirements_fails(self) -> None:
+        project = self.make_project()
+        self.write_workflow(project, self.strict_workflow())
+        codacy = FakeCodacy(
+            pr_quality={"coverage": {"diffCoverage": {"cause": "MissingRequirements"}}}
+        )
+
+        result = audit_repository(self.inventory_item(project), FakeGitHub(), codacy)
+
+        self.assertEqual("FAIL", result.status)
+        self.assertIn("coverage_pr_ready", result.to_text())
+        self.assertIn("MissingRequirements", result.to_text())
+
+    def test_plan_repository_is_read_only_and_names_required_changes(self) -> None:
+        item = self.inventory_item(self.make_project())
+
+        plan = plan_repository(item)
+
+        self.assertEqual("kairin/example", plan["repo"])
+        self.assertIn("workflow", plan)
+        self.assertIn("ruleset", plan)
+        self.assertEqual("${{ secrets.CODACY_ACCOUNT_TOKEN }}", plan["workflow"]["coverage_upload_env"]["CODACY_API_TOKEN"])
+        self.assertEqual(item["expected_checks"], plan["ruleset"]["required_checks"])
+        json.dumps(plan)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,7 +9,23 @@ class DocsTests(DotfilesTestCase):
         self.assertIn("uv run python -m unittest discover -s tests", readme)
         self.assertIn("coverage xml", readme)
         self.assertIn("docs/codacy-coverage-rollout.md", readme)
+        self.assertIn("docs/codacy-workflow-templates.md", readme)
         self.assertIn("docs/operations/github-actions-usage-baseline.md", readme)
+
+    def test_codacy_workflow_templates_cover_rollout_profiles(self):
+        templates = (REPO_ROOT / "docs" / "codacy-workflow-templates.md").read_text()
+        for text in (
+            "Python uv + coverage.py",
+            "Node npm/Vitest coverage",
+            "Mixed Node + Python",
+            "CODACY_API_TOKEN",
+            "CODACY_ORGANIZATION_PROVIDER",
+            "CODACY_USERNAME",
+            "CODACY_PROJECT_NAME",
+            "coverage.xml",
+            "coverage/lcov.info",
+        ):
+            self.assertIn(text, templates)
 
     def test_docs_cover_optional_codacy_environment_flow(self):
         getting_started = (REPO_ROOT / "docs" / "getting-started.md").read_text()

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -386,10 +386,17 @@ cat "{installer_path}"
         head_sha: str,
         base_ref: str = "main",
         pr_number: int = 17,
+        required_checks: tuple[str, ...] = (
+            "Codacy Static Code Analysis",
+            "Codacy Coverage Variation",
+            "Codacy Diff Coverage",
+            "codacy-safety-net",
+        ),
     ) -> None:
         state_file = log_path.parent / "gh-pr-state"
         check_count_file = log_path.parent / "gh-check-count"
         state_file.write_text("OPEN\n")
+        required_checks_text = "\n".join(required_checks)
         self.write_executable(
             bin_dir / "gh",
             textwrap.dedent(
@@ -446,6 +453,12 @@ JSON
   api)
     path="${{1:-}}"
     case "$path" in
+      repos/kairin/000-dotfiles/rulesets)
+        cat <<'CHECKS'
+{required_checks_text}
+CHECKS
+        exit 0
+        ;;
       repos/kairin/000-dotfiles/commits/{head_sha}/check-runs)
         if [[ "${{FAKE_GH_CHECK_MODE:-}}" == "static-after-first-missing" ]]; then
           count="$(cat "{check_count_file}" 2>/dev/null || echo 0)"
@@ -1329,72 +1342,29 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         self.assertEqual(extra_args.returncode, 2)
         self.assertIn("ship accepts at most one PR number", extra_args.stderr)
 
-    def test_ship_fails_fast_when_codacy_cli_is_recursion_trap(self) -> None:
-        # The broken codacy-cli install is a symlink pointing at its own cache
-        # wrapper, which causes `eval "$run_command $*"` infinite recursion when
-        # invoked. ./setup ship must detect this and fail fast before step 4d.
+    def test_ship_does_not_require_codacy_cli_or_project_token(self) -> None:
+        repo, _base_sha, head_sha = self.make_ship_repo()
         home = self.make_home()
         bin_dir = self.make_command_path()
-
-        # Build an INERT fake wrapper at the cache binary path. If executed,
-        # the wrapper writes a log file and exits 99 — it does NOT actually
-        # recurse. The detection markers live in comments so the guard's
-        # `grep -aq` finds them without enabling runtime recursion.
-        cache_dir = home / ".cache" / "codacy" / "codacy-cli-v2"
-        version_dir = cache_dir / "1.0.0-fake"
-        version_dir.mkdir(parents=True)
-        (cache_dir / "version.yaml").write_text('version: "1.0.0-fake"\n')
-        wrapper = version_dir / "codacy-cli-v2"
-        wrapper.write_text(
-            "#!/usr/bin/env bash\n"
-            f'echo "WRAPPER_EXECUTED" >> "{home}/codacy-wrapper.log"\n'
-            "exit 99\n"
-            "# Marker comments below are present so the guard's grep finds them.\n"
-            '# bin_path="$HOME/.cache/codacy/codacy-cli-v2/1.0.0-fake/codacy-cli-v2"\n'
-            '# eval "$run_command $*"\n'
-        )
-        wrapper.chmod(0o755)
-        (bin_dir / "codacy-cli").symlink_to(wrapper)
+        self.write_fake_ship_gh(bin_dir, home / "gh.log", head_sha=head_sha)
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "fake-token"
-        env["CODACY_CLI_V2_TMP_FOLDER"] = str(cache_dir)
+        env.pop("CODACY_PROJECT_TOKEN", None)
 
-        result = run_setup(
-            "ship",
-            "999",
-            env=env,
-            timeout=10,
-        )
+        result = run_setup("ship", "17", cwd=repo, executable=repo / "setup", env=env)
 
-        self.assertNotEqual(
-            result.returncode,
-            0,
-            f"ship should fail when codacy-cli is the recursion trap; got stdout={result.stdout!r} stderr={result.stderr!r}",
-        )
-        combined = result.stdout + result.stderr
-        self.assertIn("codacy-cli is broken", combined)
-        self.assertIn("infinite shell recursion", combined)
-        self.assertIn("[ship] step 2b", result.stdout)
-        # Guard must fire BEFORE step 4d analyze.
-        self.assertNotIn("[ship] step 4d", result.stdout)
-        # Inert wrapper must NOT have been executed.
-        self.assertFalse(
-            (home / "codacy-wrapper.log").exists(),
-            "the inert wrapper was executed — guard did not fire before invocation",
-        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PR #17 is MERGED", result.stdout)
 
     def test_ship_rejects_ambiguous_auto_detected_prs(self) -> None:
         repo, _base_sha, head_sha = self.make_ship_repo()
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_ship_gh(bin_dir, home / "gh.log", head_sha=head_sha)
-        self.write_fake_ship_codacy_cli(bin_dir, home / "codacy.log")
         (bin_dir / "sleep").unlink()
         self.write_executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "project-token"
         env["FAKE_GH_PR_LIST_MODE"] = "ambiguous"
 
         result = run_setup("ship", cwd=repo, executable=repo / "setup", env=env)
@@ -1402,8 +1372,8 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
         self.assertIn("multiple open PRs match branch 'ship-test' on kairin/000-dotfiles", result.stderr)
 
-    def test_ship_uses_base_branch_and_cleans_up_temporary_worktrees(self) -> None:
-        repo, base_sha, head_sha = self.make_ship_repo()
+    def test_ship_uses_github_required_checks_and_no_temporary_codacy_worktrees(self) -> None:
+        repo, _base_sha, head_sha = self.make_ship_repo()
         home = self.make_home()
         bin_dir = self.make_command_path()
         gh_log = home / "gh.log"
@@ -1412,31 +1382,18 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         self.write_fake_ship_codacy_cli(bin_dir, codacy_log)
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "project-token"
 
         result = run_setup("ship", "17", cwd=repo, executable=repo / "setup", env=env)
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("base=main", result.stdout)
         self.assertIn("PR #17 is MERGED", result.stdout)
-
-        codacy_lines = codacy_log.read_text().splitlines()
-        self.assertEqual(len(codacy_lines), 4)
-        self.assertTrue(codacy_lines[0].startswith("analyze --tool pylint --format sarif -o "))
-        self.assertTrue(codacy_lines[1].startswith("upload -s "))
-        self.assertIn(f"-c {head_sha}", codacy_lines[1])
-        self.assertTrue(codacy_lines[2].startswith("analyze --tool pylint --format sarif -o "))
-        self.assertTrue(codacy_lines[3].startswith("upload -s "))
-        self.assertIn(f"-c {base_sha}", codacy_lines[3])
-
-        head_sarif = Path(codacy_lines[0].split()[-1])
-        base_sarif = Path(codacy_lines[2].split()[-1])
-        self.assertNotEqual(head_sarif, base_sarif)
-        self.assertFalse(head_sarif.parent.exists())
-        self.assertFalse(base_sarif.parent.exists())
+        self.assertIn("step 4b: resolving required GitHub checks", result.stdout)
+        self.assertFalse(codacy_log.exists(), "setup ship must not invoke local codacy-cli")
 
         gh_lines = gh_log.read_text().splitlines()
         self.assertTrue(any(line.startswith("pr view 17 ") for line in gh_lines))
+        self.assertTrue(any(line.startswith("api repos/kairin/000-dotfiles/rulesets") for line in gh_lines))
         self.assertTrue(any(line.startswith("api repos/kairin/000-dotfiles/commits/") and "/check-runs" in line for line in gh_lines))
         self.assertTrue(any(line.startswith("pr merge 17 ") for line in gh_lines))
 
@@ -1445,12 +1402,10 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_ship_gh(bin_dir, home / "gh.log", head_sha=head_sha)
-        self.write_fake_ship_codacy_cli(bin_dir, home / "codacy.log")
         (bin_dir / "sleep").unlink()
         self.write_executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "project-token"
         env["FAKE_GH_CHECK_MODE"] = "missing-static"
         env["SHIP_CHECK_TIMEOUT"] = "30"
 
@@ -1458,19 +1413,17 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
 
         self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
         self.assertIn("Codacy Static Code Analysis: missing", result.stdout)
-        self.assertIn("required Codacy checks did not all reach success after 3 attempts", result.stderr)
+        self.assertIn("required GitHub checks did not all reach success before timeout", result.stderr)
 
     def test_ship_merges_when_missing_required_check_later_succeeds(self) -> None:
         repo, _base_sha, head_sha = self.make_ship_repo()
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_ship_gh(bin_dir, home / "gh.log", head_sha=head_sha)
-        self.write_fake_ship_codacy_cli(bin_dir, home / "codacy.log")
         (bin_dir / "sleep").unlink()
         self.write_executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "project-token"
         env["FAKE_GH_CHECK_MODE"] = "static-after-first-missing"
         env["SHIP_CHECK_TIMEOUT"] = "30"
 
@@ -1486,10 +1439,8 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         home = self.make_home()
         bin_dir = self.make_command_path()
         self.write_fake_ship_gh(bin_dir, home / "gh.log", head_sha=head_sha)
-        self.write_fake_ship_codacy_cli(bin_dir, home / "codacy.log")
 
         env = self.env_for(bin_dir, home)
-        env["CODACY_PROJECT_TOKEN"] = "project-token"
         env["FAKE_GH_FINAL_MERGE_STATE"] = "UNSTABLE"
 
         result = run_setup("ship", "17", cwd=repo, executable=repo / "setup", env=env)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -38,7 +38,11 @@ class WorkflowTests(DotfilesTestCase):
         self.assertIn("coverage xml", workflow)
         self.assertIn("coverage.xml", workflow)
         self.assertIn("coverage.codacy.com/get.sh", workflow)
-        self.assertIn("continue-on-error: true", workflow)
+        self.assertIn("CODACY_API_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}", workflow)
+        self.assertIn("CODACY_ORGANIZATION_PROVIDER: gh", workflow)
+        self.assertIn("CODACY_USERNAME: kairin", workflow)
+        self.assertIn("CODACY_PROJECT_NAME: 000-dotfiles", workflow)
+        self.assertNotIn("continue-on-error: true", workflow)
         # Pinned action SHAs must be preserved.
         self.assertIn("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", workflow)
         self.assertIn("astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b", workflow)
@@ -52,9 +56,8 @@ class WorkflowTests(DotfilesTestCase):
         # Stage 7 is the server-side Codacy gate; it stays informational so a
         # missing CODACY_PROJECT_TOKEN does not break local pre-push runs.
         self.assertIn("[STAGE 7/7] Codacy server-side gate", pipeline)
-        # --codacy-only is a mode of quality-pipeline.sh used by ./setup ship
-        # to refresh the SARIF upload after a merge. The pre-push hook does
-        # NOT use this mode; Codacy enforcement runs in CI and at ship time.
+        # --codacy-only remains available for optional local diagnostics.
+        # ./setup ship must rely on GitHub-required checks instead.
         self.assertIn("--codacy-only", pipeline)
         # SARIF must be uploaded for both HEAD and merge-base so Codacy can
         # diff the PR; without the base upload, the GH App posts nothing.


### PR DESCRIPTION
## Summary

- Add `codacy-rollout.json` inventory for 000-dotfiles, BCM, and graph-obsidian.
- Add `./setup codacy-audit` and `./setup codacy-plan` through `dotfiles_tools.codacy_rollout`.
- Update `./setup ship` to poll GitHub-required checks from active rulesets/branch protection instead of invoking local `codacy-cli`.
- Fix the 000-dotfiles coverage upload env for Codacy account-token identity and remove `continue-on-error`.
- Add reusable Codacy workflow templates for Python, Node/Vitest, and mixed Node + Python repositories.

## Validation

- `uv run python -m unittest discover -s tests` passed: 273 tests, 2 skipped, 1 expected failure.
- `git diff --check` passed.
- Pre-push hook passed critical checks during `git push`; line-length warnings were non-blocking.