### PR TITLE
docs: mark interim policy records as superseded (Phase C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A good dotfiles repo should:
 | Protected files never auto-overwritten | ✓ git config, fish plugins, etc. |
 | No secrets or tokens committed | ✓ Auth files `.gitignore`d |
 | Multi-platform support | ✓ Linux, WSL, Pi, Pixel Terminal |
-| Validation & test coverage | ✓ 120 unit tests; CI/CD integration |
+| Validation & test coverage | ✓ 307 unit tests (55 test classes, 5.8k LOC); CI/CD integration |
 | AI tool config management | ✓ Claude, Codex, Gemini, Copilot |
 | Per-project AI agent scaffolding | ✓ `AGENTS.md` + symlinks |
 

--- a/docs/issues/branch-protection-history.md
+++ b/docs/issues/branch-protection-history.md
@@ -1,5 +1,12 @@
 # Branch Protection History
 
+> **Phase 3 Reversal (2026-05-16, PR #254):** The "Restored: 2026-05-16"
+> section below describes an interim "safety-net only" state that was
+> superseded later that same day by PR #254. Branch protection now requires
+> all four Codacy checks unconditionally. `./setup ship` is the canonical
+> merge path. Treat this file as a historical log; do not act on its policy
+> or configuration claims.
+
 ## Original Configuration (Removed 2026-05-06)
 
 The main branch had two layers of protection configured:

--- a/docs/issues/codacy-pr-audit.md
+++ b/docs/issues/codacy-pr-audit.md
@@ -1,5 +1,11 @@
 # PR Audit: Codacy and GitHub Protection Issues Summary
 
+> **Superseded by PR #254 (2026-05-16).** The "Restoration Plan" and
+> Priority P2 entries below recommended conditional check enforcement
+> (Codacy checks only for Python PRs). That direction was abandoned.
+> All four Codacy checks are now required unconditionally on `main`.
+> Treat the action items as historical record; do not act on them.
+
 **Status:** Comprehensive audit of 13 merged PRs conducted
 **Date:** 2026-05-06
 **Scope:** All PRs merged to main after branch protection removal

--- a/docs/issues/docs-reconciliation-followups.md
+++ b/docs/issues/docs-reconciliation-followups.md
@@ -42,7 +42,7 @@ several P2 items (see "Phase 2 Resolutions" below).
   is loaded via direnv and documented as a ship prerequisite.
 - **Required checks policy** (P0): RESOLVED — `codacy-safety-net` confirmed as
   the only required GitHub check via active ruleset "Protect main" (ID
-  16046743). Codacy app checks (Static Code Analysis, Coverage Variation, Diff
+  16046743). (SUPERSEDED — see Phase 3 banner) Codacy app checks (Static Code Analysis, Coverage Variation, Diff
   Coverage) documented as advisory throughout; `codacy-rollout.json` updated to
   distinguish required from advisory checks.
 - **Doc invariant tests** (P2): RESOLVED — T021 (`fish/env.fish` target is
@@ -91,6 +91,6 @@ Shipped in this phase:
 - `cmd_ship` in `setup` wired to call `ship_upload_sarif` at steps 4d and 4h,
   making `CODACY_PROJECT_TOKEN` a documented ship prerequisite.
 - Required-check policy clarified: ruleset "Protect main" (ID 16046743) requires
-  only `codacy-safety-net`; Codacy app checks are advisory.
+  only `codacy-safety-net`; Codacy app checks are advisory. (SUPERSEDED — see Phase 3 banner)
 - Doc invariant tests T021, T022, T025 added to `tests/test_docs.py`.
 - `conf.d/env.fish` assertion added to `tests/test_apply_install.py`.


### PR DESCRIPTION
This PR completes Phase C of the Codacy Policy Alignment plan by marking historical documentation records as superseded by PR #254.

Phase C surfaces:
- docs/issues/branch-protection-history.md
- docs/issues/codacy-pr-audit.md
- docs/issues/docs-reconciliation-followups.md

Verified with 307 tests and branch protection API checks.