### PR TITLE
refactor: extract _base_install_op helper for op-builders (cluster 6)

### DIFF
--- a/dotfiles_tools/tool_installer.py
+++ b/dotfiles_tools/tool_installer.py
@@ -319,6 +319,30 @@ def _tool_operations(
 # ---------------------------------------------------------------------------
 
 
+def _base_install_op(
+    *,
+    entry_id: str,
+    op_type: str,
+    requires_sudo: bool,
+    cache_dir: Path,
+    reason: str,
+    mode: str | None = None,
+) -> dict[str, Any]:
+    op: dict[str, Any] = {
+        "entry_id": entry_id,
+        "recipe": "tool_installs",
+        "type": op_type,
+        "requires_sudo": requires_sudo,
+        "requires_network": True,
+        "requires_approval": True,
+        "cache_dir": str(cache_dir),
+        "reason": reason,
+    }
+    if mode is not None:
+        op["mode"] = mode
+    return op
+
+
 def _apt_op(
     *,
     entry_id: str,
@@ -328,17 +352,15 @@ def _apt_op(
     cache_dir: Path,
     reason: str,
 ) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "recipe": "tool_installs",
-        "type": op_type,
-        "packages": packages,
-        "requires_sudo": requires_sudo,
-        "requires_network": True,
-        "requires_approval": True,
-        "cache_dir": str(cache_dir),
-        "reason": reason,
-    }
+    op = _base_install_op(
+        entry_id=entry_id,
+        op_type=op_type,
+        requires_sudo=requires_sudo,
+        cache_dir=cache_dir,
+        reason=reason,
+    )
+    op["packages"] = packages
+    return op
 
 
 def _apt_keyring_op(
@@ -349,22 +371,20 @@ def _apt_keyring_op(
     *,
     mode: str,
 ) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "recipe": "tool_installs",
-        "type": "tool_install_apt_keyring",
-        "mode": mode,
-        "packages": list(args.get("packages") or ()),
-        "keyring_url": args["keyring_url"],
-        "keyring_path": args["keyring_path"],
-        "source_line": args["source_line"],
-        "source_path": args["source_path"],
-        "requires_sudo": True,
-        "requires_network": True,
-        "requires_approval": True,
-        "cache_dir": str(cache_dir),
-        "reason": f"{mode} {item['label']} via GitHub keyring repo",
-    }
+    op = _base_install_op(
+        entry_id=entry_id,
+        op_type="tool_install_apt_keyring",
+        requires_sudo=True,
+        cache_dir=cache_dir,
+        reason=f"{mode} {item['label']} via GitHub keyring repo",
+        mode=mode,
+    )
+    op["packages"] = list(args.get("packages") or ())
+    op["keyring_url"] = args["keyring_url"]
+    op["keyring_path"] = args["keyring_path"]
+    op["source_line"] = args["source_line"]
+    op["source_path"] = args["source_path"]
+    return op
 
 
 def _curl_op(
@@ -375,21 +395,19 @@ def _curl_op(
     *,
     mode: str,
 ) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "recipe": "tool_installs",
-        "type": "tool_install_curl",
-        "mode": mode,
-        "url": args["url"],
-        "script_name": args.get("script_name", "installer.sh"),
-        "interpreter": args.get("interpreter", "bash"),
-        "install_to": args.get("install_to"),
-        "requires_sudo": item.get("requires_sudo", False),
-        "requires_network": True,
-        "requires_approval": True,
-        "cache_dir": str(cache_dir),
-        "reason": f"{mode} {item['label']} via {args['url']}",
-    }
+    op = _base_install_op(
+        entry_id=entry_id,
+        op_type="tool_install_curl",
+        requires_sudo=item.get("requires_sudo", False),
+        cache_dir=cache_dir,
+        reason=f"{mode} {item['label']} via {args['url']}",
+        mode=mode,
+    )
+    op["url"] = args["url"]
+    op["script_name"] = args.get("script_name", "installer.sh")
+    op["interpreter"] = args.get("interpreter", "bash")
+    op["install_to"] = args.get("install_to")
+    return op
 
 
 def _npm_op(
@@ -403,19 +421,17 @@ def _npm_op(
 ) -> dict[str, Any]:
     op_type = "tool_install_npm" if mode == "install" else "tool_install_npm_upgrade"
     prefix = home / ".local"
-    return {
-        "entry_id": entry_id,
-        "recipe": "tool_installs",
-        "type": op_type,
-        "mode": mode,
-        "package": args["package"],
-        "prefix": str(prefix),
-        "requires_sudo": item.get("requires_sudo", False),
-        "requires_network": True,
-        "requires_approval": True,
-        "cache_dir": str(cache_dir),
-        "reason": f"{mode} {item['label']} via npm in {prefix}",
-    }
+    op = _base_install_op(
+        entry_id=entry_id,
+        op_type=op_type,
+        requires_sudo=item.get("requires_sudo", False),
+        cache_dir=cache_dir,
+        reason=f"{mode} {item['label']} via npm in {prefix}",
+        mode=mode,
+    )
+    op["package"] = args["package"]
+    op["prefix"] = str(prefix)
+    return op
 
 
 def _uv_tool_op(
@@ -426,19 +442,15 @@ def _uv_tool_op(
     *,
     mode: str,
 ) -> dict[str, Any]:
-    op_type = "tool_install_uv_tool"
-    op: dict[str, Any] = {
-        "entry_id": entry_id,
-        "recipe": "tool_installs",
-        "type": op_type,
-        "mode": mode,
-        "package": args["package"],
-        "requires_sudo": item.get("requires_sudo", False),
-        "requires_network": True,
-        "requires_approval": True,
-        "cache_dir": str(cache_dir),
-        "reason": f"{mode} {item['label']} via uv tool",
-    }
+    op = _base_install_op(
+        entry_id=entry_id,
+        op_type="tool_install_uv_tool",
+        requires_sudo=item.get("requires_sudo", False),
+        cache_dir=cache_dir,
+        reason=f"{mode} {item['label']} via uv tool",
+        mode=mode,
+    )
+    op["package"] = args["package"]
     if "from_url" in args:
         op["from_url"] = args["from_url"]
     return op


### PR DESCRIPTION
## Summary

Continues PR #248. That PR addressed 5 of 6 Codacy clone clusters but deferred cluster 6 (op-builder dict literals) because per-op field differences made the abstraction non-obvious. After investigation, the common-vs-specific split is actually clean: 8 keys are identical across all 5 builders, 1 more (`mode`) is identical across 4 of 5, and the rest are op-specific.

This PR extracts a `_base_install_op()` helper and refactors all 5 op-builders to call it.

## Op-builders refactored

| Function | Op type | Mode? | Specific fields |
|---|---|---|---|
| `_apt_op` | `tool_install_apt` | no | packages |
| `_apt_keyring_op` | `tool_install_apt_keyring` | yes | packages, keyring_url, keyring_path, source_line, source_path |
| `_curl_op` | `tool_install_curl` | yes | url, script_name, interpreter, install_to |
| `_npm_op` | `tool_install_npm[_upgrade]` | yes | package, prefix |
| `_uv_tool_op` | `tool_install_uv_tool` | yes | package, optional from_url |

The base helper handles the 8 shared keys (`entry_id`, `recipe`, `type`, `requires_sudo`, `requires_network`, `requires_approval`, `cache_dir`, `reason`) plus an optional `mode` parameter that defaults to `None` (so `_apt_op` doesn't pass it).

## Behavior preservation

- All function signatures unchanged
- Dict CONTENTS unchanged (same keys, same values) — Python dict equality is order-independent, so insertion-order changes are safe
- All 4 reason strings preserved verbatim (`f"{mode} {item['label']} via GitHub keyring repo"`, etc.)
- `_npm_op` still computes `prefix = home / ".local"` before the base call so the `reason` f-string interpolates correctly
- `_uv_tool_op` still appends optional `from_url` conditionally

## Test plan

- [x] All 307 tests pass (`uv run python -m unittest discover -s tests`)
- [x] `tests.test_tool_installer` specifically: 43/43 pass
- [ ] `codacy-safety-net` passes on this PR
- [ ] Codacy duplication metric drops below 10% goal
- [ ] Codacy grade lifts from C → B

## Net diff

+73 / -61 raw lines (helper definition is larger than the lines removed from each call site), but Codacy's clone detector measures repeated patterns. ~40 lines of repeated dict-key boilerplate are now centralized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)