### PR TITLE
test: harden codacy-cli regression tests + inline guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,39 @@ Inside the container, run `codex` directly or use `./setup gstack-codex`; the wr
 
 When Playwright issue #40117 is resolved, the Docker workflow becomes optional — host browser skills will work natively again. The container path can stay as a fallback.
 
+## Codacy CLI Configuration Constraint
+
+`codacy-cli analyze` silently exits 0 and produces an empty SARIF file when
+`.codacy/codacy.yaml` does not exist. It prints "No configuration file was found,
+execute init command first." but does **not** return a non-zero exit code.
+
+`.codacy/` is gitignored (`.gitignore` line 27, commit 46af6c8). Do not attempt to
+restore a committed `.codacy/codacy.yaml` — prior commits 81b38aa, 8d47730 did this
+and were removed when `.codacy/` was gitignored. The file gets silently untracked.
+
+Two patterns for ephemerally providing the config (DO NOT mix these):
+
+**In `scripts/quality-pipeline.sh`** (`CODACY_ACCOUNT_TOKEN` must NOT appear — test enforced):
+```bash
+mkdir -p .codacy
+printf -- '---\ntools:\n  - name: pylint\n' > .codacy/codacy.yaml
+codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
+rm -f .codacy/codacy.yaml
+```
+
+**In `./setup ship` step 4d** (`CODACY_ACCOUNT_TOKEN` available via direnv):
+```bash
+codacy-cli init --api-token "${CODACY_ACCOUNT_TOKEN:-}" --provider gh \
+  --organization "${CODACY_USERNAME:-}" --repository "${CODACY_PROJECT_NAME:-}" 2>/dev/null || true
+codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
+```
+
+The `/codacy` skill (`~/.claude/skills/codacy/SKILL.md`) documents all procedures
+and troubleshooting. Invoke it before running `codacy-cli`.
+
+Known non-fatal warnings: `tools//patterns failed with status 404` (codacy-cli bug),
+`"Repository Analysis" is disabled` (advisory; 200 OK = upload succeeded).
+
 ## Hook Trigger Map
 
 Use these layers precisely: tool instructions are Markdown context files, tool hooks are CLI-specific session/tool hooks, and repo hooks are Git hooks that run for any caller.

--- a/scripts/quality-pipeline.sh
+++ b/scripts/quality-pipeline.sh
@@ -84,8 +84,11 @@ fi
 # ----------------------------------------------------------------------------
 echo -e "\n${CYAN}[STAGE 3/7] Running pylint analysis...${NC}"
 SARIF="/tmp/pylint-$$.sarif"
-# codacy-cli analyze requires .codacy/codacy.yaml; write a minimal static
-# config so the analyze step works without an API call or account token.
+# REGRESSION GUARD: do NOT remove — codacy-cli analyze exits 0 with empty SARIF when
+# .codacy/codacy.yaml is absent (it prints "No configuration file" but returns 0).
+# .codacy/ is gitignored (.gitignore:27); this write is the only option without account token.
+# The test test_quality_pipeline_is_non_blocking_and_uses_local_prereqs asserts this block exists.
+# See AGENTS.md "## Codacy CLI Configuration Constraint" for the full rationale.
 mkdir -p .codacy
 printf -- '---\ntools:\n  - name: pylint\n' > .codacy/codacy.yaml
 codacy-cli analyze --tool pylint --format sarif -o "$SARIF"

