### PR TITLE
docs: complete four-required-checks rollout + invert stale test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,8 +224,10 @@ codacy-cli analyze --tool pylint --format sarif -o "$SARIF"
 The `/codacy` skill (`~/.claude/skills/codacy/SKILL.md`) documents all procedures
 and troubleshooting. Invoke it before running `codacy-cli`.
 
-Known non-fatal warnings: `tools//patterns failed with status 404` (codacy-cli bug),
-`"Repository Analysis" is disabled` (advisory; 200 OK = upload succeeded).
+Known non-fatal messages: `tools//patterns failed with status 404` (codacy-cli bug),
+`"Repository Analysis" is disabled` (informational Codacy server notice; 200 OK
+on the upload response = SARIF accepted). Neither blocks the four required Codacy
+checks from running on the PR.
 
 ## Hook Trigger Map
 

--- a/README.md
+++ b/README.md
@@ -329,8 +329,10 @@ All four Codacy checks are required by branch protection: `codacy-safety-net`
 `Codacy Diff Coverage`) — they must all report green on the PR once Codacy
 finishes processing the uploaded SARIF and coverage before the merge can
 proceed. The squash-merge proceeds only when the PR is `CLEAN` or `UNSTABLE`.
-`UNSTABLE` is allowed because non-required advisory jobs can be skipped or
-cancelled.
+`UNSTABLE` is allowed because checks outside the four required Codacy
+contexts (other GitHub Actions jobs, advisory linters) can be skipped or
+cancelled without blocking the merge — the four required Codacy checks must
+still all be green.
 The default check polling window is 15 minutes; override with
 `SHIP_CHECK_TIMEOUT=<seconds>` or `SHIP_CHECK_INTERVAL=<seconds>` only when
 debugging.

--- a/docs/codacy-branch-protection.md
+++ b/docs/codacy-branch-protection.md
@@ -49,6 +49,22 @@ Codacy Coverage Variation
 Codacy Diff Coverage
 ```
 
+For code repositories that also ship a local `codacy-safety-net` GitHub Actions
+workflow (uploading SARIF/coverage from CI), require that workflow as a fourth
+gate so the dashboard reports the branch as fully protected:
+
+```text
+codacy-safety-net
+Codacy Static Code Analysis
+Codacy Coverage Variation
+Codacy Diff Coverage
+```
+
+`codacy-safety-net` is emitted by the repo's own GitHub Actions workflow
+(`.github/workflows/codacy-safety-net.yml`, app_id `15368`); the three `Codacy
+*` checks are emitted by the Codacy GitHub App (app_id `56611`). They are
+distinct integrations — list both ids when writing the JSON templates below.
+
 Codacy may still show partial protection if only one of these checks is
 required while the matching coverage gates are enabled in Codacy, even when
 GitHub says the branch is protected.
@@ -79,8 +95,12 @@ Use this as the short checklist before marking a repository done:
 
 In `000-dotfiles`, Codacy initially reported `main` as partially protected
 because the repo already emitted coverage checks on PRs, but GitHub required
-only `Codacy Static Code Analysis`. The fix was to require all three Codacy
-contexts in both classic branch protection and the default-branch ruleset.
+only `Codacy Static Code Analysis`. An interim fix required the three Codacy
+app contexts; PR #254 (2026-05-16) extended this to **four required contexts**
+by adding the repo's local `codacy-safety-net` GitHub Actions workflow check
+(app_id `15368`). The four-check pattern is the current state for
+`000-dotfiles` — see the "coverage-enabled + local safety-net workflow"
+profile below.
 
 ## Inputs
 
@@ -295,6 +315,42 @@ gh api --method PUT "repos/$OWNER/$REPO/branches/$BRANCH/protection" --input - <
 JSON
 ```
 
