### PR TITLE
refactor: deduplicate post-install + report helpers across dotfiles_tools

### DIFF
--- a/dotfiles_tools/bootstrap.py
+++ b/dotfiles_tools/bootstrap.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping
 
 from .backups import BackupError
 from .fonts import CommandRunner, execute_font_operation, build_font_plan
-from .installer import build_plan, execute_manifest_operation
+from .installer import build_plan, execute_manifest_operation, failed_report
 from .reports import Report
 from .tool_installer import (
     TOOL_CACHE_REL,
@@ -20,6 +20,37 @@ WARNING_STATES = {"missing", "drifted", "protected", "manual", "unsupported", "n
 FAILED_STATES = {"invalid", "blocked"}
 TOOL_INSTALL_PHASES = {"all", "dev-base", "tools"}
 TOOL_POST_INSTALL_MODES = {"all", "verify", "auto", "guidance"}
+
+
+def _resolve_apply_paths(
+    repo: Path | str,
+    home: Path | str,
+    backup_dir: Path | str | None,
+) -> tuple[Path, Path, Path]:
+    repo_path = Path(repo).resolve()
+    home_path = Path(home).resolve()
+    backup_path = (
+        Path(backup_dir).expanduser().resolve()
+        if backup_dir
+        else home_path / ".dotfiles-backups"
+    )
+    return repo_path, home_path, backup_path
+
+
+def _required_yes_report(
+    command_name: str,
+    repo_path: Path,
+    home_path: Path,
+    profile: str,
+) -> Report:
+    return Report(
+        command_name,
+        "failed",
+        str(repo_path),
+        home=str(home_path),
+        profile=profile,
+        errors=[{"message": f"{command_name} requires --yes before writing"}],
+    )
 
 
 def build_bootstrap_plan(
@@ -73,18 +104,9 @@ def apply_bootstrap(
     env: Mapping[str, str] | None = None,
     runner: CommandRunner | None = None,
 ) -> Report:
-    repo_path = Path(repo).resolve()
-    home_path = Path(home).resolve()
-    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    repo_path, home_path, backup_path = _resolve_apply_paths(repo, home, backup_dir)
     if not yes:
-        return Report(
-            "bootstrap-apply",
-            "failed",
-            str(repo_path),
-            home=str(home_path),
-            profile=profile,
-            errors=[{"message": "bootstrap-apply requires --yes before writing"}],
-        )
+        return _required_yes_report("bootstrap-apply", repo_path, home_path, profile)
 
     report = build_bootstrap_plan(
         repo_path,
@@ -139,18 +161,9 @@ def apply_tool_installs(
     env: Mapping[str, str] | None = None,
     runner: CommandRunner | None = None,
 ) -> Report:
-    repo_path = Path(repo).resolve()
-    home_path = Path(home).resolve()
-    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    repo_path, home_path, backup_path = _resolve_apply_paths(repo, home, backup_dir)
     if not yes:
-        return Report(
-            "bootstrap-install-tools",
-            "failed",
-            str(repo_path),
-            home=str(home_path),
-            profile="machine",
-            errors=[{"message": "bootstrap-install-tools requires --yes before writing"}],
-        )
+        return _required_yes_report("bootstrap-install-tools", repo_path, home_path, "machine")
 
     plan = build_tool_install_subplan(repo_path, home_path, phase=phase, env=env, runner=runner)
     plan.command = "bootstrap-install-tools"
@@ -182,9 +195,7 @@ def run_tool_install_post_install(
     runner: CommandRunner | None = None,
     backup_dir: Path | str | None = None,
 ) -> Report:
-    repo_path = Path(repo).resolve()
-    home_path = Path(home).resolve()
-    backup_path = Path(backup_dir).expanduser().resolve() if backup_dir else home_path / ".dotfiles-backups"
+    repo_path, home_path, backup_path = _resolve_apply_paths(repo, home, backup_dir)
     if mode not in TOOL_POST_INSTALL_MODES:
         raise ValueError(f"unknown tool post-install mode: {mode}")
     report = Report(
@@ -205,13 +216,6 @@ def run_tool_install_post_install(
     )
     _attach_post_install_summary(report, summary)
     return report
-
-
-def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    collected: list[dict[str, Any]] = []
-    for action in actions:
-        collected.extend(action.get("backups") or [])
-    return collected
 
 
 def _attach_post_install_summary(report: Report, summary: dict[str, Any]) -> None:
@@ -241,13 +245,13 @@ def _execute_bootstrap_operations(
             apt_keyring_op = next(
                 op for op in report.operations if op.get("type") == "tool_install_apt_keyring"
             )
-            return _failed_report(report, executed, apt_keyring_op, backups, completed_writes, exc)
+            return failed_report(report, executed, apt_keyring_op, backups, completed_writes, exc)
     for op in report.operations:
         try:
             completed_writes += _execute_operation(op, repo_path, backup_path, backups, effective_runner)
             executed.append(op)
         except (OSError, BackupError, RuntimeError) as exc:
-            return _failed_report(report, executed, op, backups, completed_writes, exc)
+            return failed_report(report, executed, op, backups, completed_writes, exc)
     report.backups = backups
     report.status = "warning" if _has_manual_or_refused_work(report) else "ok"
     return report
@@ -266,34 +270,6 @@ def _execute_operation(
     if op.get("recipe") == "fonts" or str(op.get("type", "")).startswith("font_"):
         return execute_font_operation(op, runner=runner, backup_dir=backup_path, backups=backups)
     return execute_manifest_operation(op, repo_path, backup_path, backups)
-
-
-def _failed_report(
-    report: Report,
-    executed: list[dict[str, Any]],
-    op: dict[str, Any],
-    backups: list[dict[str, Any]],
-    completed_writes: int,
-    exc: Exception,
-) -> Report:
-    report.errors.append({
-        "operation_id": op.get("operation_id", ""),
-        "entry_id": op.get("entry_id", ""),
-        "message": str(exc),
-    })
-    report.operations = executed + [op]
-    report.backups = backups
-    report.status = "partial" if completed_writes else "failed"
-    if completed_writes:
-        report.operations.append({
-            "operation_id": f"op-{len(report.operations) + 1:03d}",
-            "entry_id": op.get("entry_id", ""),
-            "type": "partial_apply",
-            "target": op.get("target"),
-            "reason": "stopped on first failed write",
-            "requires_approval": False,
-        })
-    return report
 
 
 def _has_manual_or_refused_work(report: Report) -> bool:

--- a/dotfiles_tools/installer.py
+++ b/dotfiles_tools/installer.py
@@ -91,7 +91,7 @@ def _execute_apply_operations(report: Report, repo_path: Path, backup_path: Path
             completed_writes += _execute_operation(op, repo_path, backup_path, backups)
             executed.append(op)
         except (OSError, BackupError) as exc:
-            return _failed_apply_report(report, executed, op, backups, completed_writes, exc)
+            return failed_report(report, executed, op, backups, completed_writes, exc)
     report.backups = backups
     report.status = "warning" if any(op["type"] == "refuse" for op in report.operations) else "ok"
     return report
@@ -163,7 +163,7 @@ def _symlink_operation(op: dict[str, Any]) -> None:
     target.symlink_to(op["link_target"])
 
 
-def _failed_apply_report(
+def failed_report(
     report: Report,
     executed: list[dict[str, Any]],
     op: dict[str, Any],

--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -505,13 +505,26 @@ def _sudo_prefix() -> list[str]:
     return ["sudo"]
 
 
-def _execute_apt(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int:
+def _apt_get_or_skip(
+    op: dict[str, Any],
+    runner: CommandRunner,
+    not_found_message: str,
+) -> tuple[list[str], str | None]:
+    """Return (packages, apt_get_path) or ([], None) if nothing to do.
+    Sets op['result'] when apt-get is missing."""
     packages = [str(pkg) for pkg in op.get("packages", []) if pkg]
     if not packages:
-        return 0
+        return [], None
     apt_get = runner.which("apt-get")
     if not apt_get:
-        op["result"] = "apt-get not found; install packages manually"
+        op["result"] = not_found_message
+        return [], None
+    return packages, apt_get
+
+
+def _execute_apt(op: dict[str, Any], runner: CommandRunner, *, mode: str) -> int:
+    packages, apt_get = _apt_get_or_skip(op, runner, "apt-get not found; install packages manually")
+    if not packages or not apt_get:
         return 0
     _apt_update_then_install(runner, _sudo_prefix(), apt_get, packages, mode=mode)
     return 1
@@ -585,12 +598,8 @@ def prepare_apt_keyring_operations(
 
 
 def _execute_apt_keyring(op: dict[str, Any], runner: CommandRunner, cache_dir: Path) -> int:
-    packages = [str(pkg) for pkg in op.get("packages", []) if pkg]
-    if not packages:
-        return 0
-    apt_get = runner.which("apt-get")
-    if not apt_get:
-        op["result"] = "apt-get not found; install manually"
+    packages, apt_get = _apt_get_or_skip(op, runner, "apt-get not found; install manually")
+    if not packages or not apt_get:
         return 0
     prefix = _sudo_prefix()
     _prepare_apt_keyring_source(op, runner, cache_dir)
@@ -784,7 +793,7 @@ def _collect_post_install_action_summary(
     return {
         "verification": verification,
         "post_install_actions": actions,
-        "backups": _collect_post_install_backups(actions),
+        "backups": collect_post_install_backups(actions),
         "status": _post_install_summary_status(mode, verification, actions),
     }
 
@@ -805,7 +814,7 @@ def _post_install_context(
     return effective_env, effective_runner, repo, home_path, backup
 
 
-def _collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def collect_post_install_backups(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
     collected: list[dict[str, Any]] = []
     for action in actions:
         collected.extend(action.get("backups") or [])
@@ -881,11 +890,9 @@ def run_post_install_actions(
     guidance. `requires_protected_apply` copies the listed protected files
     from the repo before exec (only when yes=True and repo_path is set);
     existing targets are backed up to `backup_dir` first."""
-    effective_env = dict(os.environ if env is None else env)
-    effective_runner = runner or CommandRunner(env=effective_env, path=effective_env.get("PATH", ""))
-    repo = Path(repo_path).resolve() if repo_path else None
-    home_path = Path(home).expanduser().resolve()
-    backup = Path(backup_dir).expanduser().resolve() if backup_dir else None
+    effective_env, effective_runner, repo, home_path, backup = _post_install_context(
+        home, env=env, runner=runner, repo_path=repo_path, backup_dir=backup_dir,
+    )
     return _walk_post_install(
         effective_runner, effective_env, yes=yes,
         repo=repo, home=home_path, backup_dir=backup,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -12,7 +12,6 @@ from dotfiles_tools.bootstrap import (
     _renumber_operations,
     _status,
     _has_manual_or_refused_work,
-    _collect_post_install_backups,
     _execute_bootstrap_operations,
     build_bootstrap_plan,
     apply_bootstrap,
@@ -20,6 +19,7 @@ from dotfiles_tools.bootstrap import (
     apply_tool_installs,
     run_tool_install_post_install,
 )
+from dotfiles_tools.tool_installer import collect_post_install_backups
 from dotfiles_tools.reports import Report
 from tests.helpers import DotfilesTestCase, REPO_ROOT
 
@@ -149,11 +149,11 @@ class HasManualOrRefusedWorkTests(DotfilesTestCase):
 
 class CollectPostInstallBackupsTests(DotfilesTestCase):
     def test_returns_empty_when_no_actions(self):
-        self.assertEqual(_collect_post_install_backups([]), [])
+        self.assertEqual(collect_post_install_backups([]), [])
 
     def test_returns_empty_when_no_backups_key(self):
         actions = [{"status": "ran", "tool": "gh"}]
-        self.assertEqual(_collect_post_install_backups(actions), [])
+        self.assertEqual(collect_post_install_backups(actions), [])
 
     def test_collects_backups_from_all_actions(self):
         b1 = {"entry_id": "a", "backup_target": "/tmp/a"}
@@ -162,12 +162,12 @@ class CollectPostInstallBackupsTests(DotfilesTestCase):
             {"status": "ran", "backups": [b1]},
             {"status": "ran", "backups": [b2]},
         ]
-        result = _collect_post_install_backups(actions)
+        result = collect_post_install_backups(actions)
         self.assertEqual(result, [b1, b2])
 
     def test_skips_none_backups(self):
         actions = [{"status": "ran", "backups": None}]
-        self.assertEqual(_collect_post_install_backups(actions), [])
+        self.assertEqual(collect_post_install_backups(actions), [])
 
 
 class ExecuteBootstrapOperationsTests(DotfilesTestCase):


### PR DESCRIPTION
## Summary

Codacy flagged the repo at **15% duplication** (vs 10% goal), holding the grade at **C**. Investigation via Codacy MCP found the duplication concentrated in two files: `tool_installer.py` (72% dup, 9 clones) and `bootstrap.py` (73% dup, 8 clones).

This PR addresses **5 of the 6** clone clusters with low-risk mechanical refactors. Skipping the op-builder dict pattern (cluster 6) because per-op field differences make a base-dict extraction obscure the fields each op type actually sets.

## What's deduplicated

| # | Pattern | Before | After |
|---|---|---|---|
| 1 | `_collect_post_install_backups` duplicated verbatim in `bootstrap.py` and `tool_installer.py` | Two identical 5-line functions | One canonical `collect_post_install_backups` in `tool_installer.py`, imported by `bootstrap.py` |
| 2 | `_failed_report` (bootstrap.py) ≈ `_failed_apply_report` (installer.py) | Two functionally identical 17-line functions | One canonical `failed_report` in `installer.py`, imported by `bootstrap.py` |
| 3 | yes-check boilerplate repeated across `apply_bootstrap`, `apply_tool_installs`, `run_tool_install_post_install` in `bootstrap.py` | ~26 lines of duplicated `Path().resolve() + yes-check + failed Report` | Two helpers `_resolve_apply_paths()` and `_required_yes_report()` |
| 4 | `run_post_install_actions()` duplicates `_post_install_context()` setup body | 5-line copy of the context-setup logic | Single call to `_post_install_context()` |
| 5 | apt-get guard in `_execute_apt` and `_execute_apt_keyring` | "no packages / no apt-get / skip" repeated | Single `_apt_get_or_skip()` helper; preserves the two slightly different "apt-get not found" messages by parameter |

## What's NOT changed

- Public API surface (no public function signatures changed)
- Error message strings (tests assert on these — preserved exactly)
- `Report` class
- The op-builder pattern (cluster 6) — deferred because differences are semantically meaningful

## Test plan

- [x] All 307 tests pass
- [x] Each refactor verified individually before being committed
- [ ] `codacy-safety-net` passes on this PR
- [ ] Codacy duplication metric drops below 10% goal (currently 15%, expected ~8-10% after these clones resolve)
- [ ] Codacy grade lifts from C → B

## Methodology

Three agents executed in parallel/sequential waves:
- **Wave 1** (parallel): `bootstrap.py` and `tool_installer.py` single-file refactors
- **Wave 2** (sequential): cross-file deduplication
- **Wave 3**: full test suite + ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)