--- a/setup
+++ b/setup
@@ -1159,6 +1159,9 @@ cmd_ship() {
   else
     sarif_tmp="$(mktemp /tmp/ship-sarif-XXXXXXXX.sarif)"
     trap 'rm -f "${sarif_tmp:-}"' EXIT INT TERM
+    # REGRESSION GUARD: codacy-cli init must precede analyze — init writes .codacy/codacy.yaml.
+    # Without it, analyze exits 0 but produces empty SARIF.
+    # The test test_ship_uses_github_required_checks_and_no_temporary_codacy_worktrees asserts this.
     codacy-cli init \
       --api-token "${CODACY_ACCOUNT_TOKEN:-}" \
       --provider "${CODACY_ORGANIZATION_PROVIDER:-gh}" \

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -502,34 +502,40 @@ exit 64
             bin_dir / "codacy-cli",
             textwrap.dedent(
                 f"""#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> "{log_path}"
+# fake codacy-cli — mirrors real behavior: analyze exits 0 but empty SARIF without config
 cmd="${{1:-}}"
 shift || true
 case "$cmd" in
+  init)
+    printf '%s\\n' "init $*" >> "{log_path}"
+    # Create minimal config as real codacy-cli init would
+    mkdir -p .codacy
+    printf -- '---\\ntools:\\n  - name: pylint\\n' > .codacy/codacy.yaml
+    ;;
   analyze)
-    out=""
-    while (($#)); do
-      case "$1" in
-        -o)
-          out="${{2:-}}"
-          shift 2
-          ;;
-        *)
-          shift
-          ;;
-      esac
+    printf 'analyze\\n' >> "{log_path}"
+    if [[ ! -f .codacy/codacy.yaml ]]; then
+      echo "No configuration file was found, execute init command first." >&2
+      while [[ $# -gt 0 ]]; do
+        [[ "$1" == "-o" ]] && {{ printf '{{"runs":[]}}' > "$2"; shift 2; }} || shift
+      done
+      exit 0
+    fi
+    while [[ $# -gt 0 ]]; do
+      [[ "$1" == "-o" ]] && {{ printf 'SARIF\\n' > "$2"; shift 2; }} || shift
     done
-    [[ -n "$out" ]] || exit 64
-    printf 'SARIF\\n' > "$out"
-    exit 0
     ;;
   upload)
-    exit 0
+    printf 'upload\\n' >> "{log_path}"
+    ;;
+  --version)
+    echo "codacy-cli 0.0.0-fake"
+    ;;
+  *)
+    echo "unexpected codacy-cli call: $cmd $*" >&2
+    exit 1
     ;;
 esac
-echo "unexpected codacy-cli call: $cmd $*" >&2
-exit 64
 """
             ),
         )
@@ -1396,6 +1402,22 @@ printf '{"data":{"name":"Mister K","username":"kairin"}}\n'
         self.assertTrue(
             any("analyze" in line for line in codacy_lines),
             "codacy-cli analyze must be called during ship",
+        )
+        # init) arm logs "init <full argv>" — use startswith, not == "init"
+        self.assertTrue(
+            any(line.startswith("init ") for line in codacy_lines),
+            "codacy-cli init must be called during ship to populate .codacy/codacy.yaml",
+        )
+        self.assertTrue(
+            any("--api-token" in line for line in codacy_lines if line.startswith("init ")),
+            "codacy-cli init must be called with --api-token (CODACY_ACCOUNT_TOKEN)",
+        )
+        # Ordering: init must precede analyze
+        init_idx = next(i for i, line in enumerate(codacy_lines) if line.startswith("init "))
+        analyze_idx = next(i for i, line in enumerate(codacy_lines) if line == "analyze")
+        self.assertLess(
+            init_idx, analyze_idx,
+            "codacy-cli init must run before codacy-cli analyze (init writes .codacy/codacy.yaml)",
         )
 
         gh_lines = gh_log.read_text().splitlines()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -65,6 +65,40 @@ class WorkflowTests(DotfilesTestCase):
         self.assertIn("git merge-base HEAD origin/main", pipeline)
         self.assertNotIn("CODACY_ACCOUNT_TOKEN", pipeline)
         self.assertNotIn("GITHUB_TOKEN", pipeline)
