### PR TITLE
refactor: deduplicate font_records and font_windows

### DIFF
--- a/dotfiles_tools/font_records.py
+++ b/dotfiles_tools/font_records.py
@@ -221,28 +221,16 @@ def build_unsupported_plan(home: Path, context: dict[str, Any]) -> dict[str, Any
 
 
 def unsupported_nerd_summary(home: Path, context: dict[str, Any], item: NerdFontItem, reason: str) -> dict[str, Any]:
-    paths = nerd_paths(home, item)
-    return {
-        "entry_id": item.entry_id,
-        "label": item.label,
-        "family": item.family,
-        "source_type": "nerd_font_release",
-        "source": f"GitHub latest release asset {NERD_FONTS_REPO}/{item.asset_name}",
-        "asset_name": item.asset_name,
-        "state": "unsupported",
-        "installed_version": None,
-        "latest_version": None,
-        "cached_version": None,
-        "candidate_version": None,
-        "target": str(paths["install_dir"]),
-        "cache_path": str(paths["archive"]),
-        "terminal_face": item.terminal_face,
-        "platform": context["platform"],
-        "requires_sudo": False,
-        "terminal_impact": terminal_impact(context["platform"]),
-        "host_action": host_action(context),
-        "reason": reason,
-    }
+    return nerd_font_summary_record(
+        context,
+        item,
+        nerd_paths(home, item),
+        "unsupported",
+        reason,
+        None,
+        None,
+        None,
+    )
 
 
 def unsupported_apt_summary(context: dict[str, Any], item: dict[str, str], reason: str) -> dict[str, Any]:

--- a/dotfiles_tools/font_windows.py
+++ b/dotfiles_tools/font_windows.py
@@ -6,8 +6,9 @@ from typing import Any
 
 from .backups import create_backup
 from .font_assets import windows_font_install_script
-from .font_catalog import FONT_CACHE_REL, FONT_FACE, FONT_INSTALL_BASE_REL, WINDOWS_ENTRY_ID, FontError, NerdFontItem
+from .font_catalog import FONT_FACE, WINDOWS_ENTRY_ID, FontError, NerdFontItem
 from .font_context import check_windows_fonts_installed, host_action, terminal_impact
+from .font_records import manual_op, nerd_paths
 from .font_runner import CommandRunner
 
 
@@ -112,33 +113,11 @@ def windows_terminal_update_operation(item: NerdFontItem, settings: str) -> dict
     }
 
 
-def nerd_paths(home: Path, item: NerdFontItem) -> dict[str, Path]:
-    cache_dir = home / FONT_CACHE_REL
-    return {
-        "cache_dir": cache_dir,
-        "archive": cache_dir / item.asset_name,
-        "version": cache_dir / f"{item.cache_stem}.version.json",
-        "extract_dir": cache_dir / item.cache_stem,
-        "install_dir": home / FONT_INSTALL_BASE_REL / item.install_dir_name,
-    }
-
-
 def _windows_skip_op(entry_id: str, reason: str) -> dict[str, Any]:
     return {
         "entry_id": entry_id,
         "type": "font_skip",
         "target": "Windows per-user font store",
-        "reason": reason,
-        "requires_approval": False,
-        "recipe": "fonts",
-    }
-
-
-def manual_op(entry_id: str, reason: str) -> dict[str, Any]:
-    return {
-        "entry_id": entry_id,
-        "type": "font_manual",
-        "target": "",
         "reason": reason,
         "requires_approval": False,
         "recipe": "fonts",


### PR DESCRIPTION
## Summary

Third PR in the Codacy dedup chain (after #248 cross-module helpers, #249 op-builder base). Codacy MCP flagged `font_records.py` at 56% duplication with 3 clone groups — two verbatim cross-file with `font_windows.py`, one intra-file structural.

## Clones eliminated

| Clone | Type | Lines | Strategy |
|---|---|---|---|
| `nerd_paths` in both files | Verbatim cross-file | 9 lines | Delete from `font_windows.py`, import from `font_records` |
| `manual_op` in both files | Verbatim cross-file | 9 lines | Same — delete + import |
| `unsupported_nerd_summary` vs `nerd_font_summary_record` | Same dict shape, hardcoded vs variable values | 12 lines | One-line delegation to `nerd_font_summary_record` with "unsupported" state and `None` versions |

## Why no helper extraction (lesson from #249)

PR #249 extracted `_base_install_op` for 5 op-builders but duplication metric stayed at 11% — Codacy's clone detector saw the new pattern (helper call + assignments repeated 5 times) as still duplicated. The refactor was a wash.

This PR avoids that trap. For the intra-file clone (`unsupported_nerd_summary`), the existing `nerd_font_summary_record` signature already accepted `state, installed_tag, latest_version, cached_tag` as parameters. So `unsupported_nerd_summary` becomes a literal one-line delegation:

```python
return nerd_font_summary_record(
    context, item, nerd_paths(home, item),
    "unsupported", reason, None, None, None,
)
```

No new helper, no new call pattern to duplicate. Just reuse the existing function.

## Test plan

- [x] All 307 tests pass (`uv run python -m unittest discover -s tests`)
- [x] Dict shapes preserved byte-for-byte (verified by tests that assert on record structure)
- [x] No new imports break `font_windows.py` (FONT_CACHE_REL/FONT_INSTALL_BASE_REL removed from its imports since they're only used inside the now-deleted `nerd_paths`)
- [ ] `codacy-safety-net` passes on this PR
- [ ] Codacy duplication metric drops below 10% goal
- [ ] Codacy grade lifts from C → B

## Net diff

`2 files changed, 12 insertions(+), 45 deletions(-)` — 35 net lines removed. No public signatures changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)