+Coverage-enabled + local safety-net workflow profile (used by `000-dotfiles`
+per PR #254). Lists `codacy-safety-net` as the fourth required context so the
+dashboard reports the branch as fully protected:
+
+```bash
+gh api --method PUT "repos/$OWNER/$REPO/branches/$BRANCH/protection" --input - <<JSON
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "codacy-safety-net",
+      "Codacy Static Code Analysis",
+      "Codacy Coverage Variation",
+      "Codacy Diff Coverage"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false,
+    "required_review_thread_resolution": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+```
+
 Classic protection may show `app_id: null` for Codacy coverage checks until
 Codacy emits those checks on a pull request. The context names still matter.
 
@@ -396,6 +452,55 @@ gh api --method POST "repos/$OWNER/$REPO/rulesets" --input - <<JSON
 JSON
 ```
 
+Coverage-enabled + local safety-net workflow profile (used by `000-dotfiles`,
+PR #254). `15368` is the GitHub App id for GitHub Actions itself, which emits
+the local `codacy-safety-net` workflow check:
+
+```bash
+SAFETY_NET_APP_ID="15368"
+
+gh api --method POST "repos/$OWNER/$REPO/rulesets" --input - <<JSON
+{
+  "name": "$RULESET_NAME",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "codacy-safety-net", "integration_id": $SAFETY_NET_APP_ID },
+          { "context": "Codacy Static Code Analysis", "integration_id": $CODACY_APP_ID },
+          { "context": "Codacy Coverage Variation", "integration_id": $CODACY_APP_ID },
+          { "context": "Codacy Diff Coverage", "integration_id": $CODACY_APP_ID }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}
+JSON
+```
+
 If a suitable ruleset already exists, update it:
 
 Static-only profile for docs/config/template repositories:
@@ -472,6 +577,53 @@ gh api --method PUT "repos/$OWNER/$REPO/rulesets/$RULESET_ID" --input - <<JSON
       "parameters": {
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
+          { "context": "Codacy Static Code Analysis", "integration_id": $CODACY_APP_ID },
+          { "context": "Codacy Coverage Variation", "integration_id": $CODACY_APP_ID },
+          { "context": "Codacy Diff Coverage", "integration_id": $CODACY_APP_ID }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}
+JSON
+```
+
+Coverage-enabled + local safety-net workflow profile (update form):
+
+```bash
+SAFETY_NET_APP_ID="15368"
+
+gh api --method PUT "repos/$OWNER/$REPO/rulesets/$RULESET_ID" --input - <<JSON
+{
+  "name": "$RULESET_NAME",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "codacy-safety-net", "integration_id": $SAFETY_NET_APP_ID },
           { "context": "Codacy Static Code Analysis", "integration_id": $CODACY_APP_ID },
           { "context": "Codacy Coverage Variation", "integration_id": $CODACY_APP_ID },
           { "context": "Codacy Diff Coverage", "integration_id": $CODACY_APP_ID }

--- a/docs/codacy-coverage-rollout.md
+++ b/docs/codacy-coverage-rollout.md
@@ -33,8 +33,12 @@ Use this document as the checklist for applying the same pattern to other repos.
    - `Codacy Coverage Variation`
    - `Codacy Diff Coverage`
 10. Updated GitHub protection after coverage checks were proven.
-   - Classic `main` branch protection requires all three Codacy contexts.
-   - The active default-branch ruleset requires the same three Codacy contexts.
+   - Classic `main` branch protection requires all four required gates: the three
+     Codacy app contexts above plus the local `codacy-safety-net` GitHub Actions
+     workflow check (app_id `15368`). The fourth check applies because this repo
+     ships `.github/workflows/codacy-safety-net.yml`; repositories without that
+     workflow only require the three Codacy app contexts.
+   - The active default-branch ruleset requires the same four contexts.
    - Both protection layers use strict status checks.
 
 ## Reuse Steps For Another Repo
@@ -149,6 +153,10 @@ Use this document as the checklist for applying the same pattern to other repos.
      - `Codacy Static Code Analysis`
      - `Codacy Coverage Variation`
      - `Codacy Diff Coverage`
+   - If the target repository also ships a `codacy-safety-net` GitHub Actions
+     workflow (as `000-dotfiles` does), add `codacy-safety-net` as a fourth
+     required context. See `docs/codacy-branch-protection.md` for the
+     coverage-enabled-with-safety-net JSON template.
 11. Configure Codacy gates for the target repo.
     - Static analysis gates should match the repo's quality policy.
     - Coverage gates only block when thresholds are set in Codacy.

--- a/docs/codacy-github-issues-report.md
+++ b/docs/codacy-github-issues-report.md
@@ -1,7 +1,16 @@
 # Codacy & GitHub Protection Issues: Comprehensive Report
 
+> **Superseded for protection policy by PR #254 (2026-05-16).** The
+> remediation plan in this report (including the P2 recommendation to restore
+> protection with "conditional check enforcement") was the picture in early
+> May. PR #254 reversed that direction: `main` now requires all four Codacy
+> contexts unconditionally, with `./setup ship` performing the canonical
+> admin-bypass when the merge state lands `BLOCKED` solely because of the
+> solo-reviewer requirement. Treat the protection sections of this report as
+> historical context, not a remediation playbook.
+
 **Report Date:** 2026-05-06  
-**Status:** 13 PRs merged; 6 root causes identified; 3 priority fixes recommended  
+**Status:** 13 PRs merged; 6 root causes identified; 3 priority fixes recommended (protection-policy items superseded — see banner above)  
 **Prepared by:** Multi-agent parallel investigation and documentation
 
 ---

--- a/docs/codacy-handling-check-codacy.md
+++ b/docs/codacy-handling-check-codacy.md
@@ -23,16 +23,25 @@ This file records the local investigation into Codacy status and branch protecti
 - Local Codacy setup support in `./setup`.
 - Codacy coverage checks on PRs.
 
-## Outstanding Gap
+## Outstanding Gap (historical, superseded 2026-05-16)
 
-The repo was not fully protected by the rollout definition until the branch protection and ruleset were updated to require the three Codacy contexts.
+The repo was not fully protected by the rollout definition until the branch
+protection and ruleset were updated to require every Codacy gate. The original
+gap described "the three Codacy contexts"; PR #254 (2026-05-16) extended the
+required set to four — see "Final Live State" below.
 
-## Final Live State
+## Final Live State (2026-05-16, PR #254)
 
-- Classic branch protection on `main` now requires:
-  - `Codacy Static Code Analysis`
-  - `Codacy Coverage Variation`
-  - `Codacy Diff Coverage`
-- The default-branch ruleset now matches the same contexts with strict checks.
-- The repo is currently clean and synced with `origin/main`.
+- Classic branch protection on `main` requires all four required gates:
+  - `codacy-safety-net` (GitHub Actions workflow, app_id `15368`)
+  - `Codacy Static Code Analysis` (Codacy app, app_id `56611`)
+  - `Codacy Coverage Variation` (Codacy app, app_id `56611`)
+  - `Codacy Diff Coverage` (Codacy app, app_id `56611`)
+- Ruleset `Protect main` (id `16046743`) requires the same four contexts with
+  `strict_required_status_checks_policy: true`.
+- `./setup ship` resolves the required set dynamically from the GitHub API and
+  polls every check to green before squash-merging. When `mergeStateStatus` is
+  `BLOCKED` solely because of the solo-reviewer requirement, ship uses the
+  canonical admin-bypass path (`gh pr merge --admin` invoked by `./setup ship`,
+  not by hand).
 

--- a/docs/issues/branch-protection-history.md
+++ b/docs/issues/branch-protection-history.md
@@ -91,9 +91,14 @@ Choose one approach:
 - Codacy project: https://app.codacy.com/[organization]/[repository]
 - Backup files: `~/branch-protection-backup-2026-05-06/`
 
-## Restored: 2026-05-16
+## Restored: 2026-05-16 (interim, superseded same day)
 
-### Approach taken (Decision D2=A)
+> **Superseded by PR #254 — see "Reversal: 2026-05-16 (PR #254)" below.** This
+> "Decision D2=A" approach was the interim state between the original block
+> and the final four-check policy. The text is preserved as a log; do not act
+> on its policy claims.
+
+### Approach taken (Decision D2=A) — interim only
 
 Instead of restoring the original three Codacy app checks, only `codacy-safety-net` is required. This check is workflow-based (`.github/workflows/codacy-safety-net.yml`) and fires on every PR regardless of which files changed.
 
@@ -101,16 +106,22 @@ Instead of restoring the original three Codacy app checks, only `codacy-safety-n
 
 - **Target:** default branch (`~DEFAULT_BRANCH`)
 - **Enforcement:** active