+        # codacy-cli analyze exits 0 silently with empty SARIF when .codacy/codacy.yaml is absent.
+        # .codacy/ is gitignored (.gitignore line 27) — cannot be committed, must be written ephemerally.
+        # Regex asserts the full write structure (mkdir + printf + path + cleanup), not just strings
+        # that may appear in comments. See AGENTS.md "## Codacy CLI Configuration Constraint".
+        self.assertRegex(
+            pipeline,
+            r"mkdir -p \.codacy",
+            "quality-pipeline.sh must run 'mkdir -p .codacy' before analyze",
+        )
+        self.assertRegex(
+            pipeline,
+            r"printf[^\n]*'---\\ntools:\\n  - name: pylint\\n'[^\n]*>[ \t]*\.codacy/codacy\.yaml",
+            "quality-pipeline.sh must write valid pylint config to .codacy/codacy.yaml "
+            "(.codacy/ is gitignored; static write is the only option without CODACY_ACCOUNT_TOKEN)",
+        )
+        self.assertRegex(
+            pipeline,
+            r"rm -f \.codacy/codacy\.yaml",
+            "quality-pipeline.sh must clean up .codacy/codacy.yaml after analyze",
+        )
+        # Ordering: write must precede analyze, cleanup must follow.
+        # Anchor 'codacy-cli analyze' to a non-comment line (must be at line start or after whitespace,
+        # not preceded by '#') so we match the executable invocation, not the explanatory comment.
+        mkdir_match = re.search(r"^mkdir -p \.codacy", pipeline, re.MULTILINE)
+        analyze_match = re.search(r"^codacy-cli analyze", pipeline, re.MULTILINE)
+        cleanup_match = re.search(r"^rm -f \.codacy/codacy\.yaml", pipeline, re.MULTILINE)
+        self.assertLess(
+            mkdir_match.start(), analyze_match.start(),
+            "'mkdir -p .codacy' must appear before 'codacy-cli analyze'",
+        )
+        self.assertLess(
+            analyze_match.start(), cleanup_match.start(),
+            "'codacy-cli analyze' must appear before 'rm -f .codacy/codacy.yaml'",
+        )
 
     def test_pre_push_blocks_direct_main_push_before_quality_checks(self):
         home = self.make_home()


### PR DESCRIPTION
## Summary

PR #246 fixed silent `codacy-cli analyze` failures by writing an ephemeral `.codacy/codacy.yaml`. But the fix kept getting reverted because tests only had negative assertions and AGENTS.md was silent about the constraint. This makes the fix **self-defending**.

## Changes

- **`tests/test_workflow.py`**: Regex-based assertions verify the actual write command (`mkdir` + `printf > .codacy/codacy.yaml` + `rm -f`), with anchored `^...$` + `re.MULTILINE` ordering checks. Plain `assertIn` was insufficient — line 87 of `quality-pipeline.sh` contains `.codacy/codacy.yaml` in a comment that any string-based assertion matches.

- **`tests/test_setup_script.py`**: Fake `codacy-cli` now has an `init)` arm that creates the config file, and an `analyze)` arm that mirrors the real bug (exit 0 with empty SARIF when config absent). New assertions verify `init` runs before `analyze` using `startswith("init ")` on the full-argv log line.

- **`scripts/quality-pipeline.sh`** + **`setup` step 4d**: Inline `REGRESSION GUARD` comments naming the tests that assert the blocks must remain.

- **`AGENTS.md`**: New "Codacy CLI Configuration Constraint" section explains why `.codacy/` is gitignored, the two ephemeral patterns (no-token static write vs. account-token `init`), and links to the `/codacy` skill.

## How this prevents regression

| Layer | Mechanism | Strength |
|---|---|---|
| Tests | Regex + ordering assertions fail if write/init/cleanup removed | **Strong** — CI fails |
| Inline comments | `REGRESSION GUARD` naming the test | Weak — LLMs may delete comments with code |
| AGENTS.md | Constraint section + `/codacy` skill cross-reference | Context for new sessions |

Multi-model adversarial review (Opus 4.7 + Gemini 2.5 Pro) caught two critical issues during planning: (1) comment collision making `index`/`assertIn` no-ops, (2) `line == "init"` never matching the fake's full-argv log line.

## Test plan

- [x] All 307 tests pass (`uv run python -m unittest discover -s tests`)
- [x] Red-green verified for `test_quality_pipeline_is_non_blocking_and_uses_local_prereqs` (removing `mkdir -p .codacy` from script makes test fail)
- [x] Red-green verified for `test_ship_uses_github_required_checks_and_no_temporary_codacy_worktrees` (removing `codacy-cli init` from setup makes test fail)
- [x] Symlinks `CLAUDE.md` and `GEMINI.md` → `AGENTS.md` intact
- [ ] `codacy-safety-net` workflow passes on this PR
- [ ] Codacy dashboard reflects merged state after squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)