### PR TITLE
docs: reconcile documentation with current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,24 +22,29 @@ A collection of config templates for AI coding tools (Claude Code, Codex, Gemini
 - If a task seems to require touching a protected file, stop and ask.
 - `git show origin/main:<file>` is the authoritative original.
 
-## Repo Structure
+## Key paths
 
 ```
-agents/             Project-level agent doc templates (AGENTS.md, CLAUDE.md, GEMINI.md, copilot-instructions.md)
-claude/             ~/.claude/ templates (settings.json, keybindings.json, CLAUDE.md)
-codex/              ~/.codex/ templates (config.toml, rules/default.rules)
-gemini/             ~/.gemini/ templates (settings.json, GEMINI.md)
-gh/                 ~/.config/gh/ templates (config.yml)
-fish/               ~/.config/fish/ templates and live files (fish_plugins, direnv.fish, env.fish)
-git/                ~/.config/git/ live files (config)
-dotfiles_tools/     Python validation/setup CLI (stdlib only)
-tests/              unittest suite (uv-managed)
-specs/              Spec Kit feature specs (current: 001-dotfiles-bootstrap-validation)
-docs/               Operational docs (e.g. Codacy coverage rollout)
-docker/             Dockerfiles and compose configs (gstack-browser/ for Ubuntu 24.04 container)
-setup               Bash entrypoint that wraps dotfiles_tools with sensible defaults
-dotfiles-manifest.json  Source of truth for what installs where
+agents/                       Project-level agent doc templates (AGENTS.md, CLAUDE.md, GEMINI.md, copilot-instructions.md)
+claude/                       ~/.claude/ templates (settings.json, keybindings.json, CLAUDE.md)
+codex/                        ~/.codex/ templates (config.toml, rules/default.rules)
+gemini/                       ~/.gemini/ templates (settings.json, GEMINI.md)
+copilot/                      GitHub Copilot CLI template (copilot-instructions.md.template)
+gh/                           ~/.config/gh/ templates (config.yml)
+fish/                         ~/.config/fish/ templates and live files (fish_plugins, direnv.fish, env.fish)
+git/                          ~/.config/git/ live files (config)
+dotfiles_tools/               Python validation/setup CLI (stdlib only)
+scripts/                      Helper shell scripts (install-hooks.sh, quality-pipeline.sh, push-with-pr.sh, hooks/)
+tests/                        unittest suite (uv-managed)
+specs/                        Spec Kit feature specs (001-bootstrap-validation, 002-menu-recommendation, 002-optional-integrations)
+docs/                         Operational docs (e.g. Codacy coverage rollout)
+docker/                       Dockerfiles and compose configs (gstack-browser/ for Ubuntu 24.04 container)
+graph-obsidian-agent-docs/    Reference agent docs from the graph-obsidian project (read-only context)
+setup                         Bash entrypoint that wraps dotfiles_tools with sensible defaults
+dotfiles-manifest.json        Source of truth for what installs where
 ```
+
+Dot-prefixed directories (`.claude/`, `.codex/`, `.codacy/`, `.gstack/`, `.specify/`, `.agents/`, `.github/`, `.vscode/`) are tool state or CI config, intentionally excluded from this layout list.
 
 ## MCP Tool Availability
 
@@ -94,7 +99,7 @@ billing workflows:
 - `CODACY_PROJECT_NAME`
 - `CODACY_PROJECT_TOKEN`
 - `CODACY_USERNAME`
-- `GH_BILLING_TOKEN`
+- `GH_TOKEN` (also used by `gh` CLI; the GitHub Actions billing audit at `docs/operations/github-actions-usage-baseline.md` uses a file-backed copy of this token)
 
 These values come from direnv-managed local environment files, not from the
 repository. Do not commit them, print them, or add them to tracked config. If
@@ -128,12 +133,14 @@ git add <specific files>      # never git add -A
 git commit -m "..."
 ```
 
-Finalizing a PR: `./setup ship` is the canonical way to merge. It re-runs
-the Codacy SARIF upload after `gh pr update-branch` (the SHA churn is what
-breaks the required `Codacy Static Code Analysis` check on every merge),
-polls the four required Codacy checks, and squash-merges only when the PR
-is `CLEAN` or `UNSTABLE` after required checks are green. Requires
-`CODACY_PROJECT_TOKEN` and an authenticated `gh`.
+Finalizing a PR: `./setup ship` is the canonical way to merge. It runs
+`gh pr update-branch` if the branch is `BEHIND` its base, resolves the
+required GitHub status checks dynamically from branch protection or
+rulesets (the count is repo-dependent — not a fixed number), polls those
+checks until they all report `success`, and squash-merges only when the
+PR is `CLEAN` or `UNSTABLE`. Requires `CODACY_PROJECT_TOKEN` (for the
+SARIF upload that the validation workflow performs) and an authenticated
+`gh`.
 
 Runtime validation tooling uses Python standard library modules and uv-managed
 developer commands:
@@ -189,6 +196,9 @@ validation/setup code and must generate `coverage.xml` before Codacy upload.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, see the spec documents in
-`specs/`. Recent implementations (setup menu recommendation, optional integrations)
-are complete. Check `specs/` for any new active specifications or design documents.
+`specs/`. Spec status (2026-05-15): `001-dotfiles-bootstrap-validation` is
+complete; `002-setup-optional-integrations` is complete; `002-setup-menu-recommendation`
+has shipped code (see `dotfiles_tools/machine_summary.py`) but its `tasks.md`
+checklist is unchecked — treat the implementation as canonical, the task list as
+stale. Check `specs/` for any new active specifications or design documents.
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $ ~/000-dotfiles/setup
         DONE.
 ```
 
-Nothing is written without your explicit confirmation (`[y/N]`). Files are backed up before overwrite (default: `~/.dotfiles-backups/`). The script is idempotent—safe to run repeatedly. User-customizable files (such as `~/.claude/settings.json`, `~/.config/gh/config.yml`, `~/.config/fish/env.fish`, and 7 others) skip drift detection and are never silently overwritten by option 2.
+Nothing is written without your explicit confirmation (`[y/N]`). Files are backed up before overwrite (default: `~/.dotfiles-backups/`). The script is idempotent—safe to run repeatedly. User-customizable files (such as `~/.claude/settings.json`, `~/.config/gh/config.yml`, `~/.config/fish/env.fish`, and 11 others — 14 total; see `dotfiles-manifest.json` for the full list) skip drift detection and are never silently overwritten by option 2.
 
 ---
 
@@ -185,7 +185,7 @@ Nothing is written without your explicit confirmation (`[y/N]`). Files are backe
 | Scaffold `AGENTS.md` + `CLAUDE.md`/`GEMINI.md` in a project | `./setup init --yes` |
 | Verify agent docs in CI / pre-commit (no uv required) | `./setup verify` |
 | Audit machine and show API credential status (GitHub, HuggingFace) | `./setup` → choose option 3 |
-| Manage optional integrations (GitHub, HuggingFace, Codacy) | `./setup` → choose option 4 |
+| Manage optional integrations (GitHub, HuggingFace, Codacy) | `./setup` → choose option 5 |
 | Upgrade installed tools | `./setup` → choose option 1 |
 | Apply config drift | `./setup` → choose option 2 |
 
@@ -238,9 +238,12 @@ A good dotfiles repo should:
 | `fish/` | `~/.config/fish/` | `fish_plugins`, `conf.d/direnv.fish` (auto-installs direnv hook), `functions/direnv.fish`, `env.fish` |
 | `git/` | `~/.config/git/` | `config` |
 | `dotfiles_tools/` | — | Python validation/setup CLI (`python -m dotfiles_tools …`) |
+| `scripts/` | — | Helper shell scripts (`install-hooks.sh`, `quality-pipeline.sh`, `push-with-pr.sh`, `hooks/`) |
+| `docker/` | — | Dockerfiles and compose configs (`gstack-browser/` for Ubuntu 24.04 container) |
+| `graph-obsidian-agent-docs/` | — | Reference agent docs from the graph-obsidian project (read-only context) |
 | `setup` | `~/.local/bin/dotfiles-setup` (optional) | Self-locating bash entrypoint |
 | `dotfiles-manifest.json` | — | Source of truth for what installs where |
-| `specs/` | — | Design specification, task tracking, contracts |
+| `specs/` | — | Design specifications, task tracking, contracts (001-bootstrap-validation, 002-menu-recommendation, 002-optional-integrations) |
 | `docs/` | — | Getting started guide, operations docs, issue tracking |
 
 Files ending in `.template` are copy-and-customize sources. Placeholders follow the pattern of double-braces with upper-snake-case content (e.g. `{{PROJECT_NAME}}`) and must all be replaced before use.
@@ -258,7 +261,7 @@ Files ending in `.template` are copy-and-customize sources. Placeholders follow 
 | `./setup doctor [--home PATH] [--profile NAME]` | Read-only machine audit (wraps `dotfiles_tools doctor`) |
 | `./setup quality` | Run the local quality pipeline (`scripts/quality-pipeline.sh`): tests, coverage, Codacy upload |
 | `./setup hooks` | Install or update this repo's Git hooks, including the pre-push guard that blocks direct pushes to `main` |
-| `./setup ship [<pr-number>]` | Finalize a PR: refresh branch, re-upload Codacy SARIF, poll required checks, squash-merge |
+| `./setup ship [<pr-number>]` | Finalize a PR: refresh branch (`gh pr update-branch` if `BEHIND`), poll required checks, squash-merge when `CLEAN`/`UNSTABLE` |
 
 Menu options during `./setup`:
 - **Option 1:** Install or update developer tools. Opens a submenu that
@@ -299,14 +302,17 @@ Once a PR is open, `./setup ship` drives it to merged:
 ./setup ship 183          # ships PR #183 explicitly
 ```
 
-`setup ship` requires `CODACY_PROJECT_TOKEN` to be exported and `gh` to be
-authenticated. It runs `gh pr update-branch` automatically when the branch is
-BEHIND `main`, re-uploads the Codacy SARIF for the new HEAD and base SHA so the
-diff comparison is fresh, then polls the four required checks
-(`Codacy Static Code Analysis`, `Codacy Coverage Variation`,
-`Codacy Diff Coverage`, `codacy-safety-net`) before squash-merging. It allows
-GitHub's `UNSTABLE` merge state after those required checks are green because
-non-required advisory jobs can be skipped or cancelled.
+`setup ship` requires `CODACY_PROJECT_TOKEN` to be exported (the Codacy SARIF
+upload that gates the `Codacy Static Code Analysis` check is uploaded by the
+`.github/workflows/dotfiles-validation.yml` workflow itself, not by `./setup
+ship`) and `gh` to be authenticated. It runs `gh pr update-branch` automatically
+when the branch is `BEHIND` `main`, then resolves the required GitHub status
+checks dynamically from the branch's protection rules or rulesets (the count is
+repo-dependent; on `main` today they are `Codacy Static Code Analysis`,
+`Codacy Coverage Variation`, `Codacy Diff Coverage`, and `codacy-safety-net`),
+polls them until they all report `success`, and squash-merges only when the PR
+is `CLEAN` or `UNSTABLE`. `UNSTABLE` is allowed because non-required advisory
+jobs can be skipped or cancelled.
 The default check polling window is 15 minutes; override with
 `SHIP_CHECK_TIMEOUT=<seconds>` or `SHIP_CHECK_INTERVAL=<seconds>` only when
 debugging.

--- a/docs/codacy-branch-protection.md
+++ b/docs/codacy-branch-protection.md
@@ -122,7 +122,8 @@ not reveal its value:
 gh secret list --repo "$OWNER/$REPO"
 ```
 
-For the account-token pattern used by this repo, the workflow shape is:
+For the account-token pattern used by this repo, the workflow shape is
+(curl-based — see `.github/workflows/dotfiles-validation.yml`):
 
 ```yaml
 env:
@@ -130,10 +131,9 @@ env:
 
 - name: Upload coverage to Codacy
   if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
-  uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
-  with:
-    api-token: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
-    coverage-reports: coverage.xml
+  run: |
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+      -r coverage.xml
 ```
 
 The conditional upload is useful during rollout. Before requiring coverage

--- a/docs/codacy-coverage-rollout.md
+++ b/docs/codacy-coverage-rollout.md
@@ -99,8 +99,25 @@ Use this document as the checklist for applying the same pattern to other repos.
    `./setup /path/to/project` → "Optional integrations and APIs" →
    "Manage Codacy API access" → account token.
 
-6. Use the repository-token input in the workflow.
-   - Required workflow shape:
+6. Use a coverage upload step in the workflow.
+   - Two equivalent shapes are supported. The curl-based shape is what this repo
+     uses today (see `.github/workflows/dotfiles-validation.yml`); the pinned
+     reporter action is the alternative for repos that prefer keeping coverage
+     uploads inside the GitHub Actions ecosystem.
+
+   - **Curl-based (this repo's pattern, account-token):**
+     ```yaml
+     env:
+       CODACY_ACCOUNT_TOKEN: ${{ secrets.CODACY_ACCOUNT_TOKEN }}
+
+     - name: Upload coverage to Codacy
+       if: ${{ env.CODACY_ACCOUNT_TOKEN != '' }}
+       run: |
+         bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+           -r coverage.xml
+     ```
+
+   - **Pinned reporter action (project-token alternative):**
      ```yaml
      env:
        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ cd ~/000-dotfiles
 ./setup
 ```
 
-You'll see a summary of your machine state and a 6-option menu:
+You'll see a summary of your machine state and a 7-option menu:
 
 ```
 1. Install / update developer tools        [recommended]
@@ -60,13 +60,14 @@ You'll see a summary of your machine state and a 6-option menu:
 3. Show full technical details
 4. Show tool and sign-in guidance
 5. Configure / verify API tokens
-6. Exit without writing
+6. Install / update Git hooks for this repo
+7. Exit without writing
 ```
 
 Since tools are missing on a fresh machine, **option 1 is highlighted**. Choose it.
 
 ```
-Choose [1-6]: 1
+Choose [1-7]: 1
 ```
 
 ### Step 3: Pick a tool phase
@@ -142,8 +143,9 @@ The menu is now back. Option 2 is now highlighted:
 3. Show full technical details
 4. Show tool and sign-in guidance
 5. Configure / verify API tokens
-6. Exit without writing
-Choose [1-6]: 2
+6. Install / update Git hooks for this repo
+7. Exit without writing
+Choose [1-7]: 2
 ```
 
 Choose option 2 to open the safe-changes submenu:
@@ -234,7 +236,8 @@ Machine setup summary
 3. Show full technical details
 4. Show tool and sign-in guidance
 5. Configure / verify API tokens
-6. Exit without writing
+6. Install / update Git hooks for this repo
+7. Exit without writing
 ```
 
 Option 2 is highlighted because configs have drifted. Choose it to review the dotfiles/fonts
@@ -246,7 +249,7 @@ To upgrade installed tools:
 
 ```bash
 ~/000-dotfiles/setup
-Choose [1-6]: 1
+Choose [1-7]: 1
 ```
 
 This runs:
@@ -260,7 +263,7 @@ This runs:
 If you want to inspect cache paths, font versions, or the full operation plan without applying:
 
 ```bash
-Choose [1-6]: 3
+Choose [1-7]: 3
 ```
 
 Shows raw cache state, package versions, and all pending operations.

--- a/docs/issues/menu-renumbering.md
+++ b/docs/issues/menu-renumbering.md
@@ -1,6 +1,10 @@
 # Issue: menu option numbers change between first and subsequent runs
 
-**Status:** Fixed in PR #82 — stable 6-option menu with [recommended] tag
+**Status:** Fixed in PR #82 — stable 6-option menu with [recommended] tag.
+Subsequently expanded to a stable 7-option menu when "Install / update Git
+hooks for this repo" was added as option 6 (Exit moved to option 7). The
+state-invariance property the original fix established is preserved; the
+specific snapshot below reflects the post-#82 state, not today's menu.
 **Affects:** Users who run setup more than once
 
 ## Problem

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,28 +1,40 @@
 # specs/ — Design documentation
 
-This folder contains the complete design specification, implementation plan, and
-task tracking for the initial **dotfiles-bootstrap-validation** project.
+This folder contains the complete design specifications, implementation plans, and
+task tracking for the dotfiles project. Three specs live here:
 
-## What's here?
+- `001-dotfiles-bootstrap-validation/` — the initial bootstrap, manifest, and
+  doctor/plan/apply CLI surface (v0.1.x).
+- `002-setup-menu-recommendation/` — state-aware setup menu with `[recommended]`
+  tagging and the machine-summary engine.
+- `002-setup-optional-integrations/` — GitHub / HuggingFace / Codacy optional
+  integration management surfaced through the setup menu and `dotfiles_tools`.
 
-The folder `001-dotfiles-bootstrap-validation/` contains:
+## What's in each spec folder?
+
+Each `00N-*/` folder follows the same Spec Kit layout:
 
 - **spec.md** — Full specification with user stories, acceptance scenarios, functional
   requirements, and success criteria
 - **plan.md** — Implementation plan with architectural decisions, module inventory, phase
   summaries
-- **tasks.md** — Complete task list (63 tasks across 8 phases) with dependency tracking
-- **data-model.md** — Formal definitions of Manifest, Entry, Operation, Report, and other
-  core data structures
+- **tasks.md** — Task list with dependency tracking and checkbox status
+- **data-model.md** — Formal definitions of core data structures
 - **research.md** — Key architectural decisions with rationale and alternatives considered
-- **quickstart.md** — Validation guide covering unit tests, doctor, plan, apply, flows
+- **quickstart.md** — Validation guide covering unit tests, doctor, plan, apply flows
 - **contracts/** — Formal contracts for the CLI and manifest format (JSON Schema)
-- **checklists/** — Specification quality gates (completed ✓)
+- **checklists/** — Specification quality gates
 
-## Status
+## Status (2026-05-15)
 
-**Implementation complete.** All 63 tasks marked `[x]`. Specification validated.
-Date: 2026-05-01.
+- `001-dotfiles-bootstrap-validation`: **complete**. All 63 tasks marked `[x]`.
+  Specification validated.
+- `002-setup-optional-integrations`: **complete**. All 42 tasks marked `[x]`.
+- `002-setup-menu-recommendation`: **implementation shipped, task checklist
+  stale**. The state-aware menu and the machine-summary recommendation engine
+  are live (see `dotfiles_tools/machine_summary.py`), but the 29-task checklist
+  in `tasks.md` is still all `[ ]`. Treat the implementation as canonical;
+  refresh the checklist before relying on it as a progress signal.
 
 ## How to use this folder
 


### PR DESCRIPTION
## Summary

- Corrects false claim that `./setup ship` re-uploads Codacy SARIF (`ship_upload_sarif` at `setup:1631` is dead code; `cmd_ship` never calls it)
- Generalizes 'four required checks' to 'required GitHub status checks resolved dynamically'
- Fixes 6-option → 7-option menu across `docs/getting-started.md` (Git hooks option was added after docs were written)
- Adds missing directories (`copilot/`, `scripts/`, `docker/`, `graph-obsidian-agent-docs/`) to `AGENTS.md` Key paths and README layout table
- Replaces stale pinned Codacy GitHub Action snippet with curl-based pattern matching the actual workflow
- Corrects user_customizable count: 14 entries (not 8), fixes option 4 → 5 for optional integrations
- Updates `specs/README.md` to document all 3 specs with accurate task counts (001: 63 tasks done, 002-optional: 42 tasks done, 002-menu: 29 tasks stale/unchecked but implementation live)
- Adds historical note to `docs/issues/menu-renumbering.md` about the 7-option expansion

## Deferred (follow-up issues, not in scope for this PR)

- Push-only Codacy upload guard (workflow vs docs discrepancy)
- `codacy-rollout.json` 4 vs 3 checks discrepancy
- `fish/env.fish.template` sources `config.fish` which isn't in the bootstrap

## Test plan

- [x] 292 unit tests pass after all edits (pre-push hook confirmed)
- [x] All 4 symlinks intact (`CLAUDE.md`, `GEMINI.md`, `agents/CLAUDE.md.template`, `agents/GEMINI.md.template`)
- [x] No protected files touched (`git/config`, `fish/fish_plugins`, `.gitignore`, agent templates)
- [x] All YAML code blocks parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)