-- **Required status checks:** `codacy-safety-net` only
+- **Required status checks (interim):** `codacy-safety-net` only
   - `strict_required_status_checks_policy`: false (no requirement to be up-to-date before merge)
 - **Additional rules:** deletion prevention, non-fast-forward prevention, pull request required
-- **Advisory only (not required):** Codacy Static Code Analysis, Codacy Coverage Variation, Codacy Diff Coverage
+- **Interim non-required (now required after PR #254):** Codacy Static Code Analysis, Codacy Coverage Variation, Codacy Diff Coverage
 
-### Why this approach
+### Why this approach — and why it was reversed
 
-The three Codacy app checks still do not trigger on bash-only or docs-only PRs (no Python files changed). Requiring them again would reproduce the original blocking problem. The `codacy-safety-net` workflow always runs and provides a reliable gate without causing false blocks on non-Python changes.
+The interim rationale was: the three Codacy app checks do not trigger on
+bash-only or docs-only PRs (no Python files changed), so requiring them
+would reproduce the original blocking problem. In practice this caused
+Codacy's repository dashboard to flag `main` as "not protected by Codacy
+checks" and prompted PR #254 (same day) to make all four required and rely
+on `./setup ship`'s admin-bypass path for any `BLOCKED` merge state caused by
+the solo-reviewer requirement.
 
-### Verification
+### Verification (interim — historical only)
 
 ```bash
 gh api repos/kairin/000-dotfiles/rulesets --jq '.[].name'
@@ -118,5 +129,36 @@ gh api repos/kairin/000-dotfiles/rulesets --jq '.[].name'
 
 gh api repos/kairin/000-dotfiles/rulesets/16046743 \
   --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks'
+# Interim output (now superseded):
 # → [{"context":"codacy-safety-net","integration_id":15368}]
+```
+
+## Reversal: 2026-05-16 (PR #254)
+
+The "Decision D2=A" interim policy above was reversed on the same day.
+Branch protection (classic + ruleset `Protect main`, id `16046743`) now
+requires all **four** contexts:
+
+- `codacy-safety-net` (app_id `15368` — GitHub Actions)
+- `Codacy Static Code Analysis` (app_id `56611` — Codacy app)
+- `Codacy Coverage Variation` (app_id `56611` — Codacy app)
+- `Codacy Diff Coverage` (app_id `56611` — Codacy app)
+
+`./setup ship` resolves the required set dynamically from the GitHub API
+and admin-bypasses the merge when `mergeStateStatus=BLOCKED` solely because
+of the solo-reviewer requirement and every required check is green.
+
+Current verification:
+
+```bash
+gh api repos/kairin/000-dotfiles/branches/main/protection \
+  --jq '.required_status_checks.contexts | sort'
+# → ["Codacy Coverage Variation","Codacy Diff Coverage","Codacy Static Code Analysis","codacy-safety-net"]
+
+gh api repos/kairin/000-dotfiles/rulesets/16046743 \
+  --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks | sort_by(.context)'
+# → [{"context":"Codacy Coverage Variation","integration_id":56611},
+#    {"context":"Codacy Diff Coverage","integration_id":56611},
+#    {"context":"Codacy Static Code Analysis","integration_id":56611},
+#    {"context":"codacy-safety-net","integration_id":15368}]
 ```

--- a/docs/issues/docs-reconciliation-followups.md
+++ b/docs/issues/docs-reconciliation-followups.md
@@ -1,7 +1,21 @@
 # Documentation Reconciliation Follow-Ups
 
-**Status:** Phase 2 complete; P1/P2/P3 items remain
-**Date:** 2026-05-15 (Phase 1) / 2026-05-16 (Phase 2)
+> **Phase 3 Reversal (2026-05-16, PR #254):** The Phase 2 "RESOLVED" entries
+> below that describe `codacy-safety-net` as the **only** required check, and
+> the three Codacy app checks (`Codacy Static Code Analysis`,
+> `Codacy Coverage Variation`, `Codacy Diff Coverage`) as **advisory**, were
+> SUPERSEDED. Codacy's repository dashboard flagged main as "not protected by
+> Codacy checks" under the Phase 2 policy. Branch protection (classic +
+> ruleset `Protect main`, id `16046743`) now requires **all four** Codacy
+> checks. `./setup ship` is the canonical path: it resolves the full required
+> set dynamically from the GitHub API, polls every check to green, and
+> performs the admin-bypass merge when `mergeStateStatus=BLOCKED` solely
+> because of the solo-reviewer requirement. Agents must not run `gh pr merge`
+> by hand in this repo. The historical Phase 1 / Phase 2 text below is
+> preserved as a log; do not act on its policy claims.
+
+**Status:** Historical log; Phase 2 policy superseded by PR #254 (Phase 3 reversal — see banner above)
+**Date:** 2026-05-15 (Phase 1) / 2026-05-16 (Phase 2) / 2026-05-16 (Phase 3 reversal)
 **Context:** PR #244 reconciled the first round of doc drift and was merged with
 `./setup ship 244`. The pre-push hook ran 292 unit tests successfully. Before
 merge, `gh pr checks` showed the Codacy app checks and `codacy-safety-net` all

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -75,7 +75,13 @@ class DocsTests(DotfilesTestCase):
             "codacy-rollout.json must have required_checks distinct from expected_checks")
         self.assertIn("codacy-safety-net", dotfiles_entry["required_checks"])
 
