### PR TITLE
fix: ensure codacy-cli analyze always has a config before running

### DIFF
--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -84,7 +84,12 @@ fi
 # ----------------------------------------------------------------------------
 echo -e "\n${CYAN}[STAGE 3/7] Running pylint analysis...${NC}"
 SARIF="/tmp/pylint-$$.sarif"
+# codacy-cli analyze requires .codacy/codacy.yaml; write a minimal static
+# config so the analyze step works without an API call or account token.
+mkdir -p .codacy
+printf -- '---\ntools:\n  - name: pylint\n' > .codacy/codacy.yaml
 codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
+rm -f .codacy/codacy.yaml
 
 # ----------------------------------------------------------------------------
 # Stage 4: coverage upload — handled by .github/workflows/dotfiles-validation.yml

--- a/setup
+++ b/setup
@@ -1159,6 +1159,11 @@ cmd_ship() {
   else
     sarif_tmp="$(mktemp /tmp/ship-sarif-XXXXXXXX.sarif)"
     trap 'rm -f "${sarif_tmp:-}"' EXIT INT TERM
+    codacy-cli init \
+      --api-token "${CODACY_ACCOUNT_TOKEN:-}" \
+      --provider "${CODACY_ORGANIZATION_PROVIDER:-gh}" \
+      --organization "${CODACY_USERNAME:-}" \
+      --repository "${CODACY_PROJECT_NAME:-}" 2>/dev/null || true
     echo "[ship] step 4d: running pylint analysis → $sarif_tmp"
     if codacy-cli analyze --tool pylint --format sarif -o "$sarif_tmp"; then
       echo "[ship] step 4d: uploading SARIF for HEAD $head_oid"


### PR DESCRIPTION
## Summary

- `quality-pipeline.sh` now writes a minimal static `.codacy/codacy.yaml` before calling `codacy-cli analyze` and removes it after — no API token required
- `./setup ship` calls `codacy-cli init` with `CODACY_ACCOUNT_TOKEN` before analyzing so the config is fetched from the Codacy API
- Root cause: `codacy-cli analyze` exits 0 silently when `.codacy/codacy.yaml` is absent, producing no SARIF output

## Test plan

- [ ] All 307 unit tests pass (pre-push hook verified)
- [ ] `test_quality_pipeline_is_non_blocking_and_uses_local_prereqs` still passes (no CODACY_ACCOUNT_TOKEN in quality-pipeline.sh)
- [ ] `codacy-safety-net` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)