-    def test_quality_pipeline_does_not_claim_four_required_checks(self):
-        """T025: quality-pipeline.sh must not imply all Codacy app checks are required."""
+    def test_quality_pipeline_claims_four_required_checks(self):
+        """T025: quality-pipeline.sh must state all four Codacy checks are required.
+
+        This test was inverted on 2026-05-16 (PR #254 follow-up). Original guard
+        protected the Phase 2 policy where only ``codacy-safety-net`` was required;
+        Phase 3 reversal made all four Codacy checks unconditionally required, so
+        the script's banner must now actively claim that.
+        """
         pipeline = (REPO_ROOT / "scripts" / "quality-pipeline.sh").read_text()
-        self.assertNotIn("four required GitHub checks", pipeline)
+        self.assertIn("All four Codacy checks are required", pipeline)


### PR DESCRIPTION
## Summary

Cross-LLM follow-up to PR #254. PR #254 made all four Codacy checks required on main but only swept the canonical surfaces; a parallel codex challenge + gemini adversarial review found 6 reference docs and 1 test that still encoded the OLD policy. This PR sweeps those remaining surfaces so no LLM reading the repo can revert PR #254.

The recurring failure mode noted across prior sessions — *"why claude keeps not understanding this codacy requirement? and every time another LLM identifies the solution you keep changing it and reverting it to break"* — happens because docs and tests still describe the obsolete policy. This PR closes those gaps.

## What's now consistent

- **tests/test_docs.py T025 inverted.** Was: `assertNotIn("four required GitHub checks", pipeline)` (guard for OLD policy). Now: `assertIn("All four Codacy checks are required", pipeline)` (active guard for NEW policy). The literal phrase exists at `scripts/quality-pipeline.sh:150`.
- **docs/codacy-branch-protection.md** — new "coverage-enabled + local safety-net workflow" profile (text + JSON template for classic protection, ruleset create, ruleset update). Lists all four required contexts with the correct integration_ids (`15368` for `codacy-safety-net`, `56611` for the three Codacy app checks).
- **docs/codacy-coverage-rollout.md** Step 10 + Reuse Step 10 — "all three Codacy contexts" → four, with note that the fourth applies only when the repo ships a `codacy-safety-net` workflow.
- **docs/codacy-handling-check-codacy.md** — "Outstanding Gap" marked historical; "Final Live State" rewritten with all four gates + app_ids.
- **docs/codacy-github-issues-report.md** — superseded banner noting the P2 "conditional check enforcement" remediation plan was reversed by PR #254.
- **docs/issues/branch-protection-history.md** — "Restored: 2026-05-16 (Decision D2=A)" banner-marked as interim; new "Reversal: 2026-05-16 (PR #254)" section added with current four-context verification commands.
- **docs/issues/docs-reconciliation-followups.md** — Phase 3 banner now points at `./setup ship` as the canonical admin-bypass path (codex flagged that referencing `gh pr merge --admin` directly conflicts with repo policy of using ship).
- **AGENTS.md / README.md** — small wording fixes ("advisory" → "informational"; "non-required advisory jobs" → "checks outside the four required Codacy contexts") that the cross-LLM review flagged as still readable as the old policy.

The `/codacy` and `/plan-review` skill files at `~/.claude/skills/` were updated separately (live outside the repo) — the `/codacy` skill no longer contains the contradictory block that called the three Codacy app checks "advisory" while another section in the same file called them required.

## Cross-LLM review trail

Plan: `~/.claude/plans/recap-goal-get-twinkling-spark.md`

- **codex challenge** (5 findings): wording inside proposed edits — all addressed
- **gemini -p adversarial review** (6 findings, zero overlap with codex): broader doc tree that the initial exploration missed — all addressed
- **Final Claude adversarial subagent** on the staged diff: CLEAN, verified against live `gh api repos/kairin/000-dotfiles/branches/main/protection` and `rulesets/16046743` state.

The 0% overlap between codex and gemini findings is the lesson: a single reviewer (or a single grep query) misses categories of staleness that another reviewer catches by approaching the same diff with different priors.

## Test plan

- [x] 307 tests pass (T025 inverted, not removed; same count)
- [x] Verification grep returns empty after allowlist of historical/interim/superseded blocks
- [x] `gh api ...protection` still returns all 4 contexts (this PR does not touch protection)
- [ ] `codacy-safety-net` passes on this PR
- [ ] All 3 Codacy app checks fire and pass on this PR
- [ ] `./setup ship` merges via admin-bypass (solo PR can't self-approve)
- [ ] After merge, `~/.claude/skills/codacy/SKILL.md` reads as one consistent narrative top-to-bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)